### PR TITLE
Update `docker-compose.yaml` for reflecting Beetle v0.3.8

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
   # https://github.com/cloud-barista/cb-spider/wiki/Docker-based-Start-Guide
   # https://hub.docker.com/r/cloudbaristaorg/cb-spider
   cb-spider:
-    image: cloudbaristaorg/cb-spider:0.11.4
+    image: cloudbaristaorg/cb-spider:0.11.5
     pull_policy: missing
     container_name: cb-spider
     platform: linux/amd64
@@ -115,7 +115,7 @@ services:
       start_period: 10s
 
   cb-tumblebug-etcd:
-    image: gcr.io/etcd-development/etcd:v3.5.14
+    image: gcr.io/etcd-development/etcd:v3.5.21
     container_name: cb-tumblebug-etcd
     networks:
       - default
@@ -194,7 +194,7 @@ services:
   # used by cb-tumblebug
   # See https://github.com/cloud-barista/cb-tumblebug/blob/main/docker-compose.yaml
   cb-mapui:
-    image: cloudbaristaorg/cb-mapui:0.11.4
+    image: cloudbaristaorg/cb-mapui:0.11.12
     container_name: cb-mapui
     ports:
       - target: 1324


### PR DESCRIPTION
This PR will update `docker-compose.yaml` for reflecting Beetle v0.3.8


<details>
  <summary>Click to see version changes related to Beetle v0.3.8</summary>

**Command**: `git diff -U9999 v0.3.7...v0.3.8 deployments/docker-compose/docker-compose.yaml`

```diff
diff --git a/deployments/docker-compose/docker-compose.yaml b/deployments/docker-compose/docker-compose.yaml
index 45f5afc..9229d00 100644
--- a/deployments/docker-compose/docker-compose.yaml
+++ b/deployments/docker-compose/docker-compose.yaml
@@ -1,312 +1,314 @@
 networks:
   internal_network:
     internal: true
   external_network:
     driver: bridge

 services:
   # cm-beetle
   cm-beetle:
-    image: cloudbaristaorg/cm-beetle:0.3.7
+    image: cloudbaristaorg/cm-beetle:0.3.8
     container_name: cm-beetle
     # build:
     #   context: ${COMPOSE_PROJECT_ROOT}
     #   dockerfile: Dockerfile
     platform: linux/amd64
     networks:
       - internal_network
       - external_network
     ports:
       - target: 8056
         published: 8056
         protocol: tcp
     depends_on:
       - cb-tumblebug
     volumes:
       - ${COMPOSE_PROJECT_ROOT}/container-volume/cm-beetle-container/log/:/app/log/
       - ${COMPOSE_PROJECT_ROOT}/container-volume/cm-beetle-container/db/:/app/db/
     environment:
       # - BEETLE_ROOT=/app
       - BEETLE_SELF_ENDPOINT=localhost:8056
       # - BEETLE_API_ALLOW_ORIGINS=*
       # - BEETLE_API_AUTH_ENABLED=true
       # - BEETLE_API_USERNAME=default
       # - BEETLE_API_PASSWORD=default
       # - BEETLE_LKVSTORE_PATH=/app/db/beetle.db
       # - BEETLE_LOGFILE_PATH=/app/log/beetle.log
       # - BEETLE_LOGFILE_MAXSIZE=1000
       # - BEETLE_LOGFILE_MAXBACKUPS=3
       # - BEETLE_LOGFILE_MAXAGE=30
       # - BEETLE_LOGFILE_COMPRESS=false
       # - BEETLE_LOGLEVEL=debug
       # - BEETLE_LOGWRITER=both
       # - BEETLE_NODE_ENV=development
       # - BEETLE_AUTOCONTROL_DURATION_MS=10000
       - BEETLE_TUMBLEBUG_ENDPOINT=http://cb-tumblebug:1323
       # - BEETLE_TUMBLEBUG_API_USERNAME=default
       # - BEETLE_TUMBLEBUG_API_PASSWORD=default
     healthcheck: # for CM-Beetle
-      test: [ "CMD", "curl", "-f", "http://localhost:8056/beetle/readyz" ]
+      test: ["CMD", "curl", "-f", "http://localhost:8056/beetle/readyz"]
       interval: 1m
       timeout: 5s
       retries: 3
       start_period: 10s

   # CB-Tumblebug
   cb-tumblebug:
-    image: cloudbaristaorg/cb-tumblebug:0.11.3
+    image: cloudbaristaorg/cb-tumblebug:0.11.9
     container_name: cb-tumblebug
     # build:
     #   context: ${COMPOSE_PROJECT_ROOT}/../cb-tumblebug
     #   dockerfile: Dockerfile
     networks:
       - internal_network
       - external_network
       # - terrarium_network # Uncomment this line when you use this compose and the terrarium compose
     ports:
       - 1323:1323
     depends_on:
       cb-tumblebug-etcd:
         condition: service_started
       cb-spider:
         condition: service_started
       cb-tumblebug-postgres:
-        condition: service_healthy
+        condition: service_healthy
     volumes:
       - ./cb-tumblebug/conf/:/app/conf/
       - ${COMPOSE_PROJECT_ROOT}/container-volume/cb-tumblebug-container/meta_db/:/app/meta_db/
       - ${COMPOSE_PROJECT_ROOT}/container-volume/cb-tumblebug-container/log/:/app/log/
     environment:
       # - TB_ROOT_PATH=/app
       # # Enable TB_SELF_ENDPOINT to specify an endpoint for CB-TB API (default: localhost:1323)
       # # Use public IP if you want to access the API Dashboard from outside of localhost
       # - TB_SELF_ENDPOINT=xxx.xxx.xxx.xxx:1323
       - TB_SPIDER_REST_URL=http://cb-spider:1024/spider
       - TB_ETCD_ENDPOINTS=http://cb-tumblebug-etcd:2379
       - TB_TERRARIUM_REST_URL=http://mc-terrarium:8055/terrarium
       # - TB_IAM_MANAGER_REST_URL=http://mc-iam-manager:5000
       # - TB_ETCD_AUTH_ENABLED=false
       # - TB_ETCD_USERNAME=default
       # - TB_ETCD_PASSWORD=default
       - TB_POSTGRES_ENDPOINT=cb-tumblebug-postgres:5432
       - TB_POSTGRES_DATABASE=cb_tumblebug
       - TB_POSTGRES_USER=cb_tumblebug
       - TB_POSTGRES_PASSWORD=cb_tumblebug
       # - TB_TERRARIUM_API_USERNAME=default
       # - TB_TERRARIUM_API_PASSWORD=default
       # - TB_ALLOW_ORIGINS=*
       # - TB_AUTH_ENABLED=true
       # - TB_AUTH_MODE=jwt
       # - TB_API_USERNAME=default
       # - TB_API_PASSWORD=$$2a$$10$$4PKzCuJ6fPYsbCF.HR//ieLjaCzBAdwORchx62F2JRXQsuR3d9T0q
       # - TB_AUTOCONTROL_DURATION_MS=10000
       # - TB_DRAGONFLY_REST_URL=http://cb-dragonfly:9090/dragonfly
       # - TB_DEFAULT_NAMESPACE=default
       # - TB_DEFAULT_CREDENTIALHOLDER=admin
       # - TB_LOGFILE_PATH=/app/log/tumblebug.log
       # - TB_LOGFILE_MAXSIZE=1000
       # - TB_LOGFILE_MAXBACKUPS=3
       # - TB_LOGFILE_MAXAGE=30
       # - TB_LOGFILE_COMPRESS=false
-      # - TB_LOGLEVEL=debug
+      - TB_LOGLEVEL=debug
       # - TB_LOGWRITER=both
       # - TB_NODE_ENV=development
     healthcheck: # for CB-Tumblebug
       test: ["CMD", "curl", "-f", "http://localhost:1323/tumblebug/readyz"]
       interval: 1m
       timeout: 5s
       retries: 3
       start_period: 10s

   # cb-tumblebug-etcd
   cb-tumblebug-etcd:
-    image: gcr.io/etcd-development/etcd:v3.5.14
+    image: gcr.io/etcd-development/etcd:v3.5.21
     container_name: cb-tumblebug-etcd
     networks:
       - internal_network
     ports:
       - 2379:2379
       - 2380:2380
-    volumes:
+    volumes:
       - ${COMPOSE_PROJECT_ROOT}/container-volume/etcd/data:/etcd-data
     entrypoint: /usr/local/bin/etcd
     command:
       - --name
       - s1
       - --data-dir
       - /etcd-data
       - --listen-client-urls
       - http://0.0.0.0:2379
       - --advertise-client-urls
       - http://0.0.0.0:2379
       - --listen-peer-urls
       - http://0.0.0.0:2380
       - --initial-advertise-peer-urls
       - http://0.0.0.0:2380
       - --initial-cluster
       - s1=http://0.0.0.0:2380
       - --initial-cluster-token
       - tkn
       - --initial-cluster-state
       - new
       - --log-level
       - info
       - --logger
       - zap
       - --log-outputs
       - stderr
       - --auth-token
       - simple
     healthcheck: # for etcd
-      test: [ "CMD", "/usr/local/bin/etcd", "--version"]
+      test: ["CMD", "/usr/local/bin/etcd", "--version"]
       interval: 1m
       timeout: 5s
       retries: 3
       start_period: 10s

   # CB-Tumblebug PostgreSQL
   # This is used for storing CB-Tumblebug Spec and Image.
   cb-tumblebug-postgres:
     image: postgres:16-alpine
     container_name: cb-tumblebug-postgres
     restart: always
     networks:
       - internal_network
+      # Enable external network for outbound access (not ideal for security)
+      # In production, comment this out to disable external access
+      - external_network
     ports:
       - 5432:5432
     volumes:
       - ${COMPOSE_PROJECT_ROOT}/container-volume/cb-tumblebug-container/meta_db/postgres:/var/lib/postgresql/data
     environment:
       - POSTGRES_USER=cb_tumblebug
       - POSTGRES_PASSWORD=cb_tumblebug
       - POSTGRES_DB=cb_tumblebug
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U cb_tumblebug"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 10s

   # CB-Spider
   cb-spider:
-    image: cloudbaristaorg/cb-spider:0.11.1
+    image: cloudbaristaorg/cb-spider:0.11.5
     container_name: cb-spider
     # build:
     #   context: ../cb-spider
     #   dockerfile: Dockerfile
     networks:
       - internal_network
       - external_network # for outbound access (not ideal for security)
     # expose:
     #   - 1024
     ports:
       - 1024:1024
     volumes:
       - ${COMPOSE_PROJECT_ROOT}/container-volume/cb-spider-container/meta_db/:/root/go/src/github.com/cloud-barista/cb-spider/meta_db/
       - ${COMPOSE_PROJECT_ROOT}/container-volume/cb-spider-container/log/:/root/go/src/github.com/cloud-barista/cb-spider/log/
     environment:
       - PLUGIN_SW=OFF
       - SERVER_ADDRESS=0.0.0.0:1024
       # if you leave these values empty, REST Auth will be disabled.
       # - API_USERNAME=
       # - API_PASSWORD=
       - SPIDER_LOG_LEVEL=error
       - SPIDER_HISCALL_LOG_LEVEL=error
       - ID_TRANSFORM_MODE=OFF
     healthcheck: # for CB-Spider
       test: ["CMD", "curl", "-f", "http://localhost:1024/spider/readyz"]
       interval: 1m
       timeout: 5s
       retries: 3
       start_period: 10s

   # cb-mapui
   cb-mapui:
-    image: cloudbaristaorg/cb-mapui:0.11.4
+    image: cloudbaristaorg/cb-mapui:0.11.12
     container_name: cb-mapui
     # build:
     #   context: ../cb-mapui
     #   dockerfile: Dockerfile
     networks:
       - internal_network
       - external_network # Keep this for the time being to support legacy access methods (http://localhost:1324)
     ports:
       - target: 1324
         published: 1324
         protocol: tcp
     healthcheck: # for cb-mapui
       test: ["CMD", "nc", "-vz", "localhost", "1324"]
       interval: 1m
       timeout: 5s
       retries: 3
       start_period: 10s

   # NOTE: Synchronize the stable version of TB MCP Server before running it
   # TB-MCP (Tumblebug Model Context Protocol Server)
   # This provides MCP interface for CB-Tumblebug to work with AI assistants like Claude
-  cb-tumblebug-mcp-server:
-    build:
-      context: ./cb-tumblebug/interface/mcp
-      dockerfile: Dockerfile
-    container_name: cb-tumblebug-mcp-server
-    networks:
-      - internal_network
-      - external_network
-    ports:
-      - "8000:8000"
-    environment:
-      # TB-MCP Configuration
-      - TUMBLEBUG_API_BASE_URL=http://cb-tumblebug:1323/tumblebug
-      - TUMBLEBUG_USERNAME=default
-      - TUMBLEBUG_PASSWORD=default
-      - PYTHONUNBUFFERED=1
-      - MCP_SERVER_HOST=0.0.0.0
-      - MCP_SERVER_PORT=8000
-
+  # cb-tumblebug-mcp-server:
+  #   build:
+  #     context: ./cb-tumblebug/interface/mcp
+  #     dockerfile: Dockerfile
+  #   container_name: cb-tumblebug-mcp-server
+  #   networks:
+  #     - internal_network
+  #     - external_network
+  #   ports:
+  #     - "8000:8000"
+  #   environment:
+  #     # TB-MCP Configuration
+  #     - TUMBLEBUG_API_BASE_URL=http://cb-tumblebug:1323/tumblebug
+  #     - TUMBLEBUG_USERNAME=default
+  #     - TUMBLEBUG_PASSWORD=default
+  #     - PYTHONUNBUFFERED=1
+  #     - MCP_SERVER_HOST=0.0.0.0
+  #     - MCP_SERVER_PORT=8000

   # # mc-terrarium (PoC): resource extentions such as VPN for CB-Tumblebug by using OpenTofu
   # mc-terrarium:
   #   image: cloudbaristaorg/mc-terrarium:0.0.22
   #   container_name: mc-terrarium
   #   # build:
   #   #   context: .
   #   #   dockerfile: Dockerfile
   #   networks:
   #     - external_network
   #   ports:
   #     - target: 8055
   #       published: 8055
   #       protocol: tcp
   #   env_file:
   #     - ${HOME}/.cloud-barista/secrets/credentials             # AWS credential
   #     - ${HOME}/.cloud-barista/secrets/credential-azure.env    # Azure credential
   #     - ${HOME}/.cloud-barista/secrets/credential-alibaba.env  # Alibaba credential
   #     - ${HOME}/.cloud-barista/secrets/credential-tencent.env  # Tencent credential
   #     - ${HOME}/.cloud-barista/secrets/credential-ibm.env      # IBM credential
   #     - ${HOME}/.cloud-barista/secrets/credential-ncp.env      # NCP credential
   #   volumes:
   #     - ${HOME}/.cloud-barista/secrets/credential-gcp.json:/app/secrets/credential-gcp.json:ro # GCP credential
   #     - ${COMPOSE_PROJECT_ROOT}/container-volume/mc-terrarium-container/.terrarium:/app/.terrarium
   #     - /etc/ssl/certs:/etc/ssl/certs:ro
   #   environment:
   #     - TERRARIUM_ROOT=/app
   #     # - TERRARIUM_SELF_ENDPOINT=localhost:8055
   #     # - TERRARIUM_API_ALLOW_ORIGINS=*
   #     # - TERRARIUM_API_AUTH_ENABLED=true
   #     # - TERRARIUM_API_USERNAME=default
   #     # - TERRARIUM_API_PASSWORD=$$2a$$10$$cKUlDfR8k4VUubhhRwCV9.sFvKV3KEc9RJ.H8R/thIeVOrhQ.nuuW
   #     # - TERRARIUM_LOGFILE_PATH=/app/log/terrarium.log
   #     # - TERRARIUM_LOGFILE_MAXSIZE=1000
   #     # - TERRARIUM_LOGFILE_MAXBACKUPS=3
   #     # - TERRARIUM_LOGFILE_MAXAGE=30
   #     # - TERRARIUM_LOGFILE_COMPRESS=false
   #     - TERRARIUM_LOGLEVEL=info
   #     # - TERRARIUM_LOGWRITER=both
   #     # - TERRARIUM_NODE_ENV=production
   #     # - TERRARIUM_AUTOCONTROL_DURATION_MS=10000
   #   healthcheck: # for MC-Terrarirum
   #     test: ["CMD", "curl", "-f", "http://localhost:8055/terrarium/readyz"]
   #     interval: 5m
   #     timeout: 5s
   #     retries: 3
   #     start_period: 10s
```

</details>