### PR TITLE
Update cm-beetle v0.4.3 and related components

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
   # https://github.com/cloud-barista/cb-spider/wiki/Docker-based-Start-Guide
   # https://hub.docker.com/r/cloudbaristaorg/cb-spider
   cb-spider:
-    image: cloudbaristaorg/cb-spider:0.11.15
+    image: cloudbaristaorg/cb-spider:0.11.16
     pull_policy: always
     container_name: cb-spider
     platform: linux/amd64
@@ -54,7 +54,7 @@ services:
   # https://hub.docker.com/r/cloudbaristaorg/cb-tumblebug
   # See https://github.com/cloud-barista/cb-tumblebug/blob/main/docker-compose.yaml
   cb-tumblebug:
-    image: cloudbaristaorg/cb-tumblebug:0.11.15
+    image: cloudbaristaorg/cb-tumblebug:0.11.19
     container_name: cb-tumblebug
     pull_policy: always
     platform: linux/amd64
@@ -190,7 +190,7 @@ services:
   # used by cb-tumblebug
   # See https://github.com/cloud-barista/cb-tumblebug/blob/main/docker-compose.yaml
   cb-mapui:
-    image: cloudbaristaorg/cb-mapui:0.11.17
+    image: cloudbaristaorg/cb-mapui:0.11.19
     container_name: cb-mapui
     pull_policy: always
     ports:
@@ -213,7 +213,7 @@ services:
   # see conf folder : https://github.com/cloud-barista/cm-beetle/tree/main/conf
   # And remove the conf-related comments in the volumes settings below.
   cm-beetle:
-    image: cloudbaristaorg/cm-beetle:0.4.1
+    image: cloudbaristaorg/cm-beetle:0.4.3
     container_name: cm-beetle
     pull_policy: always
     platform: linux/amd64


### PR DESCRIPTION
* cb-tumblebug v0.11.19
* cb-spider v0.11.16
* cb-mapui v0.11.19

---

참고 바랍니다. @dev4unet @MZC-CSC @ish-hcc 

* Security Groups 관련해서 패치할 사항이 있어서 Spider, Tumblebug 버전을 함께 올렸습니다.
* 기존 VM 인프라 마이그레이션 API에 대해서는 변경된 부분이 없습니다만, 혹시 이슈가 있으면 공유 부탁드립니다.
* K8s 인프라 추천 API가 추가되었습니다. 현재 초기 버전입니다. 추후 정식으로 공유드리겠습니다. (cc. @hanizang77)
* 이외의 신규 API들도(MIddleware, Data) 개발을 진행 중에 있어 마찬가지로 추후 공유드리겠습니다.
