### PR TITLE
update cm-cicada 0.3.6, airflow-server 0.3.6

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -411,7 +411,7 @@ services:
   # https://hub.docker.com/r/cloudbaristaorg/cm-cicada
   # **important** : The cm-beetle, cm-grasshopper, and airflow-server containers must be in a readyz state and running beforehand
   cm-cicada:
-    image: cloudbaristaorg/cm-cicada:0.3.5
+    image: cloudbaristaorg/cm-cicada:0.3.6
     #image: cloudbaristaorg/cm-cicada:edge
     container_name: cm-cicada
     pull_policy: always
@@ -499,7 +499,7 @@ services:
     # build:
     #     context: ./conf/cm-cicada/_airflow ## build Docker file location
     container_name: airflow-server
-    image: cloudbaristaorg/airflow-server:0.3.5
+    image: cloudbaristaorg/airflow-server:0.3.6
     #image: cloudbaristaorg/airflow-server:edge
     restart: unless-stopped
     env_file:


### PR DESCRIPTION
- [airflow: Fix Airflow dependency issue](https://github.com/cloud-barista/cm-cicada/commit/68cb4ccf08488b894cab88a29dca8bebb239ddde)