### PR TITLE
Changing Docker image versions for some subsystems

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -267,9 +267,9 @@ services:
   # (Not required) https://github.com/cloud-barista/cm-butterfly/tree/main/api/conf/authsetting.yaml.sample to authsetting.yaml
   # https://hub.docker.com/r/cloudbaristaorg/cm-butterfly-api
   cm-butterfly-api:
-    #image: cloudbaristaorg/cm-butterfly-api:edge
+    image: cloudbaristaorg/cm-butterfly-api:edge
     #image: csescsta/cm-butterfly-api:edge
-    image: csescsta/cm-butterfly-api:20241101181110-develop
+    #image: csescsta/cm-butterfly-api:20241101181110-develop
     container_name: cm-butterfly-api
     platform: linux/amd64
     restart: always
@@ -308,9 +308,9 @@ services:
   # https://github.com/cloud-barista/cm-butterfly/blob/main/front/nginx.conf
   # https://hub.docker.com/r/cloudbaristaorg/cm-butterfly-front
   cm-butterfly-front:
-    #image: cloudbaristaorg/cm-butterfly-front:edge
+    image: cloudbaristaorg/cm-butterfly-front:edge
     #image: csescsta/cm-butterfly-front:edge
-    image: csescsta/cm-butterfly-front:20241101181110-develop
+    #image: csescsta/cm-butterfly-front:20241101181110-develop
     container_name: cm-butterfly-front
     platform: linux/amd64
     restart: always
@@ -403,8 +403,8 @@ services:
   # https://github.com/cloud-barista/cm-cicada
   # https://hub.docker.com/r/cloudbaristaorg/cm-cicada
   cm-cicada:
-    #image: cloudbaristaorg/cm-cicada:0.2.0
-    image: cloudbaristaorg/cm-cicada:edge
+    image: cloudbaristaorg/cm-cicada:0.2.2
+    #image: cloudbaristaorg/cm-cicada:edge
     container_name: cm-cicada
     restart: always
     ports:
@@ -468,8 +468,8 @@ services:
       # build:
       #     context: ./conf/cm-cicada/_airflow ## build Docker file location
       container_name: airflow-server
-      # image: airflow-server:2.9.1
-      image: cloudbaristaorg/airflow-server:edge
+      image: cloudbaristaorg/airflow-server:0.2.2
+      #image: cloudbaristaorg/airflow-server:edge
       restart: always
       ports:
           - "5555:5555"
@@ -509,8 +509,8 @@ services:
   # See https://github.com/cloud-barista/cm-grasshopper/blob/main/docker-compose.yaml
   cm-grasshopper:
     #image: cloudbaristaorg/cm-grasshopper:0.2.0
-    image: cloudbaristaorg/cm-grasshopper:0.2.1
-    #image: cloudbaristaorg/cm-grasshopper:edge
+    #image: cloudbaristaorg/cm-grasshopper:0.2.1
+    image: cloudbaristaorg/cm-grasshopper:edge
     container_name: cm-grasshopper
     restart: always
     ports:
@@ -552,8 +552,8 @@ services:
   # https://hub.docker.com/r/cloudbaristaorg/cm-ant
   cm-ant:
     container_name: cm-ant
-    # image: cloudbaristaorg/cm-ant:0.2.3
-    image: cloudbaristaorg/cm-ant:edge    
+    image: cloudbaristaorg/cm-ant:0.2.5
+    #image: cloudbaristaorg/cm-ant:edge
     platform: linux/amd64
     ports:
         - 8880:8880


### PR DESCRIPTION
We will finalize the Edge versions of certain subsystems with the latest uploaded versions.
If only the Edge version is being newly uploaded without a version tag, the Edge version will be retained.
- cloudbaristaorg/cm-ant:0.2.5
- cloudbaristaorg/airflow-server:0.2.2
- cloudbaristaorg/cm-cicada:0.2.2
- cm-grasshopper:edge
