### PR TITLE
Tested healthcheck logic in docker-compose.yaml file

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -216,6 +216,7 @@ services:
     depends_on:
       - cb-tumblebug
     volumes:
+      - ./tool/mayfly:/app/tool/mayfly
       - ./conf/cm-beetle/conf/:/app/conf/
       - ./data/cm-beetle/log/:/app/log/
     environment:
@@ -242,7 +243,8 @@ services:
       # - BEETLE_AUTOCONTROL_DURATION_MS=10000
       - BEETLE_SELF_ENDPOINT=localhost:8056
     healthcheck: # for CM-Beetle
-      test: [ "CMD", "curl", "-f", "http://localhost:1323/beetle/readyz" ]
+      test: [ "CMD", "/app/tool/mayfly", "rest", "get", "http://cm-beetle:8056/beetle/readyz" ]
+      #test: [ "CMD", "curl", "-f", "http://localhost:1323/beetle/readyz" ]
       interval: 1m
       timeout: 5s
       retries: 3

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -193,7 +193,8 @@ services:
     # depends_on:
     #   - cb-tumblebug
     healthcheck: # for cb-mapui
-      test: ["CMD", "nc", "-vz", "localhost", "1324"]
+      #test: ["CMD", "nc", "-vz", "127.0.0.1", "1324"]
+      test: ["CMD", "nc", "-vz", "cb-mapui", "1324"]
       interval: 1m
       timeout: 5s
       retries: 3


### PR DESCRIPTION
- Changed healthcheck logic in cb-mapui (issue #21 fixed)
- Changed healthcheck logic in cm-beetle (issue #22 fixed)

```
CONTAINER ID   IMAGE                                  COMMAND                   CREATED         STATUS                   PORTS                                                                                  NAMES
0565b643db7c   cloudbaristaorg/cm-butterfly:0.2.0     "./docker_entrypoint…"    6 minutes ago   Up 6 minutes             0.0.0.0:1234->1234/tcp, :::1234->1234/tcp                                              cm-butterfly
b568e83ecb4f   cloudbaristaorg/cb-mapui:0.9.0         "npm start"               6 minutes ago   Up 6 minutes (healthy)   0.0.0.0:1324->1324/tcp, :::1324->1324/tcp                                              cb-mapui
12fe3713e592   cloudbaristaorg/cm-grasshopper:edge    "/bin/sh -c '\n  if […"   6 minutes ago   Up 6 minutes (healthy)   0.0.0.0:8084->8084/tcp, :::8084->8084/tcp                                              cm-grasshopper
80cb0c3280b3   cloudbaristaorg/cm-beetle:edge         "/app/cm-beetle"          6 minutes ago   Up 6 minutes (healthy)   0.0.0.0:8056->8056/tcp, :::8056->8056/tcp                                              cm-beetle
d4904ed1d8b0   cloudbaristaorg/cm-honeybee:edge       "/cm-honeybee"            5 days ago      Up 6 minutes (healthy)   0.0.0.0:8081->8081/tcp, :::8081->8081/tcp                                              cm-honeybee
1bc21b0be09f   dev4unet/cm-honeybee-agent:0.2.0       "/docker-entrypoint.…"    5 days ago      Up 6 minutes (healthy)   0.0.0.0:8082->8082/tcp, :::8082->8082/tcp                                              cm-honeybee-agent
da4baa8ce1ef   cloudbaristaorg/cm-cicada:edge         "/cm-cicada"              5 days ago      Up 6 minutes (healthy)   0.0.0.0:8083->8083/tcp, :::8083->8083/tcp                                              cm-cicada
e39ae953b909   cloudbaristaorg/cb-tumblebug:0.9.0     "/app/src/cb-tumbleb…"    5 days ago      Up 6 minutes (healthy)   0.0.0.0:1323->1323/tcp                                                                 cb-tumblebug
c67ca8573255   cloudbaristaorg/cm-ant:0.2.1           "./ant"                   5 days ago      Up 6 minutes (healthy)   0.0.0.0:8880->8880/tcp, :::8880->8880/tcp                                              cm-ant
ae9ebffb86d1   airflow-server:2.9.1                   "/bin/bash -c '\n    …"   5 days ago      Up 6 minutes             0.0.0.0:5555->5555/tcp, :::5555->5555/tcp, 0.0.0.0:8080->8080/tcp, :::8080->8080/tcp   airflow-server
e42e2a8fc25a   redis:7.2-alpine                       "docker-entrypoint.s…"    5 days ago      Up 6 minutes (healthy)   0.0.0.0:6379->6379/tcp, :::6379->6379/tcp                                              airflow-redis
02b6932f0d03   mysql:8.0-debian                       "docker-entrypoint.s…"    5 days ago      Up 6 minutes             0.0.0.0:3306->3306/tcp, :::3306->3306/tcp, 33060/tcp                                   airflow-mysql
c799210804fd   dev4unet/cm-mayfly:v0.2.0              "bash"                    5 days ago      Up 6 minutes                                                                                                    cm-mayfly
c56bfab50b43   gcr.io/etcd-development/etcd:v3.5.14   "/usr/local/bin/etcd…"    5 days ago      Up 6 minutes (healthy)   0.0.0.0:2379-2380->2379-2380/tcp, :::2379-2380->2379-2380/tcp                          etcd
4a65211dda5f   timescale/timescaledb:latest-pg16      "docker-entrypoint.s…"    5 days ago      Up 6 minutes (healthy)   0.0.0.0:5432->5432/tcp, :::5432->5432/tcp                                              ant-postgres
c6970c2c6009   cloudbaristaorg/cb-spider:0.9.1        "/root/go/src/github…"    5 days ago      Up 6 minutes (healthy)   0.0.0.0:1024->1024/tcp, 0.0.0.0:2048->2048/tcp, 4096/tcp                               cb-spider
```