### PR TITLE
docker-compose.yaml: Fix grasshopper's SSH issue

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -557,6 +557,21 @@ services:
       - ./conf/cm-grasshopper/conf:/conf
       - ./data/cm-grasshopper/software_temp:/software_temp:rw
       - ./data/cm-grasshopper/software_log:/software_log:rw
+      - ./data/cm-honeybee/:/root/.cm-grasshopper/honeybee:ro
+    command: >
+      /bin/sh -c "
+        if [ ! -f /root/.ssh/known_hosts ]; then
+          mkdir -p /root/.ssh
+          touch /root/.ssh/known_hosts
+        fi
+        if [ ! -f /root/.cm-grasshopper/honeybee/honeybee.key ]; then
+          echo 'honeybee.key not found, exiting...';
+          exit 1;
+        else
+         cp /root/.cm-grasshopper/honeybee/honeybee.key /root/.cm-grasshopper/ && echo 'Finished copying the honeybee.key file.';
+          /cm-grasshopper;
+        fi
+      "
     healthcheck:
       test: [ "CMD", "/app/tool/mayfly", "rest", "get", "http://cm-grasshopper:8084/grasshopper/readyz" ]
       <<: *default-health-check


### PR DESCRIPTION
## docker-compose.yaml
- Fix grasshopper's honeybee.key issue
- Fix grasshopper's ~/.ssh/know_hosts file issue