### PR TITLE
Comment out setup.env sourcing in tumblebug_init.go to prevent initialization errors

### DIFF
--- a/cmd/setup/tumblebug_init.go
+++ b/cmd/setup/tumblebug_init.go
@@ -506,13 +506,14 @@ cd "%s"
 echo "Current location: $(pwd)"
 
 # Source setup.env if it exists
-if [ -f "conf/setup.env" ]; then
-    echo "Executing setup.env file..."
-    source conf/setup.env
-    echo "setup.env execution completed"
-else
-    echo "Warning: conf/setup.env file not found."
-fi
+# Note: Currently commented out as it causes errors during initialization
+# if [ -f "conf/setup.env" ]; then
+#     echo "Executing setup.env file..."
+#     source conf/setup.env
+#     echo "setup.env execution completed"
+# else
+#     echo "Warning: conf/setup.env file not found."
+# fi
 
 # Run init.sh if it exists
 if [ -f "init/init.sh" ]; then


### PR DESCRIPTION
텀블벅 Hash에 따른 API 인증 실패 방지를 위해  source setup.env를 생략 하마.