### PR TITLE
Add bearer support to authentication methods for API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ Flags:
 Use "mayfly api [command] --help" for more information about a command.
 ```
 
+For more information, see the [API Sub Command Guide](https://github.com/cloud-barista/cm-mayfly/blob/main/docs/cb-mayfly-api.md).
+
+
+
 ## api subcommand examples
 Simple usage examples for api subcommand
 ```
@@ -222,3 +226,10 @@ Simple usage examples for api subcommand
 ./mayfly api --service spider --action GetCloudDriver --pathParam driver_name:AWS
 ./mayfly api --service spider --action GetRegionZone --pathParam region_name:ap-northeast-3 --queryString ConnectionName:aws-config01
 ```
+
+Examples of changing REST authentication values   
+Example of changing the username and password for basic authentication.   
+`./mayfly api -s cm-ant -a getcostinfo --authUser=test --authPassword=test2`
+
+Example of changing the authentication token for bearer authentication.   
+`./mayfly api -s cm-ant -a getcostinfo --authToken=token`

--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -16,7 +16,7 @@ services:
       password: default
     
   cm-ant:
-    baseurl: http://localhost:8880
+    baseurl: http://localhost:8880/ant
     auth: 
       type: basic
       username: default
@@ -29,9 +29,23 @@ services:
   #     username: default
   #     password: default
 
-  # sample:
+  # sample: #none authentication method
   #   baseurl: http://localhost:1323/test
   #   auth: #none
+
+  # sample: #basic authentication method
+  #   baseurl: http://localhost:1323/test
+  #   auth: 
+  #     type: "basic"
+  #     username: "your-username"
+  #     password: "your-password"
+
+  # sample: #Bearer authentication method
+  #   baseurl: http://localhost:1323/test
+  #   auth: 
+  #     type: "bearer"
+  #     token: "your-bearer-token-here"
+
 
 # Define rest api actions for each of the services defined above.
 # specify the DATA to use for the API in the CLI.
@@ -979,59 +993,71 @@ serviceActions:
 
 
   cm-ant:
-    LoadEnvironments:
+    GetLoadTestMetrics:
       method: get
-      resourcePath: /ant/api/v1/env
-      description: "Get all of the load test environments"
-    GetAllAgentInstallInfo:
-      method: get
-      resourcePath: /ant/api/v1/load/agent
-      description: "Get all agent installation nsId, mcisId, vmId, status."
-    InstallAgent:
+      resourcePath: /api/v1/load/test/metrics
+      description: "Retrieve load test metrics based on provided parameters."
+    RunLoadTest:
       method: post
-      resourcePath: /ant/api/v1/load/agent
-      description: "Install an agent to collect server metrics during load testing such as CPU and memory."
-    UninstallAgent:
-      method: delete
-      resourcePath: /ant/api/v1/load/agent/{agentInstallInfoId}
-      description: "Uninstall an agent to collect server metrics during load testing such as CPU and memory."
-    LoadExecutionConfigs:
+      resourcePath: /api/v1/load/tests/run
+      description: "Start a load test using the provided load test configuration."
+    GetLoadTestExecutionState:
       method: get
-      resourcePath: /ant/api/v1/load/config
-      description: "Get all the load test execution configurations."
-    LoadExecutionConfig:
-      method: get
-      resourcePath: /ant/api/v1/load/config/{loadTestKey}
-      description: "Get a load test execution config by load test key."
-    LoadTestResult:
-      method: get
-      resourcePath: /ant/api/v1/load/result
-      description: "After start load test, get the result of load test."
-    LoadTestMetrics:
-      method: get
-      resourcePath: /ant/api/v1/load/result/metrics
-      description: "Get the result of metrics for target server."
-    StartLoadTest:
-      method: post
-      resourcePath: /ant/api/v1/load/start
-      description: "Start load test. Load Environment Id must be passed or Load Environment must be defined."
-    LoadExecutionStates:
-      method: get
-      resourcePath: /ant/api/v1/load/state
-      description: "Get all the load test execution state."
-    LoadExecutionState:
-      method: get
-      resourcePath: /ant/api/v1/load/state/{loadTestKey}
-      description: "Get a load test execution state by load test key."
+      resourcePath: /api/v1/load/tests/state/{loadTestKey}
+      description: "Retrieve a load test execution state by load test key."
     StopLoadTest:
       method: post
-      resourcePath: /ant/api/v1/load/stop
-      description: "After start load test, stop the load test by passing the load test key."
-    InstallLoadTester:
+      resourcePath: /api/v1/load/tests/stop
+      description: "Stop a running load test using the provided load test key."
+    GetPriceInfo:
+      method: get
+      resourcePath: /api/v1/price/info
+      description: "Retrieve pricing information for cloud resources based on specified parameters."
+    GetAllMonitoringAgentInfos:
+      method: get
+      resourcePath: /api/v1/load/monitoring/agents
+      description: "Retrieve monitoring agent information based on specified criteria."
+    GetLoadTestExecutionInfo:
+      method: get
+      resourcePath: /api/v1/load/tests/infos/{loadTestKey}
+      description: "Retrieve the load test execution state information for a specific load test key."
+    GetAllLoadTestExecutionState:
+      method: get
+      resourcePath: /api/v1/load/tests/state
+      description: "Retrieve a list of all load test execution states with pagination support."
+    InstallMonitoringAgent:
       method: post
-      resourcePath: /ant/api/v1/load/tester
-      description: "Install load test tester in the delivered load test environment"
-    UninstallLoadTester:
+      resourcePath: /api/v1/load/monitoring/agent/install
+      description: "Install a monitoring agent on specific MCIS."
+    UninstallMonitoringAgent:
+      method: post
+      resourcePath: /api/v1/load/monitoring/agents/uninstall
+      description: "Uninstall monitoring agents from specified VMs or all VMs in an MCIS."
+    GetLoadTestResult:
+      method: get
+      resourcePath: /api/v1/load/test/result
+      description: "Retrieve load test result based on provided parameters."
+    GetAllLoadTestExecutionInfos:
+      method: get
+      resourcePath: /api/v1/load/tests/infos
+      description: "Retrieve a list of all load test execution information with pagination support."
+    UpdateCostInfo:
+      method: post
+      resourcePath: /api/v1/cost/info
+      description: "Update cost information for specified resources, including details such as migration ID, cost resources, and additional AWS info if applicable. The request body must include a valid migration ID and a list of cost resources. If AWS-specific details are provided, ensure all required fields are populated."
+    GetCostInfo:
+      method: get
+      resourcePath: /api/v1/cost/info
+      description: "Retrieve cost information for specified parameters within a defined date range. The date range must be within a 6-month period. Optionally, you can specify cost aggregation type and date order for the results."
+    GetAllLoadGeneratorInstallInfo:
+      method: get
+      resourcePath: /api/v1/load/generators
+      description: "Retrieve a list of all installed load generators with pagination support."
+    InstallLoadGenerator:
+      method: post
+      resourcePath: /api/v1/load/generators
+      description: "Install a load generator either locally or remotely."
+    UninstallLoadGenerator:
       method: delete
-      resourcePath: /ant/api/v1/load/tester/{envId}
-      description: "Uninstall load test tester in the delivered load test environment"
+      resourcePath: /api/v1/load/generators/{loadGeneratorInstallInfoId}
+      description: "Uninstall a previously installed load generator."

--- a/docs/cb-mayfly-api.md
+++ b/docs/cb-mayfly-api.md
@@ -40,17 +40,52 @@ $ ./mayfly api
 api.yaml의 경우 아래와 같은 구조로 되어있습니다.   
 `api.yaml`파일에 RESTful API를 제공하는 각 프레임워크의 서비스 명(services:)과 해당 서비스 하위에 존재할 서비스 액션(serviceActions:)을 지정하는 형태로 되어있습니다.   
 
-### 서비스 정의 
+### 서비스 정의
 `services:` 하위에 `api` 서브 커맨드에서 지원할 프레임워크들의 정보를 서술합니다.   
 예를 들어, 대표 프레임워크인 cb-spider의 경우 `cb-spider:`로 서술합니다.   
 
 `baseurl`에는 해당 프레임워크에서 제공하는 REST API URI의 기본이되는 `스키마 + 호스트 + 베이스 경로`의 조합으로 기입합니다.   
 예를 들어, cb-spider의 경우 localhost에서 1024포트를 사용하고 /spider 하위에 api가 존재한다면 `http://localhost:1024/spider`로 설정하면 됩니다.
+   
+   
+**인증 정보 설정**   
+현재 REST 호출을 위한 인증 절차는 "basic"과 "bearer" 인증을 지원하고 있습니다.   
+해당 프레임워크에서 REST 호출을 위한 username과 password 기반의 기본 인증 절차가 필요한 경우에는 `auth` 영역의 `type`에는 `basic`을 입력하고 `username`과 `password` 항목으로 인증 정보를 지정하면됩니다.   
+만약, `username`과 `password` 값을 api.yaml 파일의 값이 아닌 API 호출 시점에 설정하고 싶다면 `--authUser`와 `--authPassword`를 이용해서 변경 가능합니다.   
+```
+(예시)
+./mayfly api -s 서비스명 -a 액션명 --authUser=User이름 --authPassword=비밀번호
+```
 
-만약, 해당 프레임워크에서 REST 호출을 위한 인증 절차가 필요한 경우에는 `auth` 영역에 `username`과 `password` 항목으로 인증 정보를 지정하며 현재는 basic 타입인  Bear 방식만 제공하기에 `type`에는 basic을 입력합니다.   
-아직은 basic 인증 외의 다른 방식은 지원하고 있지 않기 때문에 사실상 `type` 부분은 중요하지 않으며, `인증 절차가 필요 없는 경우에는 auth 항목 하위의 값을 삭제`하면됩니다.
+해당 프레임워크에서 REST 호출을 위한 `token` 기반의 `bearer` 인증 절차가 필요한 경우에는 `auth` 영역의 `type`에는 `bearer`을 입력하고 `token`에 인증 토큰 정보를 지정하면됩니다.   
+만약, `token` 값을 api.yaml 파일의 값이 아닌 API 호출 시점에 설정하고 싶다면 `--authUser`와 `--authPassword`를 이용해서 변경 가능합니다.   
+```
+(예시)
+./mayfly api -s 서비스명 -a 액션명 --authToken=인증토큰값
+```
 
-**[설정 예시]**
+별도의 인증 절차가 필요 없는 경우 `auth:` 항목만 유지하면됩니다.   
+ `인증 절차가 필요 없는 경우에는 auth: 항목은 유지하고 하위의 내용만 삭제`하면됩니다.
+
+**[인증 정보 설정 예시]**
+```
+  #none authentication method
+    auth: #none
+
+  #basic authentication method
+    auth: 
+      type: "basic"
+      username: "your-username"
+      password: "your-password"
+
+  #Bearer authentication method
+    auth: 
+      type: "bearer"
+      token: "your-bearer-token-here"
+```
+
+
+**[서비스 설정 예시]**
 ```
 services:
   cb-spider: #service name

--- a/src/cmd/apicall/root.go
+++ b/src/cmd/apicall/root.go
@@ -33,6 +33,11 @@ var sendData string
 var inputFileData string
 var outputFile string
 
+// auth : About changing credentials from the CLI
+var username string
+var password string
+var authToken string
+
 /*
 type ServiceInfo struct {
 	BaseURL string `yaml:"baseurl"`
@@ -212,6 +217,17 @@ func parseRequestInfo() error {
 	err := viper.UnmarshalKey("services."+serviceName, &serviceInfo)
 	if err != nil {
 		return err
+	}
+
+	// 인증 정보를 CLI로 전달 받았을 경우 처리
+	if authToken != "" {
+		serviceInfo.Auth.Token = authToken
+	}
+	if username != "" {
+		serviceInfo.Auth.Username = username
+	}
+	if password != "" {
+		serviceInfo.Auth.Password = password
 	}
 
 	if serviceInfo.BaseURL == "" {
@@ -418,6 +434,14 @@ func callRest() error {
 
 func init() {
 	apiCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "../conf/api.yaml", "config file")
+
+	// Add flags for basic authentication
+	apiCmd.PersistentFlags().StringVarP(&username, "authUser", "", "", "Username for basic authentication") // - sets the basic authentication header in the HTTP request
+	apiCmd.PersistentFlags().StringVarP(&password, "authPassword", "", "", "Password for basic authentication")
+
+	// 인증 토큰 설정
+	apiCmd.PersistentFlags().StringVarP(&authToken, "authToken", "", "", "sets the auth token of the 'Authorization' header for all HTTP requests.(The default auth scheme is 'Bearer')")
+	//apiCmd.PersistentFlags().StringVarP(&authScheme, "authScheme", "", "", "sets the auth scheme type in the HTTP request.(Exam. OAuth)(The default auth scheme is Bearer)")
 
 	apiCmd.PersistentFlags().StringVarP(&serviceName, "service", "s", "", "Service to perform")
 	apiCmd.PersistentFlags().StringVarP(&actionName, "action", "a", "", "Action to perform")


### PR DESCRIPTION
- Added “bearer” to the Added “bearer” to auth.type
- Added the ability to accept token values as parameters in the CLI to account for the “bearer” type.
Example of changing the username and password for basic authentication
`./mayfly api -s cm-ant -a getcostinfo --authUser=test --authPassword=test2`
Example of changing the authentication token for bearer authentication
`./mayfly api -s cm-ant -a getcostinfo --authToken=token`

- Added content about authentication methods to the README and API user guide