### PR TITLE
Update cm-beetle v0.4.2

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -213,7 +213,7 @@ services:
   # see conf folder : https://github.com/cloud-barista/cm-beetle/tree/main/conf
   # And remove the conf-related comments in the volumes settings below.
   cm-beetle:
-    image: cloudbaristaorg/cm-beetle:0.4.1
+    image: cloudbaristaorg/cm-beetle:0.4.2
     container_name: cm-beetle
     pull_policy: always
     platform: linux/amd64


### PR DESCRIPTION
* Upgrade to cm-beetle v0.4.2

---

Note
- 기존 VM 인프라 마이그레이션 API에 대해서는 변경된 부분이 없습니다.
- K8s 인프라 추천 API가 추가되었습니다. 현재 초기 버전입니다. 추후 정식으로 공유드리겠습니다. (cc. @hanizang77)
- 이외의 신규 API들도(MIddleware, Data) 개발을 진행 중에 있어 마찬가지로 추후 공유드리겠습니다.
