### PR TITLE
chore(lineup): align image tags to cm-beetle v0.5.3 lineup + cm-ant v0.5.1 with Basic Auth mappings

### DIFF
--- a/conf/docker/.env.example
+++ b/conf/docker/.env.example
@@ -92,6 +92,16 @@ TB_API_PASSWORD=default
 # Previous default (cb-tumblebug container built-in): info
 TB_LOGLEVEL=info
 
+# -----------------------------------------------------------------------------
+# Forward-compatible aliases — TUMBLEBUG_API_* (new name, references TB_API_*)
+# -----------------------------------------------------------------------------
+# 기존 TB_API_* 변수는 cb-tumblebug 컨테이너 자체 호환을 위해 유지한다.
+# 신규 컴포넌트(cm-ant 등)는 TUMBLEBUG_API_*를 사용하도록 점진 전환한다.
+# 값 변경 시 TB_API_*만 수정하면 TUMBLEBUG_API_*도 자동으로 따라간다.
+# -----------------------------------------------------------------------------
+TUMBLEBUG_API_USERNAME=${TB_API_USERNAME}
+TUMBLEBUG_API_PASSWORD=${TB_API_PASSWORD}
+
 
 # =============================================================================
 # 3) cm-beetle

--- a/conf/docker/.env.example
+++ b/conf/docker/.env.example
@@ -95,9 +95,9 @@ TB_LOGLEVEL=info
 # -----------------------------------------------------------------------------
 # Forward-compatible aliases — TUMBLEBUG_API_* (new name, references TB_API_*)
 # -----------------------------------------------------------------------------
-# 기존 TB_API_* 변수는 cb-tumblebug 컨테이너 자체 호환을 위해 유지한다.
-# 신규 컴포넌트(cm-ant 등)는 TUMBLEBUG_API_*를 사용하도록 점진 전환한다.
-# 값 변경 시 TB_API_*만 수정하면 TUMBLEBUG_API_*도 자동으로 따라간다.
+# TB_API_* variables are kept for cb-tumblebug container compatibility.
+# New components such as cm-ant adopt the TUMBLEBUG_API_* name to gradually
+# unify the naming. Changing TB_API_* alone keeps both in sync.
 # -----------------------------------------------------------------------------
 TUMBLEBUG_API_USERNAME=${TB_API_USERNAME}
 TUMBLEBUG_API_PASSWORD=${TB_API_PASSWORD}

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -884,6 +884,12 @@ services:
     environment:
       - ANT_SPIDER_HOST=http://cb-spider
       - ANT_SPIDER_PORT=1024
+      # cb-spider 0.12.17+ enforces Basic Auth; cm-ant must send credentials.
+      # Without these two lines cm-ant calls cb-spider with empty auth header,
+      # resulting in HTTP 401 from cb-spider on every price/cost lookup
+      # (observed during cm-beetle v0.5.3 lineup verification with cm-ant edge).
+      - ANT_SPIDER_USERNAME=${SPIDER_USERNAME}
+      - ANT_SPIDER_PASSWORD=${SPIDER_PASSWORD}
       - ANT_TUMBLEBUG_HOST=http://cb-tumblebug
       - ANT_TUMBLEBUG_PORT=1323
       - ANT_DATABASE_HOST=ant-postgres

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -864,8 +864,8 @@ services:
   # https://hub.docker.com/r/cloudbaristaorg/cm-ant
   cm-ant:
     container_name: cm-ant
-    # image: cloudbaristaorg/cm-ant:0.5.0
-    image: cloudbaristaorg/cm-ant:edge
+    # image: cloudbaristaorg/cm-ant:edge
+    image: cloudbaristaorg/cm-ant:0.5.1
     platform: linux/amd64
     pull_policy: always
     ports:
@@ -892,6 +892,12 @@ services:
       - ANT_SPIDER_PASSWORD=${SPIDER_PASSWORD}
       - ANT_TUMBLEBUG_HOST=http://cb-tumblebug
       - ANT_TUMBLEBUG_PORT=1323
+      # cm-ant should call cb-tumblebug with the same Basic Auth credentials
+      # the rest of the stack uses (.env's TB_API_*). We map the
+      # forward-compatible TUMBLEBUG_API_* alias defined in .env.example
+      # — TB_API_* remains the source of truth and TUMBLEBUG_API_* tracks it.
+      - ANT_TUMBLEBUG_USERNAME=${TUMBLEBUG_API_USERNAME}
+      - ANT_TUMBLEBUG_PASSWORD=${TUMBLEBUG_API_PASSWORD}
       - ANT_DATABASE_HOST=ant-postgres
       # cm-ant Go application reads ANT_DATABASE_USER/PASSWORD/NAME (not ANT_DB_*),
       # so remap from the shared .env names here. Without these three lines cm-ant

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
   # https://github.com/cloud-barista/cb-spider/wiki/Docker-based-Start-Guide
   # https://hub.docker.com/r/cloudbaristaorg/cb-spider
   cb-spider:
-    image: cloudbaristaorg/cb-spider:0.12.30
+    image: cloudbaristaorg/cb-spider:0.12.32
     pull_policy: always
     container_name: cb-spider
     restart: unless-stopped
@@ -55,7 +55,7 @@ services:
   # https://hub.docker.com/r/cloudbaristaorg/cb-tumblebug
   # See https://github.com/cloud-barista/cb-tumblebug/blob/main/docker-compose.yaml
   cb-tumblebug:
-    image: cloudbaristaorg/cb-tumblebug:0.12.15
+    image: cloudbaristaorg/cb-tumblebug:0.12.19
     container_name: cb-tumblebug
     restart: unless-stopped
     pull_policy: always
@@ -200,7 +200,7 @@ services:
   # used by cb-tumblebug
   # See https://github.com/cloud-barista/cb-tumblebug/blob/main/docker-compose.yaml
   cb-mapui:
-    image: cloudbaristaorg/cb-mapui:0.12.39
+    image: cloudbaristaorg/cb-mapui:0.12.43
     container_name: cb-mapui
     restart: unless-stopped
     pull_policy: always
@@ -381,7 +381,7 @@ services:
   # see conf folder : https://github.com/cloud-barista/cm-beetle/tree/main/conf
   # And remove the conf-related comments in the volumes settings below.
   cm-beetle:
-    image: cloudbaristaorg/cm-beetle:0.5.2
+    image: cloudbaristaorg/cm-beetle:0.5.3
     container_name: cm-beetle
     pull_policy: always
     platform: linux/amd64
@@ -573,8 +573,8 @@ services:
   # https://hub.docker.com/r/cloudbaristaorg/cm-honeybee
   # See https://github.com/cloud-barista/cm-honeybee/blob/main/server/docker-compose.yaml
   cm-honeybee:
-    # image: cloudbaristaorg/cm-honeybee:edge
-    image: cloudbaristaorg/cm-honeybee:0.5.0
+    image: cloudbaristaorg/cm-honeybee:edge
+    # image: cloudbaristaorg/cm-honeybee:0.5.0
     container_name: cm-honeybee
     pull_policy: always
     platform: linux/amd64
@@ -627,8 +627,8 @@ services:
   # https://hub.docker.com/r/cloudbaristaorg/cm-cicada
   # **important** : The cm-beetle, cm-grasshopper, and airflow-server containers must be in a readyz state and running beforehand
   cm-cicada:
-    # image: cloudbaristaorg/cm-cicada:edge
-    image: cloudbaristaorg/cm-cicada:0.5.0
+    image: cloudbaristaorg/cm-cicada:edge
+    # image: cloudbaristaorg/cm-cicada:0.5.0
     container_name: cm-cicada
     pull_policy: always
     restart: unless-stopped
@@ -728,8 +728,8 @@ services:
     # build:
     #     context: ./conf/cm-cicada/_airflow ## build Docker file location
     container_name: airflow-server
-    image: cloudbaristaorg/airflow-server:0.5.0
-    #image: cloudbaristaorg/airflow-server:edge
+    # image: cloudbaristaorg/airflow-server:0.5.0
+    image: cloudbaristaorg/airflow-server:edge
     restart: unless-stopped
     environment:
         # SMTP settings (managed centrally in the host .env)
@@ -799,8 +799,8 @@ services:
   # https://hub.docker.com/r/cloudbaristaorg/cm-grasshopper
   # See https://github.com/cloud-barista/cm-grasshopper/blob/main/docker-compose.yaml
   cm-grasshopper:
-    # image: cloudbaristaorg/cm-grasshopper:edge
-    image: cloudbaristaorg/cm-grasshopper:0.5.0
+    image: cloudbaristaorg/cm-grasshopper:edge
+    # image: cloudbaristaorg/cm-grasshopper:0.5.0
     container_name: cm-grasshopper
     pull_policy: always
     restart: unless-stopped
@@ -864,8 +864,8 @@ services:
   # https://hub.docker.com/r/cloudbaristaorg/cm-ant
   cm-ant:
     container_name: cm-ant
-    image: cloudbaristaorg/cm-ant:0.5.0
-    # image: cloudbaristaorg/cm-ant:edge
+    # image: cloudbaristaorg/cm-ant:0.5.0
+    image: cloudbaristaorg/cm-ant:edge
     platform: linux/amd64
     pull_policy: always
     ports:


### PR DESCRIPTION
## Summary

Align cm-mayfly's docker-compose lineup to the cm-beetle v0.5.3 release and update cm-ant integration to its v0.5.1 release that brings the cb-tumblebug / cb-spider lineup catch-up.

## Lineup matrix

| # | Service | Previous | **Current** | Source |
|--:|---|---|---|---|
| 1 | cb-spider | 0.12.30 | **0.12.32** | cm-beetle v0.5.3 Related Components |
| 2 | cb-tumblebug | 0.12.15 | **0.12.19** | cm-beetle v0.5.3 Related Components |
| 3 | cb-mapui | 0.12.39 | **0.12.43** | cm-beetle v0.5.3 Related Components |
| 4 | mc-terrarium | 0.1.4 | **0.1.4** (unchanged) | cm-beetle v0.5.3 |
| 5 | cm-beetle | 0.5.2 | **0.5.3** | baseline |
| 6 | openbao | 2.5.1 | **2.5.1** (unchanged) | external dependency |
| 7 | cm-butterfly-api | 0.5.1 | **0.5.1** (unchanged) | latest 0.5.x |
| 8 | cm-butterfly-front | 0.5.1 | **0.5.1** (unchanged) | latest 0.5.x |
| 9 | cm-damselfly | 0.5.1 | **0.5.1** (unchanged) | latest 0.5.x |
| 10 | cm-honeybee | 0.5.0 | **edge** | no post-0.5.0 release |
| 11 | cm-cicada | 0.5.0 | **edge** | no post-0.5.0 release |
| 12 | airflow-server | 0.5.0 | **edge** | no post-0.5.0 release |
| 13 | cm-grasshopper | 0.5.0 | **edge** | no post-0.5.0 release |
| 14 | cm-ant | 0.5.0 | **0.5.1** | new release with cb-tumblebug v0.12.9 / cb-spider v0.12.30 lineup support |

## cm-ant authentication mapping

cb-spider 0.12.17+ enforces Basic Auth, and cm-ant v0.5.1 calls both cb-spider and cb-tumblebug with BasicAuth. The cm-ant service environment must pass the credentials explicitly:

- \`ANT_SPIDER_USERNAME=\${SPIDER_USERNAME}\` / \`ANT_SPIDER_PASSWORD=\${SPIDER_PASSWORD}\`
- \`ANT_TUMBLEBUG_USERNAME=\${TUMBLEBUG_API_USERNAME}\` / \`ANT_TUMBLEBUG_PASSWORD=\${TUMBLEBUG_API_PASSWORD}\`

Added \`TUMBLEBUG_API_USERNAME\` / \`TUMBLEBUG_API_PASSWORD\` aliases in \`.env.example\` that reference the existing \`TB_API_USERNAME\` / \`TB_API_PASSWORD\` values.
\`TB_API_*\` remains the source of truth for cb-tumblebug container compatibility; new components such as cm-ant adopt the \`TUMBLEBUG_API_*\` naming so the docker-compose mapping resolves to the same credentials without duplicating the value.

## Verification

End-to-end verified on a fresh dev environment (Ubuntu 24.04):

- 22/22 containers healthy after clean-install → openbao init → infra run
- cm-ant readyz, swagger schema, load generator install, load test execution with result CSV, and scenario catalog CRUD all pass
- cost estimate succeeds for AWS / Azure / Alibaba (the GCP driver issue in cb-spider is tracked separately)
- JMeter installer (Eclipse Temurin JRE 21 + 3-layer JAVA_HOME fallback) confirmed working on Ubuntu 24.04 and Amazon Linux 2023

## Note on \`infra remove --clean-all\`

A separate upstream issue was filed: cloud-barista/cm-mayfly#142.
\`--clean-all\` removes the openbao container, volume, image, and host data but does not clear \`VAULT_TOKEN\` from \`.env\`, causing a subsequent \`setup openbao init\` to refuse without \`--force\`.
This PR does not address that issue (verified using the \`--force\` workaround); the fix is prepared separately.