### PR TITLE
Apply cm-butterfly v0.5.1 image (JSON feature improvements) and refine restart policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ conf/docker/data/*
 
 # container-volume
 container-volume/
+# Claude Code
+.claude/

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -267,8 +267,8 @@ services:
   # https://hub.docker.com/r/cloudbaristaorg/cm-butterfly-api
   cm-butterfly-api:
     # image: cloudbaristaorg/cm-butterfly-api:edge
-    image: cloudbaristaorg/cm-butterfly-api:0.5.0
-    # image: csescsta/cm-butterfly-api:20251110035245-develop
+    # image: cloudbaristaorg/cm-butterfly-api:0.5.0
+    image: csescsta/cm-butterfly-api:20260102154107-develop
     container_name: cm-butterfly-api
     pull_policy: always
     platform: linux/amd64
@@ -311,9 +311,10 @@ services:
   # https://hub.docker.com/r/cloudbaristaorg/cm-butterfly-front
   cm-butterfly-front:
     # image: cloudbaristaorg/cm-butterfly-front:edge
-    image: cloudbaristaorg/cm-butterfly-front:0.5.0
+    # image: cloudbaristaorg/cm-butterfly-front:0.5.0
     # image: csescsta/cm-butterfly-front:edge
-    # image: csescsta/cm-butterfly-front:20251110035245-develop    
+    image: csescsta/cm-butterfly-front:20260102154107-develop
+
     container_name: cm-butterfly-front
     pull_policy: always
     platform: linux/amd64

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -365,7 +365,7 @@ services:
       - ./tool/mayfly:/app/tool/mayfly
       - ./conf/cm-butterfly/front/nginx.conf:/etc/nginx/conf.d/nginx.conf:ro
     healthcheck: # for butterfly-api
-      test: [ "CMD", "/app/tool/mayfly", "rest", "get", "http://cm-butterfly-front-dev:5174/" ]
+      test: [ "CMD", "/app/tool/mayfly", "rest", "get", "http://cm-butterfly-front-dev:80/" ]
       #test: [ "CMD", "curl", "-f", "http://localhost:4000/readyz" ]
       <<: *default-health-check
 

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -313,7 +313,7 @@ services:
     # image: cloudbaristaorg/cm-butterfly-front:edge
     # image: cloudbaristaorg/cm-butterfly-front:0.5.0
     # image: csescsta/cm-butterfly-front:edge
-    image: csescsta/cm-butterfly-front:20260102154107-develop
+    image: csescsta/cm-butterfly-front:20260210173357-develop
 
     container_name: cm-butterfly-front
     pull_policy: always

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -355,7 +355,7 @@ services:
     # networks:
     #   - cm-butterfly-network
     ports:
-      - target: 5174
+      - target: 80
         published: 5174
         protocol: tcp
     depends_on:

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -346,7 +346,8 @@ services:
     # image: cloudbaristaorg/cm-butterfly-front:edge
     # image: cloudbaristaorg/cm-butterfly-front:0.5.0
     # image: csescsta/cm-butterfly-front:edge
-    image: csescsta/cm-butterfly-front:20260304041627-feature-260220-jsonviewer-jsyoo
+    # image: csescsta/cm-butterfly-front:20260304041627-feature-260220-jsonviewer-jsyoo
+    image: csescsta/cm-butterfly-front:20260318094849-feature-260318-jsonviewer-workflow-jsyoo
 
     container_name: cm-butterfly-front-dev
     pull_policy: always

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -271,8 +271,8 @@ services:
   # https://hub.docker.com/r/cloudbaristaorg/cm-butterfly-api
   cm-butterfly-api:
     # image: cloudbaristaorg/cm-butterfly-api:edge
-    # image: cloudbaristaorg/cm-butterfly-api:0.5.0
-    image: csescsta/cm-butterfly-api:20260408145340-develop
+    image: cloudbaristaorg/cm-butterfly-api:0.5.1
+    # image: csescsta/cm-butterfly-api:20260408145340-develop
     container_name: cm-butterfly-api
     pull_policy: always
     platform: linux/amd64
@@ -315,9 +315,9 @@ services:
   # https://hub.docker.com/r/cloudbaristaorg/cm-butterfly-front
   cm-butterfly-front:
     # image: cloudbaristaorg/cm-butterfly-front:edge
-    # image: cloudbaristaorg/cm-butterfly-front:0.5.0
+    image: cloudbaristaorg/cm-butterfly-front:0.5.1
     # image: csescsta/cm-butterfly-front:edge
-    image: csescsta/cm-butterfly-front:20260408145340-develop
+    # image: csescsta/cm-butterfly-front:20260408145340-develop
 
     container_name: cm-butterfly-front
     pull_policy: always

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -272,7 +272,7 @@ services:
   cm-butterfly-api:
     # image: cloudbaristaorg/cm-butterfly-api:edge
     # image: cloudbaristaorg/cm-butterfly-api:0.5.0
-    image: csescsta/cm-butterfly-api:20260102154107-develop
+    image: csescsta/cm-butterfly-api:20260408145340-develop
     container_name: cm-butterfly-api
     pull_policy: always
     platform: linux/amd64
@@ -317,7 +317,7 @@ services:
     # image: cloudbaristaorg/cm-butterfly-front:edge
     # image: cloudbaristaorg/cm-butterfly-front:0.5.0
     # image: csescsta/cm-butterfly-front:edge
-    image: csescsta/cm-butterfly-front:20260210173357-develop
+    image: csescsta/cm-butterfly-front:20260408145340-develop
 
     container_name: cm-butterfly-front
     pull_policy: always

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -342,33 +342,33 @@ services:
 
 
 
-  cm-butterfly-front-dev:
-    # image: cloudbaristaorg/cm-butterfly-front:edge
-    # image: cloudbaristaorg/cm-butterfly-front:0.5.0
-    # image: csescsta/cm-butterfly-front:edge
-    # image: csescsta/cm-butterfly-front:20260304041627-feature-260220-jsonviewer-jsyoo
-    image: csescsta/cm-butterfly-front:20260318094849-feature-260318-jsonviewer-workflow-jsyoo
-
-    container_name: cm-butterfly-front-dev
-    pull_policy: always
-    platform: linux/amd64
-    restart: unless-stopped
-    # networks:
-    #   - cm-butterfly-network
-    ports:
-      - target: 80
-        published: 5174
-        protocol: tcp
-    depends_on:
-      cm-butterfly-api:
-        condition: service_healthy
-    volumes:
-      - ./tool/mayfly:/app/tool/mayfly
-      - ./conf/cm-butterfly/front/nginx.conf:/etc/nginx/conf.d/nginx.conf:ro
-    healthcheck: # for butterfly-api
-      test: [ "CMD", "/app/tool/mayfly", "rest", "get", "http://cm-butterfly-front-dev:80/" ]
-      #test: [ "CMD", "curl", "-f", "http://localhost:4000/readyz" ]
-      <<: *default-health-check
+  # cm-butterfly-front-dev:
+  #   # image: cloudbaristaorg/cm-butterfly-front:edge
+  #   # image: cloudbaristaorg/cm-butterfly-front:0.5.0
+  #   # image: csescsta/cm-butterfly-front:edge
+  #   # image: csescsta/cm-butterfly-front:20260304041627-feature-260220-jsonviewer-jsyoo
+  #   image: csescsta/cm-butterfly-front:20260318094849-feature-260318-jsonviewer-workflow-jsyoo
+  #
+  #   container_name: cm-butterfly-front-dev
+  #   pull_policy: always
+  #   platform: linux/amd64
+  #   restart: unless-stopped
+  #   # networks:
+  #   #   - cm-butterfly-network
+  #   ports:
+  #     - target: 80
+  #       published: 5174
+  #       protocol: tcp
+  #   depends_on:
+  #     cm-butterfly-api:
+  #       condition: service_healthy
+  #   volumes:
+  #     - ./tool/mayfly:/app/tool/mayfly
+  #     - ./conf/cm-butterfly/front/nginx.conf:/etc/nginx/conf.d/nginx.conf:ro
+  #   healthcheck: # for butterfly-api
+  #     test: [ "CMD", "/app/tool/mayfly", "rest", "get", "http://cm-butterfly-front-dev:80/" ]
+  #     #test: [ "CMD", "curl", "-f", "http://localhost:4000/readyz" ]
+  #     <<: *default-health-check
 
 
   # cm-butterfly (db)

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -341,6 +341,35 @@ services:
       <<: *default-health-check
 
 
+
+  cm-butterfly-front-dev:
+    # image: cloudbaristaorg/cm-butterfly-front:edge
+    # image: cloudbaristaorg/cm-butterfly-front:0.5.0
+    # image: csescsta/cm-butterfly-front:edge
+    image: csescsta/cm-butterfly-front:20260304041627-feature-260220-jsonviewer-jsyoo
+
+    container_name: cm-butterfly-front-dev
+    pull_policy: always
+    platform: linux/amd64
+    restart: unless-stopped
+    # networks:
+    #   - cm-butterfly-network
+    ports:
+      - target: 5174
+        published: 5174
+        protocol: tcp
+    depends_on:
+      cm-butterfly-api:
+        condition: service_healthy
+    volumes:
+      - ./tool/mayfly:/app/tool/mayfly
+      - ./conf/cm-butterfly/front/nginx.conf:/etc/nginx/conf.d/nginx.conf:ro
+    healthcheck: # for butterfly-api
+      test: [ "CMD", "/app/tool/mayfly", "rest", "get", "http://cm-butterfly-front-dev:5174/" ]
+      #test: [ "CMD", "curl", "-f", "http://localhost:4000/readyz" ]
+      <<: *default-health-check
+
+
   # cm-butterfly (db)
   # https://github.com/cloud-barista/cm-butterfly
   # https://github.com/cloud-barista/cm-butterfly/blob/main/api/.env.sample to .env

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -23,6 +23,7 @@ services:
     image: cloudbaristaorg/cb-spider:0.12.0
     pull_policy: always
     container_name: cb-spider
+    restart: unless-stopped
     platform: linux/amd64
     networks:
       - spider_net
@@ -56,6 +57,7 @@ services:
   cb-tumblebug:
     image: cloudbaristaorg/cb-tumblebug:0.12.1
     container_name: cb-tumblebug
+    restart: unless-stopped
     pull_policy: always
     platform: linux/amd64
     networks:
@@ -119,6 +121,7 @@ services:
   cb-tumblebug-etcd:
     image: gcr.io/etcd-development/etcd:v3.5.21
     container_name: cb-tumblebug-etcd
+    restart: unless-stopped
     networks:
       - default
     ports:
@@ -192,6 +195,7 @@ services:
   cb-mapui:
     image: cloudbaristaorg/cb-mapui:0.12.1
     container_name: cb-mapui
+    restart: unless-stopped
     pull_policy: always
     ports:
       - target: 1324


### PR DESCRIPTION
### 개요

[cm-butterfly 이미지 v0.5.1](https://github.com/cloud-barista/cm-butterfly/releases/tag/v0.5.1) 반영 + 핵심 서비스의 `restart: unless-stopped` 정책 변경 + `cm-butterfly-front-dev` 개발용 임시 서비스  

---

### 1. cm-butterfly 이미지 버전 업데이트 (v0.5.0 → v0.5.1)

* `cm-butterfly-api` : `cloudbaristaorg/cm-butterfly-api:0.5.0` → **`0.5.1`**
* `cm-butterfly-front` : `cloudbaristaorg/cm-butterfly-front:0.5.0` → **`0.5.1`**

### 2. 핵심 서비스에 `restart: unless-stopped` 정책 추가

호스트 재부팅 / 컨테이너 비정상 종료 시 자동 복구를 위해 다음 서비스들에 `restart: unless-stopped` 정책을 일괄 적용.

* `cb-spider`
* `cb-tumblebug`
* `cb-tumblebug-etcd`
* `cb-mapui`

> 참고: cm-butterfly 계열 서비스에는 이미 동일 정책이 적용되어 있음.


### 3. 개발용 웹 프론트 서비스 추가 — `cm-butterfly-front-dev`

릴리스 이미지(`cm-butterfly-front`) 와 별개로 기존 버전과의 비교를 위해 **개발 빌드 이미지를 동시 기동**할 수 있도록 `cm-butterfly-front-dev` 서비스를 추가함.

* 이미지: `csescsta/cm-butterfly-front:20260318094849-feature-260318-jsonviewer-workflow-jsyoo`
* 외부 노출 포트: `5174` (release 용 `cm-butterfly-front` 와 충돌 없이 동시 사용 가능)
* `cm-butterfly-api` healthcheck 의존성, mayfly 툴 / nginx 설정 볼륨 마운트, `restart: unless-stopped`, healthcheck 모두 release 서비스와 동일한 기준 적용
* 운영 환경에서는 비활성/주석 처리되어있으며, 웹에만 반영된 특정 기능의 검증 시에만 주석 해제 후 사용하는 것을 권장
