### PR TITLE
feat(docker): pass API credentials to cm-cicada from .env

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -660,6 +660,17 @@ services:
       - ./data/cm-cicada/cicada_root:/cicada_root:rw
     environment:
       - CMCICADA_ROOT=/cicada_root
+      # cm-cicada calls cm-damselfly, cm-beetle and cb-tumblebug. Those credentials are
+      # currently hardcoded as default/default in cm-cicada.yaml, so they only work while
+      # the called services also use the defaults. We pass the shared .env values here so
+      # that once cm-cicada reads its API credentials from the environment, non-default
+      # credentials work without a compose change on our side.
+      - DAMSELFLY_API_USERNAME=${DAMSELFLY_API_USERNAME}
+      - DAMSELFLY_API_PASSWORD=${DAMSELFLY_API_PASSWORD}
+      - BEETLE_API_USERNAME=${BEETLE_API_USERNAME}
+      - BEETLE_API_PASSWORD=${BEETLE_API_PASSWORD}
+      - TB_API_USERNAME=${TB_API_USERNAME}
+      - TB_API_PASSWORD=${TB_API_PASSWORD}
     # To ensure the order of dependencies, we are explicitly using the entrypoint(./conf/depends_on_order/~.sh)
     entrypoint: ["/tool/entrypoint.sh"]
     command: ["/cm-cicada"]


### PR DESCRIPTION
## What

Pass the shared `.env` API credentials (`DAMSELFLY_API_*`, `BEETLE_API_*`, `TB_API_*`) into the `cm-cicada` service `environment` in `conf/docker/docker-compose.yaml`.

## Why

`cm-cicada` calls cm-damselfly, cm-beetle and cb-tumblebug, but those credentials are hardcoded as `default/default` in `cm-cicada.yaml`, and cm-cicada does not expand env references inside the yaml. So when `.env` supplies non-default credentials, cm-cicada still sends `default/default` and the calls fail with 401. Today the compose file does not forward these credentials to the service at all, which makes the compose a blocker even once the image starts reading them from the environment.

This change forwards the credentials so that, once cm-cicada reads its `api_connections` credentials from the environment, non-default credentials work end-to-end without any further compose change. The `cm-cicada.yaml` rendering is intentionally left untouched; reading credentials from the environment is expected on the cm-cicada side.

## Change

`conf/docker/docker-compose.yaml` — cm-cicada service `environment`, +11 lines (6 credential vars + explanatory comment). No source change.