### PR TITLE
feat(api): refresh api.yaml lineup to cm-beetle v0.5.3 baseline

### DIFF
--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -39,7 +39,7 @@
 # =============================================================================
 services:
   cb-spider: #service name
-    version: 0.11.13
+    version: 0.12.32
     baseurl: http://cb-spider:1024/spider # baseurl is Scheme + Host + Base Path
     auth: # cb-spider 0.12.17+ requires REST auth; credentials are read from the env (see header).
       type: basic
@@ -47,19 +47,19 @@ services:
       password: ${SPIDER_PASSWORD}
 
   cb-tumblebug:
-    version: 0.11.13
+    version: 0.12.19
     baseurl: http://cb-tumblebug:1323/tumblebug
     auth:
       type: basic
       username: ${TB_API_USERNAME}
       password: ${TB_API_PASSWORD}
   cm-ant:
-    version: 0.4.0
+    version: 0.5.0
     baseurl: http://cm-ant:8880/ant
     auth:
       type: none
   cm-beetle:
-    version: 0.4.0
+    version: 0.5.3
     baseurl: http://cm-beetle:8056/beetle
     auth:
       type: basic
@@ -74,24 +74,25 @@ services:
       type: none
       
   cm-cicada:
-    version: 0.4.0
+    version: 0.5.0
     baseurl: http://cm-cicada:8083/cicada
     auth:
       type: none
 
   cm-honeybee:
-    version: 0.4.0
+    version: 0.5.0
     baseurl: http://cm-honeybee:8081/honeybee
     auth:
       type: none 
 
   cm-grasshopper:
-    version: 0.4.0
+    version: 0.5.0
     baseurl: http://cm-grasshopper:8084/grasshopper
     auth:
       type: none
 
   cm-damselfly:
+    version: 0.5.1
     baseurl: http://cm-damselfly:8088/damselfly
     auth: # cm-damselfly checks these only when DAMSELFLY_API_AUTH_ENABLED=true; otherwise they are ignored.
       type: basic
@@ -100,2991 +101,3016 @@ services:
 
 serviceActions:
   cb-spider:
-    Add-Nlb-Vm:
-      method: post
-      resourcePath: /nlb/{Name}/vms
-      description: Add a new set of VMs to an existing Network Load Balancer (NLB).
-    Add-Nodegroup:
-      method: post
-      resourcePath: /cluster/{Name}/nodegroup
-      description: Add a new Node Group to an existing Cluster.
-    Add-Rule:
-      method: post
-      resourcePath: /securitygroup/{SGName}/rules
-      description: Add new rules to a Security Group.
-    Add-Subnet:
-      method: post
-      resourcePath: /vpc/{VPCName}/subnet
-      description: Add a new Subnet to an existing VPC.
-    Add-Tag:
-      method: post
-      resourcePath: /tag
-      description: |-
-        Add a tag to a specified resource.
-        ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER
-    Any-Call:
-      method: post
-      resourcePath: /anycall
-      description: "Execute a custom function (FID) with key-value parameters through
-        AnyCall. \U0001F577️ [[Development Guide](https://github.com/cloud-barista/cb-spider/wiki/AnyCall-API-Extension-Guide)]"
-    Attach-Disk:
-      method: put
-      resourcePath: /disk/{Name}/attach
-      description: Attach an existing Disk to a VM.
-    Change-Nodegroup-Scaling:
-      method: put
-      resourcePath: /cluster/{Name}/nodegroup/{NodeGroupName}/autoscalesize
-      description: Change the scaling settings for a Node Group in a Cluster.
-    Check-Tcp-Port:
-      method: get
-      resourcePath: /check/tcp
-      description: Verifies whether a given TCP port is open on the specified host.
-    Check-Udp-Port:
-      method: get
-      resourcePath: /check/udp
-      description: |-
-        Verifies whether a given UDP port is open on the specified host.
-        ※ Note: As UDP is connectionless, this check mainly performs a lookup and may not confirm if the server is working.
-    Control-Vm:
-      method: put
-      resourcePath: /controlvm/{Name}
-      description: Control the state of a Virtual Machine (VM) such as suspend, resume,
-        or reboot.
-    Count-All-Cluster:
-      method: get
-      resourcePath: /countcluster
-      description: Get the total number of Clusters across all connections.
-    Count-All-Connection:
-      method: get
-      resourcePath: /countconnectionconfig
-      description: Get the total number of connections.
-    Count-All-Disk:
-      method: get
-      resourcePath: /countdisk
-      description: Get the total number of Disks across all connections.
-    Count-All-Keypair:
-      method: get
-      resourcePath: /countkeypair
-      description: Get the total number of KeyPairs across all connections.
-    Count-All-Myimage:
-      method: get
-      resourcePath: /countmyimage
-      description: Get the total number of MyImages across all connections.
-    Count-All-Nlb:
-      method: get
-      resourcePath: /countnlb
-      description: Get the total number of Network Load Balancers (NLBs) across all
-        connections.
-    Count-All-Securitygroup:
-      method: get
-      resourcePath: /countsecuritygroup
-      description: Get the total number of Security Groups across all connections.
-    Count-All-Subnet:
-      method: get
-      resourcePath: /countsubnet
-      description: Get the total number of Subnets across all connections.
-    Count-All-Vm:
-      method: get
-      resourcePath: /countvm
-      description: Get the total number of Virtual Machines (VMs) across all connections.
-    Count-All-Vpc:
-      method: get
-      resourcePath: /countvpc
-      description: Get the total number of VPCs across all connections.
-    Count-Cluster-By-Connection:
-      method: get
-      resourcePath: /countcluster/{ConnectionName}
-      description: Get the total number of Clusters for a specific connection.
-    Count-Connection-By-Provider:
-      method: get
-      resourcePath: /countconnectionconfig/{ProviderName}
-      description: Get the total number of connections for a specific provider.
-    Count-Disk-By-Connection:
-      method: get
-      resourcePath: /countdisk/{ConnectionName}
-      description: Get the total number of Disks for a specific connection.
-    Count-Keypair-By-Connection:
-      method: get
-      resourcePath: /countkeypair/{ConnectionName}
-      description: Get the total number of KeyPairs for a specific connection.
-    Count-Myimage-By-Connection:
-      method: get
-      resourcePath: /countmyimage/{ConnectionName}
-      description: Get the total number of MyImages for a specific connection.
-    Count-Nlb-By-Connection:
-      method: get
-      resourcePath: /countnlb/{ConnectionName}
-      description: Get the total number of Network Load Balancers (NLBs) for a specific
-        connection.
-    Count-Securitygroup-By-Connection:
-      method: get
-      resourcePath: /countsecuritygroup/{ConnectionName}
-      description: Get the total number of Security Groups for a specific connection.
-    Count-Subnet-By-Connection:
-      method: get
-      resourcePath: /countsubnet/{ConnectionName}
-      description: Get the total number of Subnets for a specific connection.
-    Count-Vm-By-Connection:
-      method: get
-      resourcePath: /countvm/{ConnectionName}
-      description: Get the total number of Virtual Machines (VMs) for a specific connection.
     Count-Vpc-By-Connection:
       method: get
       resourcePath: /countvpc/{ConnectionName}
-      description: Get the total number of VPCs for a specific connection.
-    Create-Cluster:
-      method: post
-      resourcePath: /cluster
-      description: "Create a new Cluster with specified configurations. \U0001F577️
-        [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Provider-Managed-Kubernetes-and-Driver-API)]
-        <br> * NodeGroupList is optional, depends on CSP type: <br> &nbsp;- Type-I
-        (e.g., Tencent, Alibaba): requires separate Node Group addition after Cluster
-        creation. <br> &nbsp;- Type-II (e.g., Azure, NHN): mandates at least one Node
-        Group during initial Cluster creation."
-    Create-Connection-Config:
-      method: post
-      resourcePath: /connectionconfig
-      description: "Create a new Connection Config. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#4-cloud-connection-configuration-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]"
-    Create-Disk:
-      method: post
-      resourcePath: /disk
-      description: "Create a new Disk with the specified configuration. \U0001F577️
-        [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Disk-and-Driver-API)],
-        [[Snapshot-MyImage,Disk Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Snapshot,-MyImage-and-Disk-Overview)]"
-    Create-Filesystem:
-      method: post
-      resourcePath: /filesystem
-      description: Create a new FileSystem with the specified configuration.
-    Create-Keypair:
-      method: post
-      resourcePath: /keypair
-      description: "Create a new KeyPair with the specified configurations. \U0001F577️
-        [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#5-vm-keypair-%EC%83%9D%EC%84%B1-%EB%B0%8F-%EC%A0%9C%EC%96%B4)]"
-    Create-Myimage:
-      method: post
-      resourcePath: /myimage
-      description: "Create a new MyImage snapshot from a specified VM. \U0001F577️
-        [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/MyImage-and-Driver-API)],
-        [[Snapshot-MyImage,Disk Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Snapshot,-MyImage-and-Disk-Overview)]"
-    Create-Nlb:
-      method: post
-      resourcePath: /nlb
-      description: "Create a new Network Load Balancer (NLB) with specified configurations.
-        \U0001F577️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Network-Load-Balancer-and-Driver-API)]"
-    Create-Securitygroup:
-      method: post
-      resourcePath: /securitygroup
-      description: "Create a new Security Group with specified rules and tags. \U0001F577️
-        [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Security-Group-Rules-and-Driver-API)],
-        \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#4-securitygroup-%EC%83%9D%EC%84%B1-%EB%B0%8F-%EC%A0%9C%EC%96%B4)]"
-    Create-Vpc:
-      method: post
-      resourcePath: /vpc
-      description: "Create a new Virtual Private Cloud (VPC) with specified subnet
-        configurations. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#3-vpcsubnet-%EC%83%9D%EC%84%B1-%EB%B0%8F-%EC%A0%9C%EC%96%B4)]"
-    Delete-Cluster:
-      method: delete
-      resourcePath: /cluster/{Name}
-      description: Delete a specified Cluster.
-    Delete-Connection-Config:
-      method: delete
-      resourcePath: /connectionconfig/{ConfigName}
-      description: Delete a specific Connection Config.
-    Delete-Csp-Cluster:
-      method: delete
-      resourcePath: /cspcluster/{Id}
-      description: Delete a specified CSP Cluster.
-    Delete-Csp-Disk:
-      method: delete
-      resourcePath: /cspdisk/{Id}
-      description: Delete a specified CSP Disk.
-    Delete-Csp-Keypair:
-      method: delete
-      resourcePath: /cspkeypair/{Id}
-      description: Delete a specified CSP KeyPair.
-    Delete-Csp-Myimage:
-      method: delete
-      resourcePath: /cspmyimage/{Id}
-      description: Delete a specified CSP MyImage.
-    Delete-Csp-Nlb:
-      method: delete
-      resourcePath: /cspnlb/{Id}
-      description: Delete a specified CSP Network Load Balancer (NLB).
-    Delete-Csp-Securitygroup:
-      method: delete
-      resourcePath: /cspsecuritygroup/{Id}
-      description: Delete a specified CSP Security Group.
-    Delete-Csp-Vpc:
-      method: delete
-      resourcePath: /cspvpc/{Id}
-      description: Delete a specified CSP Virtual Private Cloud (VPC).
-    Delete-Disk:
-      method: delete
-      resourcePath: /disk/{Name}
-      description: Delete a specified Disk.
-    Delete-Keypair:
-      method: delete
-      resourcePath: /keypair/{Name}
-      description: Delete a specified KeyPair.
-    Delete-Myimage:
-      method: delete
-      resourcePath: /myimage/{Name}
-      description: Delete a specified MyImage.
-    Delete-Nlb:
-      method: delete
-      resourcePath: /nlb/{Name}
-      description: Delete a specified Network Load Balancer (NLB).
-    Delete-Securitygroup:
-      method: delete
-      resourcePath: /securitygroup/{Name}
-      description: Delete a specified Security Group.
-    Delete-Vpc:
-      method: delete
-      resourcePath: /vpc/{Name}
-      description: Delete a specified Virtual Private Cloud (VPC).
-    Destroy-All-Resource:
-      method: delete
-      resourcePath: /destroy
-      description: Deletes all resources associated with a specific cloud connection.
-        This action is irreversible.
-    Detach-Disk:
-      method: put
-      resourcePath: /disk/{Name}/detach
-      description: Detach an existing Disk from a VM.
-    Fetch-Resource-Usage:
-      method: get
-      resourcePath: /sysstats/usage
-      description: |-
-        Retrieve resource usage information such as CPU, memory, disk I/O, and network I/O.
-        Use query parameter 'mode=text' to get the output in text format instead of JSON.
-    Fetch-System-Info:
-      method: get
-      resourcePath: /sysstats/system
-      description: |-
-        Retrieve system information such as hostname, platform, CPU, memory, and disk.
-        Use query parameter 'mode=text' to get the output in text format instead of JSON.
-    Get-Cloudos-Metainfo:
-      method: get
-      resourcePath: /cloudos/metainfo/{CloudOSName}
-      description: Retrieve metadata information for a specific Cloud OS.
-    Get-Cluster:
-      method: get
-      resourcePath: /cluster/{Name}
-      description: Retrieve details of a specific Cluster.
-    Get-Cluster-Owner-Vpc:
-      method: post
-      resourcePath: /getclusterowner
-      description: Retrieve the owner VPC of a specified Cluster.
-    Get-Connection-Config:
-      method: get
-      resourcePath: /connectionconfig/{ConfigName}
-      description: Retrieve details of a specific Connection Config.
-    Get-Credential:
-      method: get
-      resourcePath: /credential/{CredentialName}
-      description: Retrieve details of a specific Credential.
-    Get-Csp-Vm:
-      method: get
-      resourcePath: /cspvm/{Id}
-      description: Retrieve details of a specific CSP Virtual Machine (VM).
-    Get-Disk:
-      method: get
-      resourcePath: /disk/{Name}
-      description: Retrieve details of a specific Disk.
-    Get-Driver:
-      method: get
-      resourcePath: /driver/{DriverName}
-      description: Retrieve details of a specific Cloud Driver.
+      description: "Get the total number of VPCs for a specific connection."
     Get-Driver-Capability:
       method: get
       resourcePath: /driver/capability
-      description: Retrieve capability information of the cloud driver.
-    Get-Image:
-      method: get
-      resourcePath: /vmimage/{Name}
-      description: "Retrieve details of a specific Public Image. \U0001F577️ [[User
-        Guide](https://github.com/cloud-barista/cb-spider/wiki/How-to-get-Image-List-with-REST-API)]"
-    Get-Keypair:
-      method: get
-      resourcePath: /keypair/{Name}
-      description: Retrieve details of a specific KeyPair.
-    Get-Myimage:
-      method: get
-      resourcePath: /myimage/{Name}
-      description: Retrieve details of a specific MyImage.
-    Get-Nlb:
-      method: get
-      resourcePath: /nlb/{Name}
-      description: Retrieve details of a specific Network Load Balancer (NLB).
-    Get-Nlb-Owner-Vpc:
-      method: post
-      resourcePath: /getnlbowner
-      description: Retrieve the owner VPC of a specified Network Load Balancer (NLB).
-    Get-Org-Vm-Spec:
-      method: get
-      resourcePath: /vmorgspec/{Name}
-      description: Retrieve details of a specific Original VM Spec.
-    Get-Region:
-      method: get
-      resourcePath: /region/{RegionName}
-      description: Retrieve details of a specific Region.
-    Get-Region-Zone:
-      method: get
-      resourcePath: /regionzone/{Name}
-      description: "Retrieve details of a specific Region Zone. \U0001F577️ [[User
-        Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]"
-    Get-Region-Zone-Preconfig:
-      method: get
-      resourcePath: /preconfig/regionzone/{Name}
-      description: "Retrieve details of a specific pre-configured Region Zone based
-        on driver and credential names. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]"
-    Get-Securitygroup:
-      method: get
-      resourcePath: /securitygroup/{Name}
-      description: Retrieve details of a specific Security Group.
-    Get-Sg-Owner-Vpc:
-      method: post
-      resourcePath: /getsecuritygroupowner
-      description: Retrieve the owner VPC of a specified Security Group.
-    Get-Subnet:
-      method: get
-      resourcePath: /vpc/{VPCName}/subnet/{SubnetName}
-      description: Retrieve a specific Subnet from a VPC.
-    Get-Tag:
-      method: get
-      resourcePath: /tag/{Key}
-      description: |-
-        Retrieve a specific tag for a specified resource.
-        ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER
-    Get-Vm:
-      method: get
-      resourcePath: /vm/{Name}
-      description: Retrieve details of a specific Virtual Machine (VM).
-    Get-Vm-Spec:
-      method: get
-      resourcePath: /vmspec/{Name}
-      description: "Retrieve details of a specific VM spec. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-vm-spec-%EC%A0%95%EB%B3%B4-%EC%A0%9C%EA%B3%B5)]"
-    Get-Vm-Status:
-      method: get
-      resourcePath: /vmstatus/{Name}
-      description: Retrieve the status of a specific Virtual Machine (VM).
-    Get-Vm-Using-Rs:
-      method: post
-      resourcePath: /getvmusingresources
-      description: Retrieve details of a VM using resource ID.
-    Get-Vmgroup-Healthinfo:
-      method: get
-      resourcePath: /nlb/{Name}/health
-      description: Retrieve the health information of the VM group in a specified
-        Network Load Balancer (NLB).
-    Get-Vmprice-Info:
-      method: post
-      resourcePath: /priceinfo/vm/{RegionName}
-      description: "Retrieve VM Price Information for a specific connection and region.
-        \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Price-Info-Guide)]
-        <br> * example body: {\"connectionName\":\"aws-connection\",\"FilterList\":[{\"Key\":\"instanceType\",\"Value\":\"t2.micro\"}]}"
-    Get-Vpc:
-      method: get
-      resourcePath: /vpc/{Name}
-      description: Retrieve details of a specific Virtual Private Cloud (VPC).
-    Health-Check-Health:
-      method: get
-      resourcePath: /health
-      description: "Checks the health of CB-Spider service and its dependencies via
-        /health endpoint. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]"
-    Health-Check-Healthcheck:
-      method: get
-      resourcePath: /healthcheck
-      description: "Checks the health of CB-Spider service and its dependencies via
-        /healthcheck endpoint. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]"
-    Health-Check-Ping:
-      method: get
-      resourcePath: /ping
-      description: "Checks the health of CB-Spider service and its dependencies via
-        /ping endpoint. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]"
-    Health-Check-Readyz:
-      method: get
-      resourcePath: /readyz
-      description: "Checks the health of CB-Spider service and its dependencies via
-        /readyz endpoint. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]"
-    Increase-Disk-Size:
-      method: put
-      resourcePath: /disk/{Name}/size
-      description: Increase the size of an existing disk.
-    List-All-Cluster:
-      method: get
-      resourcePath: /allcluster
-      description: Retrieve a comprehensive list of all Clusters associated with a
-        specific connection, <br> including those mapped between CB-Spider and the
-        CSP, <br> only registered in CB-Spider's metadata, <br> and only existing
-        in the CSP.
-    List-All-Cluster-Info:
-      method: get
-      resourcePath: /allclusterinfo
-      description: Retrieve a list of all Cluster information associated with a specific
-        connection.
-    List-All-Disk:
-      method: get
-      resourcePath: /alldisk
-      description: Retrieve a comprehensive list of all Disks associated with a specific
-        connection, <br> including those mapped between CB-Spider and the CSP, <br>
-        only registered in CB-Spider's metadata, <br> and only existing in the CSP.
-    List-All-Disk-Info:
-      method: get
-      resourcePath: /alldiskinfo
-      description: Retrieve a list of all Disk information associated with all connections.
-    List-All-Keypair:
-      method: get
-      resourcePath: /allkeypair
-      description: Retrieve a comprehensive list of all KeyPairs associated with a
-        specific connection, <br> including those mapped between CB-Spider and the
-        CSP, <br> only registered in CB-Spider's metadata, <br> and only existing
-        in the CSP.
-    List-All-Keypair-Info:
-      method: get
-      resourcePath: /allkeypairinfo
-      description: Retrieve a list of KeyPair information associated with all connections.
-    List-All-Myimage:
-      method: get
-      resourcePath: /allmyimage
-      description: Retrieve a comprehensive list of all MyImages associated with a
-        specific connection, <br> including those mapped between CB-Spider and the
-        CSP, <br> only registered in CB-Spider's metadata, <br> and only existing
-        in the CSP.
-    List-All-Myimage-Info:
-      method: get
-      resourcePath: /allmyimageinfo
-      description: Retrieve a comprehensive list of all MyImage information associated
-        with a specific connection, <br> including those mapped between CB-Spider
-        and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing
-        in the CSP.
-    List-All-Nlb:
-      method: get
-      resourcePath: /allnlb
-      description: Retrieve a comprehensive list of all Network Load Balancers (NLBs)
-        associated with a specific connection, <br> including those mapped between
-        CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br>
-        and only existing in the CSP.
-    List-All-Nlb-Info:
-      method: get
-      resourcePath: /allnlbinfo
-      description: Retrieve a comprehensive list of all Network Load Balancers (NLBs)
-        associated with a specific connection, <br> including those mapped between
-        CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br>
-        and only existing in the CSP.
-    List-All-Securitygroup:
-      method: get
-      resourcePath: /allsecuritygroup
-      description: Retrieve a comprehensive list of all Security Groups associated
-        with a specific connection, <br> including those mapped between CB-Spider
-        and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing
-        in the CSP.
-    List-All-Securitygroup-Info:
-      method: get
-      resourcePath: /allsecuritygroupinfo
-      description: Retrieve a list of Security Group information associated with all
-        connections.
-    List-All-Vm:
-      method: get
-      resourcePath: /allvm
-      description: Retrieve a comprehensive list of all Virtual Machines (VMs) associated
-        with a specific connection, <br> including those mapped between CB-Spider
-        and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing
-        in the CSP.
-    List-All-Vm-Info:
-      method: get
-      resourcePath: /allvminfo
-      description: Retrieve a list of detailed information on all Virtual Machines
-        (VMs) associated with a specific connection, <br> including those mapped between
-        CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br>
-        and only existing in the CSP.
-    List-All-Vpc:
-      method: get
-      resourcePath: /allvpc
-      description: Retrieve a comprehensive list of all Virtual Private Clouds (VPCs)
-        associated with a specific connection, <br> including those mapped between
-        CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br>
-        and only existing in the CSP.
-    List-All-Vpc-Info:
-      method: get
-      resourcePath: /allvpcinfo
-      description: Retrieve a comprehensive list of all Virtual Private Clouds (VPCs)
-        associated with a specific connection, <br> including those mapped between
-        CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br>
-        and only existing in the CSP.
-    List-Cloudos:
-      method: get
-      resourcePath: /cloudos
-      description: Retrieve a list of supported Cloud OS.
-    List-Cluster:
-      method: get
-      resourcePath: /cluster
-      description: Retrieve a list of Clusters associated with a specific connection.
-    List-Connection-Config:
-      method: get
-      resourcePath: /connectionconfig
-      description: Retrieve a list of registered Connection Configs.
-    List-Credential:
-      method: get
-      resourcePath: /credential
-      description: Retrieve a list of registered Credentials.
-    List-Disk:
-      method: get
-      resourcePath: /disk
-      description: Retrieve a list of Disks associated with a specific connection.
-    List-Driver:
-      method: get
-      resourcePath: /driver
-      description: Retrieve a list of registered Cloud Drivers.
-    List-Image:
-      method: get
-      resourcePath: /vmimage
-      description: "Retrieve a list of Public Images associated with a specific connection.
-        \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/How-to-get-Image-List-with-REST-API)]"
-    List-Keypair:
-      method: get
-      resourcePath: /keypair
-      description: Retrieve a list of KeyPairs associated with a specific connection.
-    List-Myimage:
-      method: get
-      resourcePath: /myimage
-      description: Retrieve a list of MyImages associated with a specific connection.
-    List-Nlb:
-      method: get
-      resourcePath: /nlb
-      description: Retrieve a list of Network Load Balancers (NLBs) associated with
-        a specific connection.
-    List-Org-Region:
-      method: get
-      resourcePath: /orgregion
-      description: Retrieve a list of Original Regions associated with a specific
-        connection. <br> The response structure may vary depending on the request
-        ConnectionName.
-    List-Org-Vm-Spec:
-      method: get
-      resourcePath: /vmorgspec
-      description: Retrieve a list of Original VM Specs associated with a specific
-        connection. <br> The response structure may vary depending on the request
-        ConnectionName.
-    List-Org-Zone:
-      method: get
-      resourcePath: /orgzone
-      description: Retrieve a list of Original Zones associated with a specific connection.
-        <br> The response structure may vary depending on the request ConnectionName.
-    List-Preconfigured-Original-Org-Region:
-      method: get
-      resourcePath: /preconfig/orgregion
-      description: Retrieve a list of pre-configured Original Regions based on driver
-        and credential names. <br> The response structure may vary depending on the
-        request DriverName and CredentialName.
+      description: "Retrieve capability information of the cloud driver."
     List-Product-Family:
       method: get
       resourcePath: /productfamily/{RegionName}
-      description: "Retrieve a list of Product Families associated with a specific
-        connection and region. \U0001F577️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Price-Info-and-Cloud-Driver-API)],
-        \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/RestAPI-Multi%E2%80%90Cloud-Price-Information-Guide)]"
-    List-Region:
-      method: get
-      resourcePath: /region
-      description: Retrieve a list of registered Regions.
-    List-Region-Zone:
-      method: get
-      resourcePath: /regionzone
-      description: "Retrieve a list of Region Zones associated with a specific connection.
-        \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]"
-    List-Region-Zone-Preconfig:
-      method: get
-      resourcePath: /preconfig/regionzone
-      description: "Retrieve a list of pre-configured Region Zones based on driver
-        and credential names. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]"
-    List-Securitygroup:
-      method: get
-      resourcePath: /securitygroup
-      description: Retrieve a list of Security Groups associated with a specific connection.
-    List-Tag:
-      method: get
-      resourcePath: /tag
-      description: |-
-        Retrieve a list of tags for a specified resource.
-        ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER
-    List-Vm:
-      method: get
-      resourcePath: /vm
-      description: Retrieve a list of Virtual Machines (VMs) associated with a specific
-        connection.
-    List-Vm-Spec:
-      method: get
-      resourcePath: /vmspec
-      description: "Retrieve a list of VM specs associated with a specific connection.
-        \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-vm-spec-%EC%A0%95%EB%B3%B4-%EC%A0%9C%EA%B3%B5)]"
-    List-Vm-Status:
-      method: get
-      resourcePath: /vmstatus
-      description: Retrieve a list of statuses for Virtual Machines (VMs) associated
-        with a specific connection.
-    List-Vpc:
-      method: get
-      resourcePath: /vpc
-      description: Retrieve a list of Virtual Private Clouds (VPCs) associated with
-        a specific connection.
-    List-Vpc-Securitygroup:
-      method: get
-      resourcePath: /securitygroup/vpc/{VPCName}
-      description: Retrieve a list of Security Groups associated with a specific VPC
-        in a given cloud connection.
-    Register-Cluster:
-      method: post
-      resourcePath: /regcluster
-      description: Register a new Cluster with the specified VPC and CSP ID.
-    Register-Credential:
-      method: post
-      resourcePath: /credential
-      description: "Register a new Credential. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-cloud-credential-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]"
-    Register-Disk:
-      method: post
-      resourcePath: /regdisk
-      description: Register a new Disk with the specified name, zone, and CSP ID.
-    Register-Driver:
-      method: post
-      resourcePath: /driver
-      description: "Register a new Cloud Driver. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#1-cloud-driver-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]"
-    Register-Keypair:
-      method: post
-      resourcePath: /regkeypair
-      description: Register a new KeyPair with the specified name and CSP ID.
-    Register-Myimage:
-      method: post
-      resourcePath: /regmyimage
-      description: Register a new MyImage with the specified name and CSP ID.
-    Register-Nlb:
-      method: post
-      resourcePath: /regnlb
-      description: Register a new Network Load Balancer (NLB) with the specified name
-        and CSP ID.
-    Register-Region:
-      method: post
-      resourcePath: /region
-      description: "Register a new Region. \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#3-cloud-regionzone-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]"
-    Register-Securitygroup:
-      method: post
-      resourcePath: /regsecuritygroup
-      description: Register a new Security Group with the specified name and CSP ID.
-    Register-Subnet:
-      method: post
-      resourcePath: /regsubnet
-      description: Register a new Subnet within a specified VPC.
-    Register-Vm:
-      method: post
-      resourcePath: /regvm
-      description: Register a new Virtual Machine (VM) with the specified name and
-        CSP ID.
-    Register-Vpc:
-      method: post
-      resourcePath: /regvpc
-      description: Register a new Virtual Private Cloud (VPC) with the specified name
-        and CSP ID.
-    Remove-Csp-Subnet:
-      method: delete
-      resourcePath: /vpc/{VPCName}/cspsubnet/{Id}
-      description: Remove an existing CSP Subnet from a VPC.
-    Remove-Nlb-Vm:
-      method: delete
-      resourcePath: /nlb/{Name}/vms
-      description: Remove a set of VMs from an existing Network Load Balancer (NLB).
-    Remove-Nodegroup:
-      method: delete
-      resourcePath: /cluster/{Name}/nodegroup/{NodeGroupName}
-      description: Remove an existing Node Group from a Cluster.
-    Remove-Rule:
-      method: delete
-      resourcePath: /securitygroup/{SGName}/rules
-      description: Remove existing rules from a Security Group.
-    Remove-Subnet:
-      method: delete
-      resourcePath: /vpc/{VPCName}/subnet/{SubnetName}
-      description: Remove an existing Subnet from a VPC.
-    Remove-Tag:
-      method: delete
-      resourcePath: /tag/{Key}
-      description: |-
-        Remove a specific tag from a specified resource.
-        ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER
-    Set-Nodegroup-Autoscaling:
-      method: put
-      resourcePath: /cluster/{Name}/nodegroup/{NodeGroupName}/onautoscaling
-      description: Enable or disable auto scaling for a Node Group in a Cluster.
-    Start-Vm:
-      method: post
-      resourcePath: /vm
-      description: "Start a new Virtual Machine (VM) with specified configurations.
-        \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-%EB%A9%80%ED%8B%B0%ED%81%B4%EB%9D%BC%EC%9A%B0%EB%93%9C-vm-%EC%9D%B8%ED%94%84%EB%9D%BC-%EC%9E%90%EC%9B%90-%EC%A0%9C%EC%96%B4multi-cloud-vm-infra-resource-control)],
-        [[Snapshot-MyImage,Disk Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Snapshot,-MyImage-and-Disk-Overview)]"
-    Terminate-Csp-Vm:
-      method: delete
-      resourcePath: /cspvm/{Id}
-      description: Terminate a specified CSP Virtual Machine (VM).
-    Terminate-Vm:
-      method: delete
-      resourcePath: /vm/{Name}
-      description: Terminate a specified Virtual Machine (VM).
-    Unregister-Cluster:
-      method: delete
-      resourcePath: /regcluster/{Name}
-      description: Unregister a Cluster with the specified name.
-    Unregister-Credential:
-      method: delete
-      resourcePath: /credential/{CredentialName}
-      description: Unregister a specific Credential.
+      description: "Retrieve a list of Product Families associated with a specific connection and region. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Price-Info-and-Cloud-Driver-API)], 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/RestAPI-Multi%E2%80%90Cloud-Price-Information-Guide)]"
     Unregister-Disk:
       method: delete
       resourcePath: /regdisk/{Name}
-      description: Unregister a Disk with the specified name.
-    Unregister-Driver:
-      method: delete
-      resourcePath: /driver/{DriverName}
-      description: Unregister a specific Cloud Driver.
-    Unregister-Keypair:
-      method: delete
-      resourcePath: /regkeypair/{Name}
-      description: Unregister a KeyPair with the specified name.
-    Unregister-Myimage:
-      method: delete
-      resourcePath: /regmyimage/{Name}
-      description: Unregister a MyImage with the specified name.
-    Unregister-Nlb:
-      method: delete
-      resourcePath: /regnlb/{Name}
-      description: Unregister a Network Load Balancer (NLB) with the specified name.
+      description: "Unregister a Disk with the specified name."
     Unregister-Region:
       method: delete
       resourcePath: /region/{RegionName}
-      description: Unregister a specific Region.
-    Unregister-Securitygroup:
+      description: "Unregister a specific Region."
+    Get-Region:
+      method: get
+      resourcePath: /region/{RegionName}
+      description: "Retrieve details of a specific Region."
+    List-All-Disk:
+      method: get
+      resourcePath: /alldisk
+      description: "Retrieve a comprehensive list of all Disks associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+    Get-Region-Zone-Preconfig:
+      method: get
+      resourcePath: /preconfig/regionzone/{Name}
+      description: "Retrieve details of a specific pre-configured Region Zone based on driver and credential names. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]"
+    Unregister-Myimage:
       method: delete
-      resourcePath: /regsecuritygroup/{Name}
-      description: Unregister a Security Group with the specified name.
-    Unregister-Subnet:
-      method: delete
-      resourcePath: /regsubnet/{Name}
-      description: Unregister a Subnet from a specified VPC.
+      resourcePath: /regmyimage/{Name}
+      description: "Unregister a MyImage with the specified name."
     Unregister-Vm:
       method: delete
       resourcePath: /regvm/{Name}
-      description: Unregister a Virtual Machine (VM) with the specified name.
-    Unregister-Vpc:
-      method: delete
-      resourcePath: /regvpc/{Name}
-      description: Unregister a VPC with the specified name.
-    Upgrade-Cluster:
-      method: put
-      resourcePath: /cluster/{Name}/upgrade
-      description: Upgrade a Cluster to a specified version.
-    Upload-Driver:
+      description: "Unregister a Virtual Machine (VM) with the specified name."
+    List-Vm:
+      method: get
+      resourcePath: /vm
+      description: "Retrieve a list of Virtual Machines (VMs) associated with a specific connection."
+    Start-Vm:
       method: post
-      resourcePath: /driver/upload
-      description: Upload a Cloud Driver library file.
+      resourcePath: /vm
+      description: "Start a new Virtual Machine (VM) with specified configurations. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-%EB%A9%80%ED%8B%B0%ED%81%B4%EB%9D%BC%EC%9A%B0%EB%93%9C-vm-%EC%9D%B8%ED%94%84%EB%9D%BC-%EC%9E%90%EC%9B%90-%EC%A0%9C%EC%96%B4multi-cloud-vm-infra-resource-control)], [[Snapshot-MyImage,Disk Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Snapshot,-MyImage-and-Disk-Overview)]"
+    Get-Connection-Config:
+      method: get
+      resourcePath: /connectionconfig/{ConfigName}
+      description: "Retrieve details of a specific Connection Config."
+    Delete-Connection-Config:
+      method: delete
+      resourcePath: /connectionconfig/{ConfigName}
+      description: "Delete a specific Connection Config."
+    Count-Nlb-By-Connection:
+      method: get
+      resourcePath: /countnlb/{ConnectionName}
+      description: "Get the total number of Network Load Balancers (NLBs) for a specific connection."
+    Count-S3-By-Connection:
+      method: get
+      resourcePath: /counts3/{ConnectionName}
+      description: "Get the total number of S3 buckets for a specific connection."
+    Health-Check-Health:
+      method: get
+      resourcePath: /health
+      description: "Checks the health of CB-Spider service and its dependencies via /health endpoint. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]"
+    Health-Check-Healthcheck:
+      method: get
+      resourcePath: /healthcheck
+      description: "Checks the health of CB-Spider service and its dependencies via /healthcheck endpoint. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]"
+    List-Org-Region:
+      method: get
+      resourcePath: /orgregion
+      description: "Retrieve a list of Original Regions associated with a specific connection. <br> The response structure may vary depending on the request ConnectionName."
     Version-Info:
       method: get
       resourcePath: /version
-      description: Retrieves the version information of CB-Spider.
-  cb-tumblebug:
-    AddNLBVMs:
+      description: "Retrieves the version information of CB-Spider."
+    List-Recent-Imagespec:
+      method: get
+      resourcePath: /vm/imagespecrecent
+      description: "Get list of recently used Image and Spec combinations for VM creation with statistics"
+    Delete-Recent-Imagespec:
+      method: delete
+      resourcePath: /vm/imagespecrecent
+      description: "Remove an Image and Spec combination from recent records"
+    Any-Call:
       method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb/{nlbId}/vm
-      description: Add VMs to NLB
-    AnalyzeProvisioningRisk:
+      resourcePath: /anycall
+      description: "Execute a custom function (FID) with key-value parameters through AnyCall. 🕷️ [[Development Guide](https://github.com/cloud-barista/cb-spider/wiki/AnyCall-API-Extension-Guide)]"
+    Add-Nodegroup:
+      method: post
+      resourcePath: /cluster/{Name}/nodegroup
+      description: "Add a new Node Group to an existing Cluster."
+    Count-Vm-By-Connection:
       method: get
-      resourcePath: /provisioning/risk/{specId}
-      description: |-
-        Evaluate the likelihood of provisioning failure based on historical data for a specific VM specification and image combination.
-        This endpoint provides intelligent risk assessment to help prevent deployment failures:
-
-        **Risk Analysis Factors:**
-        - Historical failure rate for the VM specification
-        - Image-specific compatibility with the spec
-        - Recent failure patterns and trends
-        - Cross-reference of spec+image combination success rates
-
-        **Risk Levels:**
-        - `high`: Very likely to fail (>80% failure rate or image-specific failures)
-        - `medium`: Moderate risk (50-80% failure rate or mixed results)
-        - `low`: Low risk (<50% failure rate or no previous failures)
-        - `unknown`: Insufficient data for analysis
-
-        **Recommended Actions by Risk Level:**
-        - **High Risk**: Consider alternative specs or images, verify CSP quotas and permissions
-        - **Medium Risk**: Proceed with caution, have backup plans ready
-        - **Low Risk**: Safe to proceed with normal deployment
-
-        **Integration Points:**
-        - Automatically called during MCI review process
-        - Can be used in CI/CD pipelines for deployment validation
-        - Helpful for capacity planning and resource selection
-    AnalyzeProvisioningRiskDetailed:
+      resourcePath: /countvm/{ConnectionName}
+      description: "Get the total number of Virtual Machines (VMs) for a specific connection."
+    Delete-Csp-Myimage:
+      method: delete
+      resourcePath: /cspmyimage/{Id}
+      description: "Delete a specified CSP MyImage."
+    Proxy-Mcinsight-Vmspec-Filters:
       method: get
-      resourcePath: /tumblebug/provisioning/risk/detailed
-      description: |-
-        Provides comprehensive risk analysis with separate assessments for VM specification and image risks, plus actionable recommendations.
-        This endpoint offers enhanced risk analysis by separating spec-level and image-level risk factors:
-
-        **Risk Analysis Breakdown:**
-        - **Spec Risk**: Analyzes whether the VM specification itself has compatibility or resource issues
-        - **Image Risk**: Evaluates the track record of the specific image with this spec
-        - **Overall Risk**: Combines both factors to determine the primary risk source
-        - **Recommendations**: Provides actionable guidance based on risk analysis
-
-        **Spec Risk Factors:**
-        - Number of different images that failed with this spec (indicates spec-level issues)
-        - Overall failure rate across all images
-        - Success/failure ratio with various images
-
-        **Image Risk Factors:**
-        - Previous success/failure history of this specific image with this spec
-        - Whether this is a new, untested combination
-
-        **Recommendation Types:**
-        - Change VM specification (when spec is the primary risk factor)
-        - Try different image (when image is the primary risk factor)
-        - Monitor deployment closely (for new combinations or medium risk)
-        - Proceed with confidence (for low-risk combinations)
-    CheckHTTPVersion:
+      resourcePath: /mcinsight/vm-spec/filters
+      description: "Proxy endpoint to retrieve VM Spec filters from MC-Insight API"
+    Health-Check-Ping:
       method: get
-      resourcePath: /httpVersion
-      description: Checks and logs the HTTP version of the incoming request to the
-        server console.
-    CheckK8sNodeGroupsOnK8sCreation:
+      resourcePath: /ping
+      description: "Checks the health of CB-Spider service and its dependencies via /ping endpoint. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]"
+    Add-Tag:
+      method: post
+      resourcePath: /tag
+      description: "Add a tag to a specified resource.\n※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER"
+    List-Tag:
       method: get
-      resourcePath: /checkK8sNodeGroupsOnK8sCreation
-      description: Check whether nodegroups are required during the K8sCluster creation
-    CheckK8sNodeImageDesignation:
+      resourcePath: /tag
+      description: "Retrieve a list of tags for a specified resource.\n※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER"
+    Bulk-Import-Favorite-Imagespec:
+      method: post
+      resourcePath: /vm/imagespecfavorite/bulk
+      description: "Import multiple VM favorite records from JSON, skipping duplicates"
+    List-Keypair:
       method: get
-      resourcePath: /checkK8sNodeImageDesignation
-      description: Check whether node image designation is possible to create a K8sCluster
-    CheckResource:
+      resourcePath: /keypair
+      description: "Retrieve a list of KeyPairs associated with a specific connection."
+    Create-Keypair:
+      method: post
+      resourcePath: /keypair
+      description: "Create a new KeyPair with the specified configurations. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#5-vm-keypair-%EC%83%9D%EC%84%B1-%EB%B0%8F-%EC%A0%9C%EC%96%B4)]"
+    Get-S3-Presigned-Upload-Url:
       method: get
-      resourcePath: /ns/{nsId}/checkResource/{resourceType}/{resourceId}
-      description: Check resources' existence
-    CreateOrUpdateLabel:
+      resourcePath: /s3/presigned/upload/{BucketName}/{ObjectKey}
+      description: "Generates a presigned URL that can be used to upload an object to S3 without requiring AWS credentials. This is a CB-Spider special feature."
+    Set-Nodegroup-Autoscaling:
       method: put
-      resourcePath: /label/{labelType}/{uid}
-      description: Create or update a label for a resource identified by its uid
-    CreateSharedResource:
+      resourcePath: /cluster/{Name}/nodegroup/{NodeGroupName}/onautoscaling
+      description: "Enable or disable auto scaling for a Node Group in a Cluster."
+    Count-All-Myimage:
+      method: get
+      resourcePath: /countmyimage
+      description: "Get the total number of MyImages across all connections."
+    Get-Vmgroup-Healthinfo:
+      method: get
+      resourcePath: /nlb/{Name}/health
+      description: "Retrieve the health information of the VM group in a specified Network Load Balancer (NLB)."
+    Get-Vmprice-Info:
+      method: get
+      resourcePath: /priceinfo/vm/{RegionName}
+      description: "Retrieve VM Price Information for a specific connection and region. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Price-Info-Guide)]"
+    Unregister-Rdbms:
+      method: delete
+      resourcePath: /regrdbms/{Name}
+      description: "Unregister an RDBMS with the specified name."
+    Fetch-Resource-Usage:
+      method: get
+      resourcePath: /sysstats/usage
+      description: "Retrieve resource usage information such as CPU, memory, disk I/O, and network I/O.\nUse query parameter 'mode=text' to get the output in text format instead of JSON."
+    List-Favorite-Imagespec:
+      method: get
+      resourcePath: /vm/imagespecfavorite
+      description: "Get list of favorite Image and Spec combinations"
+    Add-Favorite-Imagespec:
       method: post
-      resourcePath: /ns/{nsId}/sharedResource
-      description: Create shared resources for MC-Infra
-    DelAllCustomImage:
+      resourcePath: /vm/imagespecfavorite
+      description: "Add an Image and Spec combination to favorites"
+    Delete-Favorite-Imagespec:
       method: delete
-      resourcePath: /ns/{nsId}/resources/customImage
-      description: Delete all customImages
-    DelAllDataDisk:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/dataDisk
-      description: Delete all Data Disks
-    DelAllImage:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/image
-      description: Delete all images
-    DelAllMci:
-      method: delete
-      resourcePath: /ns/{nsId}/mci
-      description: Delete all MCIs
-    DelAllMciPolicy:
-      method: delete
-      resourcePath: /ns/{nsId}/policy/mci
-      description: Delete all MCI policies
-    DelAllNLB:
-      method: delete
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb
-      description: Delete all NLBs
-    DelAllNs:
-      method: delete
-      resourcePath: /ns
-      description: Delete all namespaces
-    DelAllSecurityGroup:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/securityGroup
-      description: Delete all Security Groups
-    DelAllSharedResources:
-      method: delete
-      resourcePath: /ns/{nsId}/sharedResources
-      description: Delete all Default Resource Objects in the given namespace
-    DelAllSshKey:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/sshKey
-      description: Delete all SSH Keys
-    DelAllVNet:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/vNet
-      description: Delete all VNets
-    DelCustomImage:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/customImage/{customImageId}
-      description: Delete customImage
-    DelDataDisk:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/dataDisk/{dataDiskId}
-      description: Delete Data Disk
-    DelFirewallRules:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}/rules
-      description: |-
-        Delete specific FirewallRules: Remove specified rules from the Security Group while keeping other existing rules.
-        This API will remove only the specified rules from the Security Group, leaving all other rules intact.
-
-        Usage:
-        Use this API to remove specific firewall rules from a Security Group. Only the rules matching the provided criteria will be deleted.
-        - Rules that exactly match the provided Direction, Protocol, Port, and CIDR will be removed.
-        - All other existing rules will remain unchanged.
-
-        Notes:
-        - "Ports" field supports single port ("22"), port range ("80-100"), and multiple ports/ranges ("22,80-100,443").
-        - "Protocol" can be TCP, UDP, ICMP, ALL, etc. (as supported by the cloud provider).
-        - "Direction" must be either "inbound" or "outbound".
-        - "CIDR" is the allowed IP range.
-    DelImage:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/image/{imageId}
-      description: Delete image
-    DelMci:
-      method: delete
-      resourcePath: /ns/{nsId}/mci/{mciId}
-      description: Delete MCI
-    DelMciPolicy:
-      method: delete
-      resourcePath: /ns/{nsId}/policy/mci/{mciId}
-      description: Delete MCI Policy
-    DelMciVm:
-      method: delete
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{vmId}
-      description: Delete VM in specified MCI
-    DelNLB:
-      method: delete
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb/{nlbId}
-      description: Delete NLB
-    DelNs:
-      method: delete
-      resourcePath: /ns/{nsId}
-      description: Delete namespace
-    DelSecurityGroup:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}
-      description: Delete Security Group
-    DelSpec:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/spec/{specId}
-      description: Delete spec
-    DelSshKey:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}
-      description: Delete SSH Key
-    DelSubnet:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}
-      description: |-
-        Delete Subnet
-        - refine: delete a subnet `object` if there's no resource on CSP or no inforamation on Spider
-        - force: force: delete a subnet `resource` on a CSP regardless of the current resource status (e.g., attempt to delete even if in use)
-    DelVNet:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}
-      description: |-
-        Delete VNet
-        - withsubnets: delete VNet and its subnets
-        - refine: delete information of VNet and its subnets if there's no info/resource in Spider/CSP
-        - force: delete VNet and its subnets regardless of the status of info/resource in Spider/CSP
-    DeleteAllK8sCluster:
-      method: delete
-      resourcePath: /ns/{nsId}/k8sCluster
-      description: Delete all K8sClusters
-    DeleteAllRequests:
-      method: delete
-      resourcePath: /requests
-      description: Delete details of all requests
-    DeleteDeregisterSubnet:
-      method: delete
-      resourcePath: /ns/{nsId}/deregisterCspResource/vNet/{vNetId}/subnet/{subnetId}
-      description: Deregister Subnet, which was created in CSP
-    DeleteDeregisterVNet:
-      method: delete
-      resourcePath: /ns/{nsId}/deregisterCspResource/vNet/{vNetId}
-      description: Deregister the VNet, which was created in CSP
-    DeleteK8sCluster:
-      method: delete
-      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}
-      description: Delete K8sCluster
-    DeleteK8sNodeGroup:
-      method: delete
-      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}
-      description: Remove a K8sNodeGroup
-    DeleteObject:
-      method: delete
-      resourcePath: /object
-      description: Delete an object
-    DeleteObjectStorage:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/objectStorage/{objectStorageId}
-      description: Delete a Object Storage
-    DeleteObjects:
-      method: delete
-      resourcePath: /objects
-      description: Delete child objects along with the given object
-    DeleteProvisioningLog:
-      method: delete
-      resourcePath: /provisioning/log/{specId}
-      description: |-
-        Remove all provisioning history data for a specific VM specification.
-        This operation permanently deletes historical failure and success records:
-
-        **Warning**: This action is irreversible and will remove:
-        - All failure and success statistics
-        - Historical error messages and troubleshooting data
-        - Risk analysis baseline for future deployments
-        - Failure pattern analysis data
-
-        **When to Use:**
-        - **Data Cleanup**: Remove outdated or irrelevant provisioning history
-        - **Fresh Start**: Clear history after infrastructure changes that resolve previous issues
-        - **Privacy Compliance**: Remove logs containing sensitive error information
-        - **Storage Management**: Clean up logs to manage kvstore space
-
-        **Impact on System:**
-        - Future risk analysis for this spec will have no historical baseline
-        - MCI review process will not show historical warnings for this spec
-        - Provisioning reliability metrics will be reset to zero
-    DeleteRequest:
-      method: delete
-      resourcePath: /request/{reqId}
-      description: Delete details of a specific request
-    DeleteSiteToSiteVpn:
-      method: delete
-      resourcePath: /ns/{nsId}/mci/{mciId}/vpn/{vpnId}
-      description: Delete a site-to-site VPN
-    DeleteSqlDb:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/sqlDb/{sqlDbId}
-      description: Delete a SQL datatbase
-    FetchImages:
+      resourcePath: /vm/imagespecfavorite
+      description: "Remove an Image and Spec combination from favorites"
+    List-Vm-Spec:
+      method: get
+      resourcePath: /vmspec
+      description: "Retrieve a list of VM specs associated with a specific connection. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-vm-spec-%EC%A0%95%EB%B3%B4-%EC%A0%9C%EA%B3%B5)]"
+    List-All-Securitygroup:
+      method: get
+      resourcePath: /allsecuritygroup
+      description: "Retrieve a comprehensive list of all Security Groups associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+    Count-All-Subnet:
+      method: get
+      resourcePath: /countsubnet
+      description: "Get the total number of Subnets across all connections."
+    Register-Nlb:
       method: post
-      resourcePath: /fetchImages
-      description: Fetch images waiting for completion
-    FetchImagesAsync:
+      resourcePath: /regnlb
+      description: "Register a new Network Load Balancer (NLB) with the specified name and CSP ID."
+    Register-Vpc:
       method: post
-      resourcePath: /fetchImagesAsync
-      description: Fetch images in the background without waiting for completion
-    FetchPrice:
+      resourcePath: /regvpc
+      description: "Register a new Virtual Private Cloud (VPC) with the specified name and CSP ID."
+    List-Vpc:
+      method: get
+      resourcePath: /vpc
+      description: "Retrieve a list of Virtual Private Clouds (VPCs) associated with a specific connection."
+    Create-Vpc:
       method: post
-      resourcePath: /fetchPrice
-      description: Fetch price from all CSP connections and update the price information
-        for associated specs in the system.
-    FetchSpecs:
+      resourcePath: /vpc
+      description: "Create a new Virtual Private Cloud (VPC) with specified subnet configurations. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#3-vpcsubnet-%EC%83%9D%EC%84%B1-%EB%B0%8F-%EC%A0%9C%EC%96%B4)]"
+    List-Cloudos:
+      method: get
+      resourcePath: /cloudos
+      description: "Retrieve a list of supported Cloud OS."
+    Upload-Driver:
       method: post
-      resourcePath: /fetchSpecs
-      description: Fetch specs from CSPs and register them in the system.
-    FilterSpecsByRange:
+      resourcePath: /driver/upload
+      description: "Upload a Cloud Driver library file."
+    List-Rdbms-Databases:
+      method: get
+      resourcePath: /rdbms/{Name}/databases
+      description: "List databases inside an RDBMS instance using the CSP-native API."
+    Create-Rdbms-Database:
       method: post
-      resourcePath: /ns/{nsId}/resources/filterSpecsByRange
-      description: Filter specs by range. Use limit field to control the maximum number
-        of results. If limit is 0 or not specified, returns all matching results.
-    ForwardAnyReqToAny:
+      resourcePath: /rdbms/{Name}/databases
+      description: "Create a database inside an RDBMS instance using the CSP-native API."
+    Get-Vm-Spec:
+      method: get
+      resourcePath: /vmspec/{Name}
+      description: "Retrieve details of a specific VM spec. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-vm-spec-%EC%A0%95%EB%B3%B4-%EC%A0%9C%EA%B3%B5)]"
+    Get-Cluster-Token:
+      method: get
+      resourcePath: /cluster/{Name}/token
+      description: "Get a temporary token for accessing EKS cluster (for kubectl exec auth)"
+    Count-All-Cluster:
+      method: get
+      resourcePath: /countcluster
+      description: "Get the total number of Clusters across all connections."
+    Unregister-Keypair:
+      method: delete
+      resourcePath: /regkeypair/{Name}
+      description: "Unregister a KeyPair with the specified name."
+    Get-Subnet:
+      method: get
+      resourcePath: /vpc/{VPCName}/subnet/{SubnetName}
+      description: "Retrieve a specific Subnet from a VPC."
+    Remove-Subnet:
+      method: delete
+      resourcePath: /vpc/{VPCName}/subnet/{SubnetName}
+      description: "Remove an existing Subnet from a VPC."
+    List-All-Myimage:
+      method: get
+      resourcePath: /allmyimage
+      description: "Retrieve a comprehensive list of all MyImages associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+    List-All-Vm-Info:
+      method: get
+      resourcePath: /allvminfo
+      description: "Retrieve a list of detailed information on all Virtual Machines (VMs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+    Get-Credential:
+      method: get
+      resourcePath: /credential/{CredentialName}
+      description: "Retrieve details of a specific Credential."
+    Unregister-Credential:
+      method: delete
+      resourcePath: /credential/{CredentialName}
+      description: "Unregister a specific Credential."
+    Delete-Csp-Securitygroup:
+      method: delete
+      resourcePath: /cspsecuritygroup/{Id}
+      description: "Delete a specified CSP Security Group."
+    Get-Rdbms-Owner-Vpc:
+      method: get
+      resourcePath: /getrdbmsowner
+      description: "Retrieve the Owner VPC of a given RDBMS CSP ID."
+    Get-Nlb:
+      method: get
+      resourcePath: /nlb/{Name}
+      description: "Retrieve details of a specific Network Load Balancer (NLB)."
+    Delete-Nlb:
+      method: delete
+      resourcePath: /nlb/{Name}
+      description: "Delete a specified Network Load Balancer (NLB)."
+    Get-Rdbms-Metainfo:
+      method: get
+      resourcePath: /rdbmsmetainfo
+      description: "Retrieve CSP-specific RDBMS capability information (supported engines, features, storage options)."
+    Get-Securitygroup:
+      method: get
+      resourcePath: /securitygroup/{Name}
+      description: "Retrieve details of a specific Security Group."
+    Delete-Securitygroup:
+      method: delete
+      resourcePath: /securitygroup/{Name}
+      description: "Delete a specified Security Group."
+    List-All-Cluster-Info:
+      method: get
+      resourcePath: /allclusterinfo
+      description: "Retrieve a list of all Cluster information associated with a specific connection."
+    List-All-Nlb-Info:
+      method: get
+      resourcePath: /allnlbinfo
+      description: "Retrieve a comprehensive list of all Network Load Balancers (NLBs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+    List-All-Vm:
+      method: get
+      resourcePath: /allvm
+      description: "Retrieve a comprehensive list of all Virtual Machines (VMs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+    List-Cluster:
+      method: get
+      resourcePath: /cluster
+      description: "Retrieve a list of Clusters associated with a specific connection."
+    Create-Cluster:
       method: post
-      resourcePath: /forward/{path}
-      description: Forward any (GET) request to CB-Spider
-    GetAllBenchmark:
+      resourcePath: /cluster
+      description: "Create a new Cluster with specified configurations. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Provider-Managed-Kubernetes-and-Driver-API)] <br> * NodeGroupList is optional, depends on CSP type: <br> &nbsp;- Type-I (e.g., Tencent, Alibaba): requires separate Node Group addition after Cluster creation. <br> &nbsp;- Type-II (e.g., Azure, NHN): mandates at least one Node Group during initial Cluster creation."
+    Terminate-Vm:
+      method: delete
+      resourcePath: /vm/{Name}
+      description: "Terminate a specified Virtual Machine (VM)."
+    Get-Vm:
+      method: get
+      resourcePath: /vm/{Name}
+      description: "Retrieve details of a specific Virtual Machine (VM)."
+    List-Image:
+      method: get
+      resourcePath: /vmimage
+      description: "Retrieve a list of Public Images associated with a specific connection. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/How-to-get-Image-List-with-REST-API)]"
+    Count-All-Disk:
+      method: get
+      resourcePath: /countdisk
+      description: "Get the total number of Disks across all connections."
+    Delete-Csp-Nlb:
+      method: delete
+      resourcePath: /cspnlb/{Id}
+      description: "Delete a specified CSP Network Load Balancer (NLB)."
+    Get-Rdbms:
+      method: get
+      resourcePath: /rdbms/{Name}
+      description: "Retrieve details of a specific RDBMS instance."
+    Delete-Rdbms:
+      method: delete
+      resourcePath: /rdbms/{Name}
+      description: "Delete a specified RDBMS instance."
+    List-Region:
+      method: get
+      resourcePath: /region
+      description: "Retrieve a list of registered Regions."
+    Register-Region:
       method: post
-      resourcePath: /ns/{nsId}/benchmarkAll/mci/{mciId}
-      description: Run MCI benchmark for all performance metrics and return results
-    GetAllConfig:
-      method: get
-      resourcePath: /config
-      description: List all configs
-    GetAllCustomImage:
-      method: get
-      resourcePath: /ns/{nsId}/resources/customImage
-      description: List all customImages or customImages' ID
-    GetAllDataDisk:
-      method: get
-      resourcePath: /ns/{nsId}/resources/dataDisk
-      description: List all Data Disks or Data Disks' ID
-    GetAllImage:
-      method: get
-      resourcePath: /ns/{nsId}/resources/image
-      description: List all images or images' ID
-    GetAllK8sCluster:
-      method: get
-      resourcePath: /ns/{nsId}/k8sCluster
-      description: List all K8sClusters or K8sClusters' ID
-    GetAllMci:
-      method: get
-      resourcePath: /ns/{nsId}/mci
-      description: List all MCIs or MCIs' ID
-    GetAllMciPolicy:
-      method: get
-      resourcePath: /ns/{nsId}/policy/mci
-      description: List all MCI policies
-    GetAllNLB:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb
-      description: List all NLBs or NLBs' ID
-    GetAllNs:
-      method: get
-      resourcePath: /ns
-      description: List all namespaces or namespaces' ID
-    GetAllObjectStorage:
-      method: get
-      resourcePath: /ns/{nsId}/resources/objectStorage
-      description: Get all Object Storages (TBD)
-    GetAllRequests:
-      method: get
-      resourcePath: /requests
-      description: Get details of all requests with optional filters.
-    GetAllSecurityGroup:
-      method: get
-      resourcePath: /ns/{nsId}/resources/securityGroup
-      description: List all Security Groups or Security Groups' ID
-    GetAllSiteToSiteVpn:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/vpn
-      description: Get all site-to-site VPNs
-    GetAllSqlDb:
-      method: get
-      resourcePath: /ns/{nsId}/resources/sqlDb
-      description: Get all SQL Databases (TBD)
-    GetAllSshKey:
-      method: get
-      resourcePath: /ns/{nsId}/resources/sshKey
-      description: List all SSH Keys or SSH Keys' ID
-    GetAllSubnet:
-      method: get
-      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet
-      description: List all subnets
-    GetAllVNet:
-      method: get
-      resourcePath: /ns/{nsId}/resources/vNet
-      description: List all VNets or VNets' ID
-    GetAvailableK8sNodeImage:
-      method: get
-      resourcePath: /availableK8sNodeImage
-      description: (UNDER DEVELOPMENT!!!) Get available kubernetes cluster node image
-    GetAvailableK8sVersion:
-      method: get
-      resourcePath: /availableK8sVersion
-      description: Get available kubernetes cluster version
-    GetBastionNodes:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{targetVmId}/bastion
-      description: Get bastion nodes for a VM
-    GetBenchmark:
+      resourcePath: /region
+      description: "Register a new Region. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#3-cloud-regionzone-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]"
+    Register-Vm:
       method: post
-      resourcePath: /ns/{nsId}/benchmark/mci/{mciId}
-      description: Run MCI benchmark for a single performance metric and return results
-    GetCloudInfo:
+      resourcePath: /regvm
+      description: "Register a new Virtual Machine (VM) with the specified name and CSP ID."
+    List-All-Cluster:
       method: get
-      resourcePath: /cloudInfo
-      description: Get cloud information
-    GetConfig:
+      resourcePath: /allcluster
+      description: "Retrieve a comprehensive list of all Clusters associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+    Count-Securitygroup-By-Connection:
       method: get
-      resourcePath: /config/{configId}
-      description: Get config
-    GetConnConfig:
+      resourcePath: /countsecuritygroup/{ConnectionName}
+      description: "Get the total number of Security Groups for a specific connection."
+    Count-Subnet-By-Connection:
       method: get
-      resourcePath: /connConfig/{connConfigName}
-      description: Get registered ConnConfig info
-    GetConnConfigList:
+      resourcePath: /countsubnet/{ConnectionName}
+      description: "Get the total number of Subnets for a specific connection."
+    Proxy-Mcinsight-Vmspec:
       method: get
-      resourcePath: /connConfig
-      description: List all registered ConnConfig
-    GetControlK8sCluster:
+      resourcePath: /mcinsight/vm-spec
+      description: "Proxy endpoint to retrieve VM Spec list from MC-Insight API with filters"
+    Get-Region-Zone:
       method: get
-      resourcePath: /ns/{nsId}/control/k8sCluster/{k8sClusterId}
-      description: Control the creation of K8sCluster (continue, withdraw)
-    GetControlMci:
+      resourcePath: /regionzone/{Name}
+      description: "Retrieve details of a specific Region Zone. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]"
+    List-All-Disk-Info:
       method: get
-      resourcePath: /ns/{nsId}/control/mci/{mciId}
-      description: Control the lifecycle of MCI (refine, suspend, resume, reboot,
-        terminate)
-    GetControlMciVm:
+      resourcePath: /alldiskinfo
+      description: "Retrieve a list of all Disk information associated with all connections."
+    Count-Cluster-By-Connection:
       method: get
-      resourcePath: /ns/{nsId}/control/mci/{mciId}/vm/{vmId}
-      description: Control the lifecycle of VM (suspend, resume, reboot, terminate)
-    GetCustomImage:
+      resourcePath: /countcluster/{ConnectionName}
+      description: "Get the total number of Clusters for a specific connection."
+    Register-Myimage:
+      method: post
+      resourcePath: /regmyimage
+      description: "Register a new MyImage with the specified name and CSP ID."
+    Add-Subnet:
+      method: post
+      resourcePath: /vpc/{VPCName}/subnet
+      description: "Add a new Subnet to an existing VPC."
+    Remove-Nodegroup:
+      method: delete
+      resourcePath: /cluster/{Name}/nodegroup/{NodeGroupName}
+      description: "Remove an existing Node Group from a Cluster."
+    List-All-Rdbms:
       method: get
-      resourcePath: /ns/{nsId}/resources/customImage/{customImageId}
-      description: Get customImage
-    GetDataDisk:
+      resourcePath: /allrdbms
+      description: "Retrieve a comprehensive list of all RDBMS instances associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+    Count-All-Securitygroup:
       method: get
-      resourcePath: /ns/{nsId}/resources/dataDisk/{dataDiskId}
-      description: Get Data Disk
-    GetFetchImagesAsyncResult:
+      resourcePath: /countsecuritygroup
+      description: "Get the total number of Security Groups across all connections."
+    Register-Keypair:
+      method: post
+      resourcePath: /regkeypair
+      description: "Register a new KeyPair with the specified name and CSP ID."
+    List-Org-Vm-Spec:
       method: get
-      resourcePath: /fetchImagesResult
-      description: Get detailed results from the last asynchronous image fetch operation
-    GetImage:
+      resourcePath: /vmorgspec
+      description: "Retrieve a list of Original VM Specs associated with a specific connection. <br> The response structure may vary depending on the request ConnectionName."
+    Get-Vpc:
       method: get
-      resourcePath: /ns/{nsId}/resources/image/{imageId}
-      description: GetImage returns an image object if there are matched images for
-        the given namespace and imageKey(Id, CspResourceName)
-    GetK8sCluster:
+      resourcePath: /vpc/{Name}
+      description: "Retrieve details of a specific Virtual Private Cloud (VPC)."
+    Delete-Vpc:
+      method: delete
+      resourcePath: /vpc/{Name}
+      description: "Delete a specified Virtual Private Cloud (VPC)."
+    Count-Myimage-By-Connection:
       method: get
-      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}
-      description: Get K8sCluster
-    GetK8sClusterInfo:
+      resourcePath: /countmyimage/{ConnectionName}
+      description: "Get the total number of MyImages for a specific connection."
+    Delete-Csp-Keypair:
+      method: delete
+      resourcePath: /cspkeypair/{Id}
+      description: "Delete a specified CSP KeyPair."
+    Get-Nlb-Owner-Vpc:
+      method: post
+      resourcePath: /getnlbowner
+      description: "Retrieve the owner VPC of a specified Network Load Balancer (NLB)."
+    Get-Vm-Using-Rs:
+      method: post
+      resourcePath: /getvmusingresources
+      description: "Retrieve details of a VM using resource ID."
+    Proxy-Mcinsight-Vmprice-Filters:
       method: get
-      resourcePath: /k8sClusterInfo
-      description: Get kubernetes cluster information
-    GetLabels:
+      resourcePath: /mcinsight/price-info/filters
+      description: "Proxy endpoint to retrieve VM Price filters from MC-Insight API"
+    Register-Subnet:
+      method: post
+      resourcePath: /regsubnet
+      description: "Register a new Subnet within a specified VPC."
+    Get-S3-Presigned-Url:
       method: get
-      resourcePath: /label/{labelType}/{uid}
-      description: Get labels for a resource identified by its uid
-    GetLatencyBenchmark:
+      resourcePath: /s3/presigned/download/{BucketName}/{ObjectKey}
+      description: "Generates a presigned URL that can be used to download an object from S3 without requiring AWS credentials. This is a CB-Spider special feature."
+    Delete-Csp-Vpc:
+      method: delete
+      resourcePath: /cspvpc/{Id}
+      description: "Delete a specified CSP Virtual Private Cloud (VPC)."
+    List-Nlb:
       method: get
-      resourcePath: /ns/{nsId}/benchmarkLatency/mci/{mciId}
-      description: Run MCI benchmark for network latency
-    GetMci:
+      resourcePath: /nlb
+      description: "Retrieve a list of Network Load Balancers (NLBs) associated with a specific connection."
+    Create-Nlb:
+      method: post
+      resourcePath: /nlb
+      description: "Create a new Network Load Balancer (NLB) with specified configurations. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Network-Load-Balancer-and-Driver-API)]"
+    List-Region-Zone:
       method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}
-      description: 'Get MCI object (option: status, accessInfo, vmId)'
-    GetMciAssociatedResources:
+      resourcePath: /regionzone
+      description: "Retrieve a list of Region Zones associated with a specific connection. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]"
+    List-All-Keypair-Info:
       method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/associatedResources
-      description: Get associated resource ID list for a given MCI (VNet, Subnet,
-        SecurityGroup, SSHKey, etc.)
-    GetMciGroupIds:
+      resourcePath: /allkeypairinfo
+      description: "Retrieve a list of KeyPair information associated with all connections."
+    List-All-Rdbms-Info:
       method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/subgroup
-      description: List SubGroup IDs in a specified MCI
-    GetMciGroupVms:
+      resourcePath: /allrdbmsinfo
+      description: "Retrieve a list of all RDBMS information associated with all connections."
+    Control-Vm:
+      method: put
+      resourcePath: /controlvm/{Name}
+      description: "Control the state of a Virtual Machine (VM) such as suspend, resume, or reboot."
+    Count-Rdbms-By-Connection:
       method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/subgroup/{subgroupId}
-      description: List VMs with a SubGroup label in a specified MCI
-    GetMciPolicy:
+      resourcePath: /countrdbms/{ConnectionName}
+      description: "Get the total number of RDBMS instances for a specific connection."
+    Proxy-Mcinsight-Vmimage:
       method: get
-      resourcePath: /ns/{nsId}/policy/mci/{mciId}
-      description: Get MCI Policy
-    GetMciVm:
+      resourcePath: /mcinsight/vm-image
+      description: "Proxy endpoint to retrieve VM Image list from MC-Insight API with filters"
+    List-Org-Zone:
       method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{vmId}
-      description: Get VM in specified MCI
-    GetMonitorData:
-      method: get
-      resourcePath: /ns/{nsId}/monitoring/mci/{mciId}/metric/{metric}
-      description: Get monitoring data of specified MCI for specified monitoring metric
-        (cpu, memory, disk, network)
-    GetNLB:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb/{nlbId}
-      description: Get NLB
-    GetNLBHealth:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb/{nlbId}/healthz
-      description: Get NLB Health
-    GetNs:
-      method: get
-      resourcePath: /ns/{nsId}
-      description: Get namespace
-    GetObject:
-      method: get
-      resourcePath: /object
-      description: Get value of an object
-    GetObjectStorage:
-      method: get
-      resourcePath: /ns/{nsId}/resources/objectStorage/{objectStorageId}
-      description: Get resource info of a Object Storage
-    GetObjects:
-      method: get
-      resourcePath: /objects
-      description: List all objects for a given key
-    GetProviderList:
-      method: get
-      resourcePath: /provider
-      description: List all registered Providers
-    GetProvisioningLog:
-      method: get
-      resourcePath: /provisioning/log/{specId}
-      description: |-
-        Retrieve detailed provisioning history for a specific VM specification including success/failure patterns and risk analysis.
-        This endpoint provides comprehensive insights into provisioning reliability:
-
-        **Historical Data Includes:**
-        - Success and failure counts with timestamps
-        - CSP-specific error messages and failure patterns
-        - Image compatibility tracking across different attempts
-        - Failure rate analysis and risk assessment
-        - Regional and provider-specific reliability metrics
-
-        **Use Cases:**
-        - **Pre-deployment Risk Assessment**: Check if a spec has historical failures before creating MCI
-        - **Troubleshooting**: Analyze failure patterns to identify root causes
-        - **Capacity Planning**: Understand reliability patterns for different specs and regions
-        - **Cost Optimization**: Avoid specs with high failure rates that waste resources
-
-        **Response Details:**
-        - `failureCount`: Total number of provisioning failures
-        - `successCount`: Number of successes (only tracked after failures occur)
-        - `failureImages`: List of CSP images that failed with this spec
-        - `successImages`: List of CSP images that succeeded with this spec
-        - `failureMessages`: Detailed error messages from CSP
-        - `lastUpdated`: Timestamp of most recent provisioning attempt
-    GetPublicKeyForCredentialEncryption:
-      method: get
-      resourcePath: /credential/publicKey
-      description: Generates an RSA key pair using a 4096-bit key size with the RSA
-        algorithm. The public key is generated using the RSA algorithm with OAEP padding
-        and SHA-256 as the hash function. This key is used to encrypt an AES key that
-        will be used for hybrid encryption of credentials.
-    GetReadyz:
+      resourcePath: /orgzone
+      description: "Retrieve a list of Original Zones associated with a specific connection. <br> The response structure may vary depending on the request ConnectionName."
+    Health-Check-Readyz:
       method: get
       resourcePath: /readyz
-      description: Check Tumblebug is ready
-    GetRegion:
+      description: "Checks the health of CB-Spider service and its dependencies via /readyz endpoint. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]"
+    Get-Tag:
       method: get
-      resourcePath: /provider/{providerName}/region/{regionName}
-      description: Get registered region info
+      resourcePath: /tag/{Key}
+      description: "Retrieve a specific tag for a specified resource.\n※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER"
+    Remove-Tag:
+      method: delete
+      resourcePath: /tag/{Key}
+      description: "Remove a specific tag from a specified resource.\n※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER"
+    Get-Cloudos-Metainfo:
+      method: get
+      resourcePath: /cloudos/metainfo/{CloudOSName}
+      description: "Retrieve metadata information for a specific Cloud OS."
+    Get-Driver:
+      method: get
+      resourcePath: /driver/{DriverName}
+      description: "Retrieve details of a specific Cloud Driver."
+    Unregister-Driver:
+      method: delete
+      resourcePath: /driver/{DriverName}
+      description: "Unregister a specific Cloud Driver."
+    Register-Cluster:
+      method: post
+      resourcePath: /regcluster
+      description: "Register a new Cluster with the specified VPC and CSP ID."
+    List-All-Vpc:
+      method: get
+      resourcePath: /allvpc
+      description: "Retrieve a comprehensive list of all Virtual Private Clouds (VPCs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+    List-Connection-Config:
+      method: get
+      resourcePath: /connectionconfig
+      description: "Retrieve a list of registered Connection Configs."
+    Create-Connection-Config:
+      method: post
+      resourcePath: /connectionconfig
+      description: "Create a new Connection Config. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#4-cloud-connection-configuration-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]"
+    Destroy-All-Resource:
+      method: delete
+      resourcePath: /destroy
+      description: "Deletes all resources associated with a specific cloud connection. This action is irreversible."
+    Detach-Disk:
+      method: put
+      resourcePath: /disk/{Name}/detach
+      description: "Detach an existing Disk from a VM."
+    Create-Filesystem:
+      method: post
+      resourcePath: /filesystem
+      description: "Create a new FileSystem with the specified configuration."
+    Get-Keypair:
+      method: get
+      resourcePath: /keypair/{Name}
+      description: "Retrieve details of a specific KeyPair."
+    Delete-Keypair:
+      method: delete
+      resourcePath: /keypair/{Name}
+      description: "Delete a specified KeyPair."
+    Add-Nlb-Vm:
+      method: post
+      resourcePath: /nlb/{Name}/vms
+      description: "Add a new set of VMs to an existing Network Load Balancer (NLB)."
+    Remove-Nlb-Vm:
+      method: delete
+      resourcePath: /nlb/{Name}/vms
+      description: "Remove a set of VMs from an existing Network Load Balancer (NLB)."
+    List-Securitygroup:
+      method: get
+      resourcePath: /securitygroup
+      description: "Retrieve a list of Security Groups associated with a specific connection."
+    Create-Securitygroup:
+      method: post
+      resourcePath: /securitygroup
+      description: "Create a new Security Group with specified rules and tags. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Security-Group-Rules-and-Driver-API)], 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#4-securitygroup-%EC%83%9D%EC%84%B1-%EB%B0%8F-%EC%A0%9C%EC%96%B4)]"
+    Delete-Csp-Disk:
+      method: delete
+      resourcePath: /cspdisk/{Id}
+      description: "Delete a specified CSP Disk."
+    Change-Nodegroup-Scaling:
+      method: put
+      resourcePath: /cluster/{Name}/nodegroup/{NodeGroupName}/autoscalesize
+      description: "Change the scaling settings for a Node Group in a Cluster."
+    Count-All-Vm:
+      method: get
+      resourcePath: /countvm
+      description: "Get the total number of Virtual Machines (VMs) across all connections."
+    Delete-Rdbms-Database:
+      method: delete
+      resourcePath: /rdbms/{Name}/databases/{DBName}
+      description: "Drop a database inside an RDBMS instance using the CSP-native API."
+    Put-S3-Object-From-File:
+      method: put
+      resourcePath: /s3/{BucketName}/{ObjectKey}
+      description: "Uploads a file to S3 bucket or uploads a part for multipart upload based on query parameters.\n\n**Operations:**\n- No query params: Upload object (standard upload)\n- ?uploadId={id}&partNumber={num}: Upload a part for multipart upload\n\n**Part Upload Example (Step 2 of multipart upload):**\n- uploadId: Use UploadId from initiate response (Step 1)\n- partNumber: 1, 2, 3... (consecutive integers, minimum 1)\n- Body: Binary file data (in Swagger UI, use \"Choose File\" button)\n- Response: Check ETag header - save it for completion (Step 4)\n- Repeat for each part with different partNumber"
+    Handle-S3-Object-Post:
+      method: post
+      resourcePath: /s3/{BucketName}/{ObjectKey}
+      description: "Object-level POST operations. **Response type varies by query parameter:**\n\n| Query Parameter | Response Schema | Description |\n|---|---|---|\n| `?uploads` | `InitiateMultipartUploadResultJSON` | Initiate multipart upload (returns UploadId) |\n| `?uploadId={id}` | `CompleteMultipartUploadResultJSON` | Complete multipart upload |\n\n**Note**: The example value below shows the `?uploads` (initiate) response.\n\n**Multipart Upload Testing Guide (Swagger UI):**\n\n**Step 1: Initiate Multipart Upload**\n- Use POST /s3/{BucketName}/{ObjectKey}?uploads\n- Set ConnectionName, BucketName, ObjectKey (e.g., \"testfile.bin\")\n- Response will contain UploadId (save this!)\n\n**Step 2: Upload Parts**\n- Use PUT /s3/{BucketName}/{ObjectKey}?uploadId={saved_uploadId}&partNumber=1\n- In request body, upload file part (binary data)\n- Response header contains ETag (save this!)\n- Repeat for part 2, 3, etc. with partNumber=2, 3...\n\n**Step 3: List Parts (Optional)**\n- Use GET /s3/{BucketName}/{ObjectKey}?uploadId={saved_uploadId}&list-type=parts\n- Verify all uploaded parts\n\n**Step 4: Complete Upload**\n- Use POST /s3/{BucketName}/{ObjectKey}?uploadId={saved_uploadId}\n- IMPORTANT: Enter uploadId in query parameter field (not in the parameter table below)\n- Body (required): Provide parts list with PartNumber and ETag for each uploaded part\n- Note: ETag values must include double quotes, e.g., \"abc123\" (with surrounding double quotes)"
+    Delete-S3-Object:
+      method: delete
+      resourcePath: /s3/{BucketName}/{ObjectKey}
+      description: "Deletes an object or aborts a multipart upload based on query parameters.\n\n**Operations:**\n- No query params: Delete object (current version)\n- ?versionId={id}: Delete specific version\n- ?uploadId={id}: Abort multipart upload"
+    Get-S3-Object-Info:
+      method: head
+      resourcePath: /s3/{BucketName}/{ObjectKey}
+      description: "Returns metadata about an object without returning the object itself.\n\n**Important**: This is a HEAD request that only returns headers (metadata), not the file content.\nThe response includes Content-Type, Content-Length, Last-Modified, ETag, and version information.\nDo NOT use \"Download file\" button in Swagger UI - it will create an empty/invalid file.\nUse GET /s3/{BucketName}/{ObjectKey} to download the actual file."
+    Download-S3-Object:
+      method: get
+      resourcePath: /s3/{BucketName}/{ObjectKey}
+      description: "Downloads an object from S3 or lists parts of a multipart upload. **Response type varies by query parameter:**\n\n| Query Parameter | Response | Description |\n|---|---|---|\n| *(none)* | `application/octet-stream` (binary) | Download object content |\n| `?versionId={id}` | `application/octet-stream` (binary) | Download specific object version |\n| `?uploadId={id}&list-type=parts` | `ListPartsResultJSON` | List parts of in-progress multipart upload |\n\n**Note**: The example value below shows the `?uploadId&list-type=parts` (list parts JSON) response.\nFor binary downloads, the response body is the raw file content.\n\n**List Parts Example (verify uploaded parts):**\n- uploadId: Use UploadId from initiate response\n- list-type: Must be \"parts\"\n- Response shows all uploaded parts with PartNumber, ETag, Size\n- Optional: part-number-marker (pagination), max-parts (limit)"
+    Get-Image:
+      method: get
+      resourcePath: /vmimage/{Name}
+      description: "Retrieve details of a specific Public Image. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/How-to-get-Image-List-with-REST-API)]"
+    Count-Connection-By-Provider:
+      method: get
+      resourcePath: /countconnectionconfig/{ProviderName}
+      description: "Get the total number of connections for a specific provider."
+    Count-All-Keypair:
+      method: get
+      resourcePath: /countkeypair
+      description: "Get the total number of KeyPairs across all connections."
+    Count-All-Nlb:
+      method: get
+      resourcePath: /countnlb
+      description: "Get the total number of Network Load Balancers (NLBs) across all connections."
+    Get-Cluster-Owner-Vpc:
+      method: post
+      resourcePath: /getclusterowner
+      description: "Retrieve the owner VPC of a specified Cluster."
+    Proxy-Mcinsight-Vmprice:
+      method: get
+      resourcePath: /mcinsight/price-info
+      description: "Proxy endpoint to retrieve VM Price information from MC-Insight API with filters"
+    List-Quota-Service-Type:
+      method: get
+      resourcePath: /quotaservicetype
+      description: "Retrieve the list of service type names for which quota information is available. Use a returned service type as input to the GetQuotaInfo API. 🕷️ Supported CSPs: AWS, Azure, GCP, Alibaba."
+    List-Rdbms:
+      method: get
+      resourcePath: /rdbms
+      description: "Retrieve a list of RDBMS instances associated with a specific connection."
+    Create-Rdbms:
+      method: post
+      resourcePath: /rdbms
+      description: "Create a new Relational Database (RDBMS) with the specified configuration."
+    Register-Securitygroup:
+      method: post
+      resourcePath: /regsecuritygroup
+      description: "Register a new Security Group with the specified name and CSP ID."
+    List-All-Myimage-Info:
+      method: get
+      resourcePath: /allmyimageinfo
+      description: "Retrieve a comprehensive list of all MyImage information associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+    List-Credential:
+      method: get
+      resourcePath: /credential
+      description: "Retrieve a list of registered Credentials."
+    Register-Credential:
+      method: post
+      resourcePath: /credential
+      description: "Register a new Credential. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-cloud-credential-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]"
+    Get-Disk:
+      method: get
+      resourcePath: /disk/{Name}
+      description: "Retrieve details of a specific Disk."
+    Delete-Disk:
+      method: delete
+      resourcePath: /disk/{Name}
+      description: "Delete a specified Disk."
+    List-Preconfigured-Original-Org-Region:
+      method: get
+      resourcePath: /preconfig/orgregion
+      description: "Retrieve a list of pre-configured Original Regions based on driver and credential names. <br> The response structure may vary depending on the request DriverName and CredentialName."
+    Unregister-Cluster:
+      method: delete
+      resourcePath: /regcluster/{Name}
+      description: "Unregister a Cluster with the specified name."
+    List-S3-Buckets:
+      method: get
+      resourcePath: /s3
+      description: "Returns a list of all buckets owned by the authenticated sender of the request. To list buckets, you must have the ConnectionName parameter."
+    Get-S3-Bucket-Usage:
+      method: get
+      resourcePath: /s3/{BucketName}/usage
+      description: "Returns the total size (in bytes) of all objects stored in an S3 bucket.\n\n**Response Fields:**\n- CurrentSize: Size of current (latest) objects in bytes\n- DeletedVersionsSize: Size of non-current versions in bytes\n- TotalSize: Total bucket size (CurrentSize + DeletedVersionsSize)"
+    List-Vpc-Securitygroup:
+      method: get
+      resourcePath: /securitygroup/vpc/{VPCName}
+      description: "Retrieve a list of Security Groups associated with a specific VPC in a given cloud connection."
+    List-All-Keypair:
+      method: get
+      resourcePath: /allkeypair
+      description: "Retrieve a comprehensive list of all KeyPairs associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+    List-All-Securitygroup-Info:
+      method: get
+      resourcePath: /allsecuritygroupinfo
+      description: "Retrieve a list of Security Group information associated with all connections."
+    Upgrade-Cluster:
+      method: put
+      resourcePath: /cluster/{Name}/upgrade
+      description: "Upgrade a Cluster to a specified version."
+    Count-All-Vpc:
+      method: get
+      resourcePath: /countvpc
+      description: "Get the total number of VPCs across all connections."
+    Proxy-Mcinsight-Vmimage-Filters:
+      method: get
+      resourcePath: /mcinsight/vm-image/filters
+      description: "Proxy endpoint to retrieve VM Image filters from MC-Insight API"
+    Get-Quota-Info:
+      method: get
+      resourcePath: /quotainfo
+      description: "Retrieve all quota limits and current usage for a given service type. No filtering is applied; all CSP-original quota items for the service type are returned. 🕷️ Supported CSPs: AWS, Azure, GCP, Alibaba."
+    Unregister-Securitygroup:
+      method: delete
+      resourcePath: /regsecuritygroup/{Name}
+      description: "Unregister a Security Group with the specified name."
+    Get-Csp-Vm:
+      method: get
+      resourcePath: /cspvm/{Id}
+      description: "Retrieve details of a specific CSP Virtual Machine (VM)."
+    Terminate-Csp-Vm:
+      method: delete
+      resourcePath: /cspvm/{Id}
+      description: "Terminate a specified CSP Virtual Machine (VM)."
+    Unregister-Nlb:
+      method: delete
+      resourcePath: /regnlb/{Name}
+      description: "Unregister a Network Load Balancer (NLB) with the specified name."
+    Add-Rule:
+      method: post
+      resourcePath: /securitygroup/{SGName}/rules
+      description: "Add new rules to a Security Group."
+    Remove-Rule:
+      method: delete
+      resourcePath: /securitygroup/{SGName}/rules
+      description: "Remove existing rules from a Security Group."
+    Fetch-System-Info:
+      method: get
+      resourcePath: /sysstats/system
+      description: "Retrieve system information such as hostname, platform, CPU, memory, and disk.\nUse query parameter 'mode=text' to get the output in text format instead of JSON."
+    List-All-Nlb:
+      method: get
+      resourcePath: /allnlb
+      description: "Retrieve a comprehensive list of all Network Load Balancers (NLBs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+    Count-All-Connection:
+      method: get
+      resourcePath: /countconnectionconfig
+      description: "Get the total number of connections."
+    Count-Keypair-By-Connection:
+      method: get
+      resourcePath: /countkeypair/{ConnectionName}
+      description: "Get the total number of KeyPairs for a specific connection."
+    Delete-Csp-Cluster:
+      method: delete
+      resourcePath: /cspcluster/{Id}
+      description: "Delete a specified CSP Cluster."
+    Delete-Csp-Rdbms:
+      method: delete
+      resourcePath: /csprdbms/{Id}
+      description: "Delete a specified CSP RDBMS."
+    List-Myimage:
+      method: get
+      resourcePath: /myimage
+      description: "Retrieve a list of MyImages associated with a specific connection."
+    Create-Myimage:
+      method: post
+      resourcePath: /myimage
+      description: "Create a new MyImage snapshot from a specified VM. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/MyImage-and-Driver-API)], [[Snapshot-MyImage,Disk Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Snapshot,-MyImage-and-Disk-Overview)]"
+    Check-Udp-Port:
+      method: get
+      resourcePath: /check/udp
+      description: "Verifies whether a given UDP port is open on the specified host.\n※ Note: As UDP is connectionless, this check mainly performs a lookup and may not confirm if the server is working."
+    List-Disk:
+      method: get
+      resourcePath: /disk
+      description: "Retrieve a list of Disks associated with a specific connection."
+    Create-Disk:
+      method: post
+      resourcePath: /disk
+      description: "Create a new Disk with the specified configuration. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Disk-and-Driver-API)], [[Snapshot-MyImage,Disk Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Snapshot,-MyImage-and-Disk-Overview)]"
+    Register-Driver:
+      method: post
+      resourcePath: /driver
+      description: "Register a new Cloud Driver. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#1-cloud-driver-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]"
+    List-Driver:
+      method: get
+      resourcePath: /driver
+      description: "Retrieve a list of registered Cloud Drivers."
+    Get-Myimage:
+      method: get
+      resourcePath: /myimage/{Name}
+      description: "Retrieve details of a specific MyImage."
+    Delete-Myimage:
+      method: delete
+      resourcePath: /myimage/{Name}
+      description: "Delete a specified MyImage."
+    List-Region-Zone-Preconfig:
+      method: get
+      resourcePath: /preconfig/regionzone
+      description: "Retrieve a list of pre-configured Region Zones based on driver and credential names. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]"
+    Get-Vm-Status:
+      method: get
+      resourcePath: /vmstatus/{Name}
+      description: "Retrieve the status of a specific Virtual Machine (VM)."
+    Check-Tcp-Port:
+      method: get
+      resourcePath: /check/tcp
+      description: "Verifies whether a given TCP port is open on the specified host."
+    Create-S3-Bucket:
+      method: put
+      resourcePath: /s3/{BucketName}
+      description: "Creates a new S3 bucket or sets bucket configuration based on query parameters.\n\n**Operations:**\n- No query params: Create a new bucket\n- ?versioning: Set versioning configuration (Enable/Suspend)\n- ?cors: Set CORS configuration\n\n**IMPORTANT: Choose only ONE body configuration based on query parameter:**\n- If using ?versioning: Use VersioningConfiguration body\n- If using ?cors: Use CORSConfiguration body\n- If no query params: No body required (bucket creation)\n\n**Versioning Status Values:**\n- Enabled: Enable versioning for the bucket\n- Suspended: Suspend versioning for the bucket\n\n**CORS Configuration Example:**\n- AllowedOrigin: [\"*\"] or [\"https://example.com\"]\n- AllowedMethod: [\"GET\", \"PUT\", \"POST\", \"DELETE\", \"HEAD\"]\n- AllowedHeader: [\"*\"] or [\"Content-Type\", \"Authorization\"]\n- ExposeHeader: [\"ETag\", \"x-amz-request-id\"]\n- MaxAgeSeconds: 3600 (cache preflight response for 1 hour)"
+    Put-S3-Object-From-Form:
+      method: post
+      resourcePath: /s3/{BucketName}
+      description: "Uploads a file using HTML form (multipart/form-data) or deletes multiple objects based on query parameters.\n\n**Operations:**\n- No query params: Upload object via form (requires 'key' and 'file' fields, Content-Type: multipart/form-data)\n- ?delete: Delete multiple objects (requires JSON body, Content-Type: application/json)\n\n**JSON Body Example for Delete Multiple Objects:**\n```json\n{\n\"Delete\": {\n\"Objects\": [\n{\"Key\": \"file1.txt\"},\n{\"Key\": \"file2.txt\"},\n{\"Key\": \"folder/file3.txt\"}\n]\n}\n}\n```"
+    Delete-S3-Bucket:
+      method: delete
+      resourcePath: /s3/{BucketName}
+      description: "Deletes an S3 bucket or specific bucket configuration based on query parameters.\n\n**Operations:**\n- No query params: Delete bucket (must be empty)\n- ?cors: Delete CORS configuration\n- ?empty: Force empty bucket (removes all objects)\n- ?force: Force delete bucket with all contents"
+    Get-S3-Bucket-Head:
+      method: head
+      resourcePath: /s3/{BucketName}
+      description: "Check if a bucket exists using HEAD request. Returns 200 if exists, 404 if not found."
+    Get-S3-Bucket-Get:
+      method: get
+      resourcePath: /s3/{BucketName}
+      description: "List objects in bucket or get bucket configuration. **Response type varies by query parameter:**\n\n| Query Parameter | Response Schema | Description |\n|---|---|---|\n| *(none)* | `ListBucketResultJSON` | List objects in bucket (default) |\n| `?location` | `{\"LocationConstraint\": \"ap-northeast-2\"}` | Bucket region/location |\n| `?versioning` | `VersioningConfiguration` | Versioning status: Enabled / Suspended / \"\" |\n| `?cors` | `CORSConfiguration` | CORS configuration rules |\n| `?versions` | `ListVersionsResultJSON` | Object version history |\n| `?uploads` | `ListMultipartUploadsResultJSON` | In-progress multipart uploads |\n\n**Note**: The example value below shows the default (no query params) `ListBucketResultJSON` response."
+    Get-Org-Vm-Spec:
+      method: get
+      resourcePath: /vmorgspec/{Name}
+      description: "Retrieve details of a specific Original VM Spec."
+    List-Vm-Status:
+      method: get
+      resourcePath: /vmstatus
+      description: "Retrieve a list of statuses for Virtual Machines (VMs) associated with a specific connection."
+    Remove-Csp-Subnet:
+      method: delete
+      resourcePath: /vpc/{VPCName}/cspsubnet/{Id}
+      description: "Remove an existing CSP Subnet from a VPC."
+    Count-Disk-By-Connection:
+      method: get
+      resourcePath: /countdisk/{ConnectionName}
+      description: "Get the total number of Disks for a specific connection."
+    Register-Rdbms:
+      method: post
+      resourcePath: /regrdbms
+      description: "Register a new RDBMS with the specified name and CSP ID."
+    Unregister-Subnet:
+      method: delete
+      resourcePath: /regsubnet/{Name}
+      description: "Unregister a Subnet from a specified VPC."
+    Bulk-Import-Recent-Imagespec:
+      method: post
+      resourcePath: /vm/imagespecrecent/bulk
+      description: "Import multiple VM recent records from JSON, skipping duplicates"
+    List-All-Vpc-Info:
+      method: get
+      resourcePath: /allvpcinfo
+      description: "Retrieve a comprehensive list of all Virtual Private Clouds (VPCs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+    Increase-Disk-Size:
+      method: put
+      resourcePath: /disk/{Name}/size
+      description: "Increase the size of an existing disk."
+    Get-Sg-Owner-Vpc:
+      method: post
+      resourcePath: /getsecuritygroupowner
+      description: "Retrieve the owner VPC of a specified Security Group."
+    Register-Disk:
+      method: post
+      resourcePath: /regdisk
+      description: "Register a new Disk with the specified name, zone, and CSP ID."
+    Unregister-Vpc:
+      method: delete
+      resourcePath: /regvpc/{Name}
+      description: "Unregister a VPC with the specified name."
+    Get-Cluster:
+      method: get
+      resourcePath: /cluster/{Name}
+      description: "Retrieve details of a specific Cluster."
+    Delete-Cluster:
+      method: delete
+      resourcePath: /cluster/{Name}
+      description: "Delete a specified Cluster."
+    Count-All-Rdbms:
+      method: get
+      resourcePath: /countrdbms
+      description: "Get the total number of RDBMS instances across all connections."
+    Attach-Disk:
+      method: put
+      resourcePath: /disk/{Name}/attach
+      description: "Attach an existing Disk to a VM."
+  cb-tumblebug:
     GetRegions:
       method: get
       resourcePath: /provider/{providerName}/region
-      description: Get registered region info
-    GetRequest:
-      method: get
-      resourcePath: /request/{reqId}
-      description: Get details of a specific request
-    GetRequestStatusOfSiteToSiteVpn:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/vpn/{vpnId}/request/{requestId}
-      description: Check the status of a specific request by its ID
-    GetRequiredK8sSubnetCount:
-      method: get
-      resourcePath: /requiredK8sSubnetCount
-      description: Get the required subnet count to create a K8sCluster
-    GetResourcesByLabelSelector:
-      method: get
-      resourcePath: /resources/{labelType}
-      description: |-
-        Get resources based on a label selector. The label selector supports the following operators:
-        - `=` : Selects resources where the label key equals the specified value (e.g., `env=production`).
-        - `!=` : Selects resources where the label key does not equal the specified value (e.g., `tier!=frontend`).
-        - `in` : Selects resources where the label key is in the specified set of values (e.g., `region in (us-west, us-east)`).
-        - `notin` : Selects resources where the label key is not in the specified set of values (e.g., `env notin (production, staging)`).
-        - `exists` : Selects resources where the label key exists (e.g., `env exists`).
-        - `!exists` : Selects resources where the label key does not exist (e.g., `env !exists`).
-    GetSecurityGroup:
-      method: get
-      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}
-      description: Get Security Group
-    GetSiteToSiteVpn:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/vpn/{vpnId}
-      description: Get resource info of a site-to-site VPN
-    GetSitesInMci:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/site
-      description: Get sites in MCI
-    GetSpec:
-      method: get
-      resourcePath: /ns/{nsId}/resources/spec/{specId}
-      description: Get spec
-    GetSqlDb:
-      method: get
-      resourcePath: /ns/{nsId}/resources/sqlDb/{sqlDbId}
-      description: Get resource info of a SQL datatbase
-    GetSshKey:
-      method: get
-      resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}
-      description: Get SSH Key
-    GetSubnet:
-      method: get
-      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}
-      description: Get Subnet
-    GetSystemLabelInfo:
-      method: get
-      resourcePath: /labelInfo
-      description: Return LabelTypes and system defined label keys with example
-    GetVNet:
-      method: get
-      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}
-      description: Get VNet
-    GetVmDataDisk:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{vmId}/dataDisk
-      description: Get available dataDisks for a VM
-    InitAllConfig:
-      method: delete
-      resourcePath: /config
-      description: Init all configs
-    InitConfig:
-      method: delete
-      resourcePath: /config/{configId}
-      description: Init config
-    InspectResources:
-      method: post
-      resourcePath: /inspectResources
-      description: Inspect Resources (vNet, securityGroup, sshKey, vm) registered
-        in CB-Tumblebug, CB-Spider, CSP
-    InspectResourcesOverview:
-      method: get
-      resourcePath: /inspectResourcesOverview
-      description: Inspect Resources Overview (vNet, securityGroup, sshKey, vm) registered
-        in CB-Tumblebug and CSP for all connections
-    LoadAssets:
-      method: get
-      resourcePath: /loadAssets
-      description: Load Common Resources from internal asset files (Spec, Image)
-    LookupImage:
-      method: post
-      resourcePath: /lookupImage
-      description: Lookup image (for debugging purposes)
-    LookupImageList:
-      method: post
-      resourcePath: /lookupImages
-      description: Lookup image list (for debugging purposes)
-    LookupSpec:
-      method: post
-      resourcePath: /lookupSpec
-      description: Lookup spec (for debugging purposes)
-    LookupSpecList:
-      method: post
-      resourcePath: /lookupSpecs
-      description: Lookup spec list (for debugging purposes)
-    MergeCSPResourceLabel:
-      method: put
-      resourcePath: /mergeCSPLabel/{labelType}/{uid}
-      description: Fetch the labels in the CSP and merge them with the existing labels
-    PostCmdK8sCluster:
-      method: post
-      resourcePath: /ns/{nsId}/cmd/k8sCluster/{k8sClusterId}
-      description: |-
-        Send a command to specified Container in K8sCluster
-        [note] This feature is not intended for general use
-        This API is provided as an exceptional and limited function for specific purposes such as migration.
-        Kubernetes resource information required as input for this API is not currently provided, and its availability in the future is uncertain.
-    PostCmdMci:
-      method: post
-      resourcePath: /ns/{nsId}/cmd/mci/{mciId}
-      description: Send a command to specified MCI
-    PostConfig:
-      method: post
-      resourcePath: /config
-      description: Create or Update config (TB_SPIDER_REST_URL, TB_DRAGONFLY_REST_URL,
-        ...)
-    PostCustomImage:
-      method: post
-      resourcePath: /ns/{nsId}/resources/customImage
-      description: Register existing Custom Image in a CSP (option=register)
-    PostDataDisk:
-      method: post
-      resourcePath: /ns/{nsId}/resources/dataDisk
-      description: Create Data Disk
-    PostFileToK8sCluster:
-      method: post
-      resourcePath: /ns/{nsId}/transferFile/k8sCluster/{k8sClusterId}
-      description: |-
-        Transfer a file to specified Container in K8sCluster. The tar command is required in the container.
-        [note] This feature is not intended for general use
-        This API is provided as an exceptional and limited function for specific purposes such as migration.
-        Kubernetes resource information required as input for this API is not currently provided, and its availability in the future is uncertain.
-    PostFileToMci:
-      method: post
-      resourcePath: /ns/{nsId}/transferFile/mci/{mciId}
-      description: |-
-        Transfer a file to specified MCI to the specified path.
-        The file size should be less than 10MB.
-        Not for gerneral file transfer but for specific purpose (small configuration files).
-    PostFirewallRules:
-      method: post
-      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}/rules
-      description: |-
-        Add new FirewallRules: Add the provided firewall rules to the existing rules in the Security Group.
-        This API will only add new rules without deleting or modifying existing ones.
-        If a rule with identical properties already exists, it will be skipped to avoid duplicates.
-
-        Usage:
-        Use this API to add new firewall rules to a Security Group while preserving existing rules.
-        - Only new rules that don't already exist will be added.
-        - Existing rules remain unchanged.
-        - If an identical rule already exists, it will be skipped.
-
-        Notes:
-        - "Ports" field supports single port ("22"), port range ("80-100"), and multiple ports/ranges ("22,80-100,443").
-        - The valid port number range is 0 to 65535 (inclusive).
-        - "Protocol" can be TCP, UDP, ICMP, ALL, etc. (as supported by the cloud provider).
-        - "Direction" must be either "inbound" or "outbound".
-        - "CIDR" is the allowed IP range.
-    PostImage:
-      method: post
-      resourcePath: /ns/{nsId}/resources/image
-      description: Register image
-    PostInstallBenchmarkAgentToMci:
-      method: post
-      resourcePath: /ns/{nsId}/installBenchmarkAgent/mci/{mciId}
-      description: Install the benchmark agent to specified MCI
-    PostInstallMonitorAgentToMci:
-      method: post
-      resourcePath: /ns/{nsId}/monitoring/install/mci/{mciId}
-      description: Install monitoring agent (CB-Dragonfly agent) to MCI
-    PostK8sCluster:
-      method: post
-      resourcePath: /ns/{nsId}/k8sCluster
-      description: Create K8sCluster<br>Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1614
-    PostK8sClusterDynamic:
-      method: post
-      resourcePath: /ns/{nsId}/k8sClusterDynamic
-      description: Create K8sCluster Dynamically from common spec and image
-    PostK8sClusterDynamicCheckRequest:
-      method: post
-      resourcePath: /k8sClusterDynamicCheckRequest
-      description: Check available ConnectionConfig list before create K8sCluster
-        Dynamically from common spec and image
-    PostK8sNodeGroup:
-      method: post
-      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup
-      description: Add a K8sNodeGroup
-    PostK8sNodeGroupDynamic:
-      method: post
-      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroupDynamic
-      description: Create K8sNodeGroup Dynamically from common spec and image
-    PostMcNLB:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/mcSwNlb
-      description: Create a special purpose MCI for NLB and depoly and setting SW
-        NLB
-    PostMci:
-      method: post
-      resourcePath: /ns/{nsId}/mci
-      description: |-
-        Create MCI with detailed VM specifications and resource configuration.
-        This endpoint creates a complete multi-cloud infrastructure by:
-        1. **VM Provisioning**: Creates VMs across multiple cloud providers using predefined specs and images
-        2. **Resource Management**: Automatically handles VPC/VNet, security groups, SSH keys, and network configuration
-        3. **Status Tracking**: Monitors VM creation progress and handles failures based on policy settings
-        4. **Post-Deployment**: Optionally installs monitoring agents and executes custom commands
-
-        **Key Features:**
-        - Multi-cloud VM deployment with heterogeneous configurations
-        - Automatic resource dependency management (VPC → Security Group → VM)
-        - Built-in failure handling with configurable policies (continue/rollback/refine)
-        - Optional CB-Dragonfly monitoring agent installation
-        - Post-deployment command execution support
-        - Real-time status updates and progress tracking
-
-        **VM Lifecycle:**
-        1. Creating → Running (successful deployment)
-        2. Creating → Failed (deployment error, handled by failure policy)
-        3. Running → Terminated (manual or policy-driven cleanup)
-
-        **Failure Policies:**
-        - `continue`: Keep successful VMs, mark failed ones for later refinement
-        - `rollback`: Delete entire MCI if any VM fails (all-or-nothing)
-        - `refine`: Automatically clean up failed VMs, keep successful ones
-
-        **Resource Requirements:**
-        - Valid VM specifications (must exist in system namespace)
-        - Valid images (must be available in target CSP regions)
-        - Sufficient CSP quotas and permissions
-        - Network connectivity between components
-    PostMciDynamic:
-      method: post
-      resourcePath: /ns/{nsId}/mciDynamic
-      description: |-
-        Create multi-cloud infrastructure dynamically using common specifications and images with automatic resource discovery and optimization.
-        This is the **recommended approach** for MCI creation, providing simplified configuration with powerful automation:
-
-        **Dynamic Resource Creation:**
-        1. **Automatic Resource Discovery**: Validates and selects optimal VM specifications and images from common namespace
-        2. **Intelligent Network Setup**: Creates VNets, subnets, security groups, and SSH keys automatically per provider
-        3. **Cross-Cloud Orchestration**: Coordinates VM provisioning across multiple cloud providers simultaneously
-        4. **Dependency Management**: Handles resource creation order and inter-dependencies automatically
-        5. **Failure Recovery**: Implements configurable failure policies for robust deployment
-
-        **Key Advantages Over Static MCI:**
-        - **Simplified Configuration**: Use common spec/image IDs instead of provider-specific resources
-        - **Automatic Resource Management**: No need to pre-create VNets, security groups, or SSH keys
-        - **Multi-Cloud Optimization**: Intelligent placement and configuration across providers
-        - **Built-in Best Practices**: Security groups, network isolation, and access controls applied automatically
-        - **Scalable Architecture**: Supports large-scale deployments with optimized resource utilization
-
-        **Configuration Process:**
-        1. **Resource Discovery**: Use `/recommendSpec` to find suitable VM specifications
-        2. **Image Selection**: Use system namespace to discover compatible images
-        3. **Request Validation**: Use `/mciDynamicCheckRequest` to validate configuration before deployment
-        4. **Optional Preview**: Use `/mciDynamicReview` to estimate costs and review configuration
-        5. **Deployment**: Submit MCI dynamic request with failure policy and deployment options
-
-        **Failure Policies (PolicyOnPartialFailure):**
-        - **`continue`** (default): Create MCI with successful VMs, failed VMs remain for manual refinement
-        - **`rollback`**: Delete entire MCI if any VM fails (all-or-nothing deployment)
-        - **`refine`**: Automatically clean up failed VMs, keep successful ones (recommended for large deployments)
-
-        **Deployment Options:**
-        - **`hold`**: Create MCI object but hold VM provisioning for manual approval
-        - **Normal**: Proceed with immediate VM provisioning after resource creation
-
-        **Multi-Cloud Example Configuration:**
-        ```json
-        {
-        "name": "multi-cloud-web-tier",
-        "description": "Web application across AWS, Azure, and GCP",
-        "policyOnPartialFailure": "refine",
-        "vm": [
-        {
-        "name": "aws-web-servers",
-        "subGroupSize": "3",
-        "specId": "aws+us-east-1+t3.medium",
-        "imageId": "ami-0abcdef1234567890",
-        "rootDiskSize": "100",
-        "label": {"tier": "web", "provider": "aws"}
-        },
-        {
-        "name": "azure-api-servers",
-        "subGroupSize": "2",
-        "specId": "azure+eastus+Standard_B2s",
-        "imageId": "Canonical:0001-com-ubuntu-server-jammy:22_04-lts",
-        "label": {"tier": "api", "provider": "azure"}
-        }
-        ]
-        }
-        ```
-
-        **Performance Considerations:**
-        - VM provisioning occurs in parallel across providers
-        - Network resources are created concurrently where possible
-        - Large deployments (>10 VMs) automatically use optimized batching
-        - Built-in rate limiting prevents CSP API throttling
-
-        **Monitoring and Post-Deployment:**
-        - Optional CB-Dragonfly monitoring agent installation
-        - Custom post-deployment command execution
-        - Real-time status tracking and progress updates
-        - Automatic resource labeling and metadata management
-    PostMciDynamicCheckRequest:
-      method: post
-      resourcePath: /mciDynamicCheckRequest
-      description: |-
-        Validate resource availability and discover optimal connection configurations before creating MCI dynamically.
-        This endpoint provides comprehensive resource validation and connection discovery for MCI planning:
-
-        **Resource Validation Process:**
-        1. **Specification Analysis**: Validates that requested common specs exist and are accessible
-        2. **Provider Discovery**: Identifies available cloud providers and regions for each specification
-        3. **Connectivity Assessment**: Tests connection configurations and CSP API accessibility
-        4. **Quota Verification**: Checks available quotas and resource limits where possible
-        5. **Compatibility Matrix**: Generates matrix of viable spec-provider-region combinations
-
-        **Connection Configuration Discovery:**
-        - **Available Providers**: Lists all configured cloud providers (AWS, Azure, GCP, etc.)
-        - **Active Regions**: Shows available regions per provider with connectivity status
-        - **Specification Mapping**: Maps common specs to provider-specific instance types
-        - **Image Compatibility**: Validates image availability across different providers/regions
-        - **Network Capabilities**: Identifies supported network features and configurations
-
-        **Pre-Deployment Validation:**
-        - **Resource Existence**: Confirms all specified resources exist in system namespace
-        - **Permission Verification**: Validates CSP credentials and required permissions
-        - **API Connectivity**: Tests connection to CSP APIs and service endpoints
-        - **Dependency Resolution**: Identifies any missing dependencies or prerequisites
-
-        **Optimization Recommendations:**
-        - **Cost-Effective Regions**: Suggests regions with lower pricing for specified resources
-        - **Performance Optimization**: Recommends regions with better network performance
-        - **Availability Zone**: Identifies optimal AZ distribution for high availability
-        - **Resource Bundling**: Suggests efficient resource combinations and groupings
-
-        **Output Information:**
-        - **Connection Candidates**: List of viable connection configurations
-        - **Provider Capabilities**: Detailed capabilities matrix per provider
-        - **Resource Status**: Real-time availability status for each requested resource
-        - **Recommendation Summary**: Actionable recommendations for optimal deployment
-
-        **Use Cases:**
-        - Pre-validate MCI configuration before expensive deployment operations
-        - Discover optimal provider/region combinations for cost or performance
-        - Troubleshoot resource availability issues during MCI planning
-        - Generate connection configuration templates for standardized deployments
-        - Assess infrastructure capacity and planning constraints
-
-        **Integration Workflow:**
-        1. Use this endpoint to validate and discover connection options
-        2. Review recommendations and adjust specifications if needed
-        3. Use `/mciDynamicReview` for detailed cost estimation and final validation
-        4. Proceed with `/mciDynamic` using validated configuration
-    PostMciDynamicReview:
-      method: post
-      resourcePath: /ns/{nsId}/mciDynamicReview
-      description: |-
-        Review and validate MCI dynamic request comprehensively before actual provisioning.
-        This endpoint performs comprehensive validation of MCI dynamic creation requests without actually creating resources.
-        It checks resource availability, validates specifications and images, estimates costs, and provides detailed recommendations.
-
-        **Key Features:**
-        - Validates all VM specifications and images against CSP availability
-        - Provides cost estimation (including partial estimates when some costs are unknown)
-        - Identifies potential configuration issues and warnings
-        - Recommends optimization strategies
-        - Shows provider and region distribution
-        - Non-invasive validation (no resources are created)
-
-        **Review Status:**
-        - `Ready`: All VMs can be created successfully
-        - `Warning`: VMs can be created but with configuration warnings
-        - `Error`: Critical errors prevent MCI creation
-
-        **Use Cases:**
-        - Pre-validation before expensive MCI creation
-        - Cost estimation and planning
-        - Configuration optimization
-        - Multi-cloud resource planning
-    PostMciPolicy:
-      method: post
-      resourcePath: /ns/{nsId}/policy/mci/{mciId}
-      description: Create MCI Automation policy
-    PostMciSubGroupScaleOut:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/subgroup/{subgroupId}
-      description: |-
-        Horizontally scale an existing VM subgroup by adding more identical instances for increased capacity.
-        This endpoint provides elastic scaling capabilities for running application tiers:
-
-        **Scale-Out Process:**
-        1. **SubGroup Validation**: Verifies target subgroup exists and is in scalable state
-        2. **Template Replication**: Uses existing VM configuration as template for new instances
-        3. **Resource Allocation**: Ensures sufficient CSP quotas and network resources
-        4. **Parallel Deployment**: Deploys multiple new VMs simultaneously for faster scaling
-        5. **Integration**: Seamlessly integrates new VMs into existing subgroup and MCI
-
-        **Configuration Inheritance:**
-        - **VM Specifications**: New VMs inherit exact specifications from existing subgroup members
-        - **Network Settings**: Automatically placed in same VNet, subnet, and security groups
-        - **SSH Keys**: Use same SSH key pairs for consistent access management
-        - **Monitoring**: Inherit monitoring agent configuration and policies
-        - **Labels and Metadata**: Propagate all labels and metadata from parent subgroup
-
-        **Scaling Scenarios:**
-        - **Traffic Spikes**: Quickly add capacity during high-demand periods
-        - **Seasonal Scaling**: Scale out for predictable demand increases
-        - **Performance Optimization**: Add instances to reduce per-VM resource utilization
-        - **Geographic Expansion**: Scale existing workloads to handle broader user base
-        - **Fault Tolerance**: Increase redundancy by adding more instances
-
-        **Intelligent Scaling:**
-        - **Sequential Naming**: New VMs follow established naming pattern (e.g., web-4, web-5, web-6)
-        - **Load Distribution**: New VMs are distributed optimally across availability zones
-        - **Resource Efficiency**: Reuses existing network and security infrastructure
-        - **Minimal Disruption**: Scaling occurs without affecting existing VM operations
-        - **Consistent Configuration**: Ensures all VMs in subgroup remain homogeneous
-
-        **Operational Benefits:**
-        - **Zero Downtime**: Existing VMs continue running during scale-out operation
-        - **Immediate Availability**: New VMs are ready for traffic as soon as deployment completes
-        - **Unified Management**: All VMs (old and new) managed through single subgroup
-        - **Policy Consistency**: All scaling and management policies apply uniformly
-        - **Monitoring Integration**: New VMs automatically included in existing monitoring dashboards
-
-        **Scale-Out Considerations:**
-        - **CSP Quotas**: Verifies sufficient instance, network, and storage quotas
-        - **Region Capacity**: Ensures target region has capacity for requested instance types
-        - **Network Limits**: Validates that VNet can accommodate additional VMs
-        - **Cost Impact**: Additional VMs incur proportional CSP billing costs
-        - **Application Readiness**: Applications should be designed to handle additional instances
-
-        **Post-Scale Operations:**
-        - New VMs immediately participate in subgroup operations
-        - Can be individually managed while maintaining subgroup membership
-        - Support for further scaling operations (scale-out or scale-in)
-        - Ready for application deployment and load balancer integration
-
-        **Best Practices:**
-        - Monitor application performance before and after scaling
-        - Ensure load balancers are configured to include new instances
-        - Verify application clustering and session management handle new instances
-        - Consider database connection limits and other resource constraints
-    PostMciVm:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm
-      description: |-
-        Create and add a group of identical virtual machines (subgroup) to an existing MCI using detailed specifications.
-        This endpoint provides precise control over VM configuration and placement within existing infrastructure:
-
-        **SubGroup Creation Process:**
-        1. **MCI Integration**: Validates target MCI exists and can accommodate new VMs
-        2. **Resource Validation**: Verifies all specified resources (specs, images, networks) exist and are accessible
-        3. **Homogeneous Deployment**: Creates multiple identical VMs with consistent configuration
-        4. **Network Integration**: Integrates new VMs with existing MCI networking and security policies
-        5. **Group Management**: Establishes subgroup for collective management and operations
-
-        **Detailed Configuration Control:**
-        - **Specific Resource References**: Uses exact resource IDs rather than common specifications
-        - **Network Placement**: Precise control over VNet, subnet, and security group assignment
-        - **Storage Configuration**: Detailed disk configuration including type, size, and performance tiers
-        - **Instance Customization**: Full control over VM specifications, images, and metadata
-        - **Security Settings**: Explicit security group and SSH key configuration
-
-        **SubGroup Benefits:**
-        - **Collective Operations**: Perform operations on entire subgroup simultaneously
-        - **Homogeneous Scaling**: All VMs in subgroup share identical configuration
-        - **Simplified Management**: Single configuration template for multiple VMs
-        - **Consistent Naming**: Automatic sequential naming (e.g., web-1, web-2, web-3)
-        - **Group Policies**: Apply scaling, monitoring, and lifecycle policies at subgroup level
-
-        **Use Cases:**
-        - **Application Tiers**: Deploy multiple instances of web servers, application servers, or databases
-        - **Load Distribution**: Create multiple identical VMs for load balancing scenarios
-        - **High Availability**: Deploy redundant instances across availability zones
-        - **Batch Processing**: Create worker nodes for distributed computing workloads
-        - **Development Environments**: Provision identical development or testing instances
-
-        **Configuration Requirements:**
-        - **Resource IDs**: Must specify exact resource identifiers (not common specs)
-        - **Network Configuration**: VNet, subnet, and security group must exist and be compatible
-        - **SSH Keys**: Must specify valid SSH key pairs for access management
-        - **Image Compatibility**: Specified image must be available in target region
-        - **Quota Validation**: Sufficient CSP quotas must be available for all requested VMs
-
-        **SubGroup Size Considerations:**
-        - **Small Groups (1-5 VMs)**: Fast deployment, minimal resource contention
-        - **Medium Groups (6-20 VMs)**: Optimized parallel deployment with resource batching
-        - **Large Groups (21+ VMs)**: Advanced deployment strategies to avoid CSP rate limits
-        - **Resource Limits**: Respects CSP quotas and CB-Tumblebug configuration limits
-
-        **Post-Deployment Integration:**
-        - SubGroup becomes integral part of parent MCI
-        - All VMs inherit MCI-level monitoring and management policies
-        - Can be scaled out further or individual VMs can be managed separately
-        - Supports all standard CB-Tumblebug VM lifecycle operations
-    PostMciVmDynamic:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/vmDynamic
-      description: |-
-        Dynamically add new virtual machines to an existing MCI using common specifications and automated resource management.
-        This endpoint provides elastic scaling capabilities for running MCIs:
-
-        **Dynamic VM Addition Process:**
-        1. **MCI Validation**: Verifies target MCI exists and is in a valid state for expansion
-        2. **Resource Discovery**: Resolves common spec and image to provider-specific resources
-        3. **Network Integration**: Automatically configures new VMs to use existing MCI network resources
-        4. **Subgroup Management**: Creates new subgroups or expands existing ones based on configuration
-        5. **Status Synchronization**: Updates MCI status and metadata to reflect new VM additions
-
-        **Integration with Existing Infrastructure:**
-        - **Network Reuse**: New VMs automatically join existing VNets and security groups
-        - **SSH Key Sharing**: Uses existing SSH keys for consistent access management
-        - **Monitoring Integration**: New VMs inherit monitoring configuration from parent MCI
-        - **Label Propagation**: Applies MCI-level labels and policies to new VMs
-        - **Resource Consistency**: Maintains naming conventions and resource organization
-
-        **Scaling Scenarios:**
-        - **Horizontal Scaling**: Add more instances to handle increased workload
-        - **Multi-Region Expansion**: Deploy VMs in new regions while maintaining MCI cohesion
-        - **Provider Diversification**: Add VMs from different cloud providers for redundancy
-        - **Workload Specialization**: Deploy VMs with different specifications for specific tasks
-
-        **Configuration Requirements:**
-        - `specId`: Must specify valid VM specification from system namespace
-        - `imageId`: Must specify valid image compatible with target provider/region
-        - `name`: Becomes subgroup name; VMs will be named with sequential suffixes
-        - `subGroupSize`: Number of identical VMs to create (default: 1)
-
-        **Network and Security:**
-        - New VMs automatically inherit security group rules from existing MCI
-        - Network connectivity to existing VMs is established automatically
-        - Firewall rules and access policies are applied consistently
-        - SSH access is configured using existing key pairs
-
-        **Example Use Cases:**
-        - Scale out web tier during traffic spikes
-        - Add GPU instances for machine learning workloads
-        - Deploy edge nodes in additional geographic regions
-        - Add specialized storage or database nodes to existing application stack
-
-        **Post-Addition Operations:**
-        - New VMs are immediately available for standard MCI operations
-        - Can be individually managed or grouped with existing subgroups
-        - Monitoring and logging are automatically configured
-        - Application deployment and configuration management can proceed immediately
-    PostMciVmSnapshot:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{vmId}/snapshot
-      description: Snapshot VM and create a Custom Image Object using the Snapshot
-    PostNLB:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb
-      description: Create NLB
-    PostNs:
-      method: post
-      resourcePath: /ns
-      description: Create namespace
-    PostObjectStorage:
-      method: post
-      resourcePath: /ns/{nsId}/resources/objectStorage
-      description: |
-        Create a Object Storages
-
-        Supported CSPs: AWS, Azure
-        - Note - `connectionName` example: aws-ap-northeast-2, azure-koreacentral
-
-        - Note - Please check the `requiredCSPResource` property which includes CSP specific values.
-
-        - Note - You can find the API usage examples on this link, https://github.com/cloud-barista/mc-terrarium/discussions/117
-    PostRegisterCSPNativeVM:
-      method: post
-      resourcePath: /ns/{nsId}/registerCspVm
-      description: |-
-        Import and register pre-existing virtual machines from cloud service providers into CB-Tumblebug management.
-        This endpoint allows you to bring existing CSP resources under CB-Tumblebug control without recreating them:
-
-        **Registration Process:**
-        1. **Discovery**: Validates that the specified VM exists in the target CSP
-        2. **Metadata Import**: Retrieves VM configuration, network settings, and current status
-        3. **Resource Mapping**: Creates CB-Tumblebug resource objects that reference the existing CSP resources
-        4. **Status Synchronization**: Aligns CB-Tumblebug status with actual CSP VM state
-        5. **Management Integration**: Enables CB-Tumblebug operations on the registered VMs
-
-        **Supported VM States:**
-        - Running VMs (most common use case)
-        - Stopped VMs (will be registered with current state)
-        - VMs with attached storage and network interfaces
-
-        **Resource Compatibility:**
-        - VM must exist in a supported CSP (AWS, Azure, GCP, etc.)
-        - Network resources (VPC, subnets, security groups) will be discovered and mapped
-        - Storage volumes and attached disks will be registered automatically
-        - SSH keys and security configurations will be imported
-
-        **Post-Registration Capabilities:**
-        - Standard CB-Tumblebug VM lifecycle operations (start, stop, terminate)
-        - Monitoring agent installation (if CB-Dragonfly is configured)
-        - Command execution and automation
-        - Integration with other CB-Tumblebug MCIs
-
-        **Important Notes:**
-        - Registration does not modify the existing VM configuration
-        - Original CSP billing and resource management still applies
-        - CB-Tumblebug provides additional management layer and automation
-        - Ensure proper CSP credentials and permissions are configured
-    PostRegisterSubnet:
-      method: post
-      resourcePath: /ns/{nsId}/registerCspResource/vNet/{vNetId}/subnet
-      description: Register Subnet, which was created in CSP
-    PostRegisterVNet:
-      method: post
-      resourcePath: /ns/{nsId}/registerCspResource/vNet
-      description: Register the VNet, which was created in CSP
-    PostSecurityGroup:
-      method: post
-      resourcePath: /ns/{nsId}/resources/securityGroup
-      description: Create Security Group
-    PostSiteToSiteVpn:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/vpn
-      description: |-
-        Create a site-to-site VPN
-
-        The supported CSP sets are as follows:
-
-        - AWS and one of CSPs in Azure, GCP, Alibaba, Tencent, and IBM
-
-        - Note: It will take about `15 ~ 45 minutes`.
-    PostSpec:
-      method: post
-      resourcePath: /ns/{nsId}/resources/spec
-      description: Register spec
-    PostSqlDb:
-      method: post
-      resourcePath: /ns/{nsId}/resources/sqlDb
-      description: |
-        Create a SQL Databases
-
-        Supported CSPs: AWS, Azure, GCP, NCP
-        - Note - `connectionName` example: aws-ap-northeast-2, azure-koreacentral, gcp-asia-northeast3, ncp-kr
-
-        - Note - Please check the `requiredCSPResource` property which includes CSP specific values.
-
-        - Note - You can find the API usage examples on this link, https://github.com/cloud-barista/mc-terrarium/discussions/110
-    PostSshKey:
-      method: post
-      resourcePath: /ns/{nsId}/resources/sshKey
-      description: Create SSH Key
-    PostSubnet:
-      method: post
-      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet
-      description: Create Subnet
-    PostSystemMci:
-      method: post
-      resourcePath: /systemMci
-      description: |-
-        Create specialized MCI instances for CB-Tumblebug system operations and infrastructure probing.
-        This endpoint provisions system-level infrastructure that supports CB-Tumblebug's internal functions:
-
-        **System MCI Types:**
-        - `probe`: Creates lightweight VMs for network connectivity testing and CSP capability discovery
-        - `monitor`: Deploys monitoring infrastructure for system health and performance tracking
-        - `test`: Provisions test environments for validating CSP integrations and features
-
-        **Probe MCI Features:**
-        - **Connectivity Testing**: Validates network paths between different CSP regions
-        - **Latency Measurement**: Measures inter-region and inter-provider network performance
-        - **Feature Discovery**: Tests CSP-specific capabilities and service availability
-        - **Resource Validation**: Verifies that CB-Tumblebug can successfully provision resources
-
-        **System Namespace:**
-        - All system MCIs are created in the special `system` namespace
-        - Isolated from user workloads and regular MCI operations
-        - Managed automatically by CB-Tumblebug internal processes
-        - May be used for background maintenance and monitoring tasks
-
-        **Automatic Configuration:**
-        - Uses optimized VM specifications for system tasks (typically minimal resources)
-        - Automatically selects appropriate regions and providers based on probe requirements
-        - Configures necessary network access and security policies
-        - Deploys with minimal attack surface and security hardening
-
-        **Lifecycle Management:**
-        - System MCIs may be automatically created, updated, or destroyed by CB-Tumblebug
-        - Typically short-lived for specific system tasks
-        - Resource cleanup is handled automatically
-        - Status and results are logged for system administrators
-
-        **Use Cases:**
-        - Infrastructure health checks and validation
-        - Performance benchmarking across cloud providers
-        - Automated testing of new CSP integrations
-        - Network topology discovery and optimization
-    PostTestStreamResponse:
-      method: post
-      resourcePath: /testStreamResponse
-      description: Receives a number and streams the decrementing number every second
-        until zero
-    PostUtilToDesignNetwork:
-      method: post
-      resourcePath: /util/net/design
-      description: Design a hierarchical network configuration of a VPC network or
-        multi-cloud network consisting of multiple VPC networks
-    PostUtilToDesignVNet:
-      method: post
-      resourcePath: /util/vNet/design
-      description: Design VNet and subnets based on user-friendly properties
-    PostUtilToValidateNetwork:
-      method: post
-      resourcePath: /util/net/validate
-      description: Validate a hierarchical configuration of a VPC network or multi-cloud
-        network consisting of multiple VPC networks
-    PostVNet:
-      method: post
-      resourcePath: /ns/{nsId}/resources/vNet
-      description: Create a new VNet
-    PostVmDataDisk:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{vmId}/dataDisk
-      description: Provisioning (Create and attach) dataDisk
-    PutChangeK8sNodeGroupAutoscaleSize:
-      method: put
-      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}/autoscaleSize
-      description: Change a K8sNodeGroup's Autoscale Size
-    PutDataDisk:
-      method: put
-      resourcePath: /ns/{nsId}/resources/dataDisk/{dataDiskId}
-      description: Upsize Data Disk
-    PutImage:
-      method: put
-      resourcePath: /ns/{nsId}/resources/image/{imageId}
-      description: Update image
-    PutMciAssociatedSecurityGroups:
-      method: put
-      resourcePath: /ns/{nsId}/mci/{mciId}/associatedSecurityGroups
-      description: |-
-        Update all Security Groups associated with a given MCI. The firewall rules of all Security Groups will be synchronized to match the requested set.
-        Update all Security Groups associated with a given MCI. The firewall rules of all associated Security Groups will be synchronized to match the requested set.
-
-        This API will add missing rules and delete extra rules so that each Security Group's rules become identical to the requested set.
-        Only firewall rules are updated; other metadata (name, description, etc.) is not changed.
-
-        Usage:
-        Use this API to update (synchronize) the firewall rules of all Security Groups associated with the specified MCI. The rules in the request body will become the only rules in each Security Group after the operation.
-        - All existing rules not present in the request will be deleted.
-        - All rules in the request that do not exist will be added.
-        - If a rule exists but differs in CIDR or port range, it will be replaced.
-        - Special protocols (ICMP, etc.) are handled in the same way.
-
-        Notes:
-        - "Ports" field supports single port ("22"), port range ("80-100"), and multiple ports/ranges ("22,80-100,443").
-        - The valid port number range is 0 to 65535 (inclusive).
-        - "Protocol" can be TCP, UDP, ICMP, etc. (as supported by the cloud provider).
-        - "Direction" must be either "inbound" or "outbound".
-        - "CIDR" is the allowed IP range.
-        - All existing rules not in the request (including default ICMP, etc.) will be deleted.
-        - Metadata (name, description, etc.) is not changed.
-    PutMonitorAgentStatusInstalled:
-      method: put
-      resourcePath: /ns/{nsId}/monitoring/status/mci/{mciId}/vm/{vmId}
-      description: Set monitoring agent (CB-Dragonfly agent) installation status installed
-        (for Windows VM only)
-    PutNs:
-      method: put
-      resourcePath: /ns/{nsId}
-      description: Update namespace
-    PutSecurityGroup:
-      method: put
-      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}
-      description: |-
-        Update Security Group: Synchronize the firewall rules of the specified Security Group to match the requested list exactly.
-        This API will add missing rules and delete extra rules so that the Security Group's rules become identical to the requested set.
-        Only firewall rules are updated; other metadata (name, description, etc.) is not changed.
-
-        Usage:
-        Use this API to update (synchronize) the firewall rules of a Security Group. The rules in the request body will become the only rules in the Security Group after the operation.
-        - All existing rules not present in the request will be deleted.
-        - All rules in the request that do not exist will be added.
-        - If a rule exists but differs in CIDR or port range, it will be replaced.
-        - Special protocols (ICMP, etc.) are handled in the same way.
-
-        Notes:
-        - "Ports" field supports single port ("22"), port range ("80-100"), and multiple ports/ranges ("22,80-100,443").
-        - The valid port number range is 0 to 65535 (inclusive).
-        - "Protocol" can be TCP, UDP, ICMP, etc. (as supported by the cloud provider).
-        - "Direction" must be either "inbound" or "outbound".
-        - "CIDR" is the allowed IP range.
-        - All existing rules not in the request (including default ICMP, etc.) will be deleted.
-        - Metadata (name, description, etc.) is not changed.
-    PutSetK8sNodeGroupAutoscaling:
-      method: put
-      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}/onAutoscaling
-      description: Set a K8sNodeGroup's Autoscaling On/Off
-    PutSpec:
-      method: put
-      resourcePath: /ns/{nsId}/resources/spec/{specId}
-      description: Update spec
-    PutSshKey:
-      method: put
-      resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}
-      description: Update SSH Key
-    PutUpgradeK8sCluster:
-      method: put
-      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/upgrade
-      description: Upgrade a K8sCluster's version
-    PutVmDataDisk:
-      method: put
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{vmId}/dataDisk
-      description: Attach/Detach available dataDisk
-    RecommendK8sNode:
-      method: post
-      resourcePath: /k8sClusterRecommendNode
-      description: Recommend K8sCluster's Node plan (filter and priority) Find details
-        from https://github.com/cloud-barista/cb-tumblebug/discussions/1234
+      description: "Get registered region info"
     RecommendSpec:
       method: post
       resourcePath: /recommendSpec
-      description: |-
-        Recommend specs for configuring an infrastructure (filter and priority)
-        Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234
-        Get available options by /recommendSpecOptions for filtering and prioritizing specs in RecommendSpec API
-    RecommendSpecOptions:
+      description: "Recommend specs for configuring an infrastructure (filter and priority)\nFind details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234\nGet available options by /recommendSpecOptions for filtering and prioritizing specs in RecommendSpec API"
+    CheckResource:
       method: get
-      resourcePath: /recommendSpecOptions
-      description: Get available options for filtering and prioritizing specs in RecommendSpec
-        API
-    RecordProvisioningEvent:
+      resourcePath: /ns/{nsId}/checkResource/{resourceType}/{resourceId}
+      description: "Check resources' existence"
+    GetNLBSupport:
+      method: get
+      resourcePath: /nlb/support
+      description: "Get CSP support information for NLB health checker configuration fields (customHealthCheckerInterval, customHealthCheckerTimeout, customHealthCheckerThreshold).\nA false value means the CSP does not support a custom value for that field (e.g., AWS TCP NLB does not support custom timeout).\nIf cspType query parameter is provided, returns support information for that specific CSP.\nIf cspType is not provided, returns support information for all CSPs."
+    PostSubnet:
       method: post
-      resourcePath: /provisioning/event
-      description: |-
-        Manually record a provisioning success or failure event for historical tracking and analysis.
-        This endpoint allows external systems or manual processes to contribute to provisioning history:
-
-        **Use Cases:**
-        - **External Provisioning Tools**: Record events from non-CB-Tumblebug provisioning systems
-        - **Manual Testing**: Log results from manual deployment tests
-        - **Migration**: Import historical data from other systems
-        - **Integration**: Connect with CI/CD pipelines for comprehensive tracking
-
-        **Event Types:**
-        - **Success Events**: Only recorded if previous failures exist for the spec
-        - **Failure Events**: Always recorded to build failure pattern database
-
-        **Data Quality:**
-        - Provide accurate timestamps for proper chronological analysis
-        - Include detailed error messages for failure events
-        - Use consistent spec ID and image name formats
-
-        **Impact on System:**
-        - Contributes to risk analysis algorithms
-        - Affects future MCI review recommendations
-        - Builds historical baseline for reliability metrics
-    RegisterCredential:
+      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet
+      description: "Create Subnet"
+    GetAllSubnet:
+      method: get
+      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet
+      description: "List all subnets"
+    GetNodeDataDisk:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/dataDisk
+      description: "Get available dataDisks for a node"
+    PutNodeDataDisk:
+      method: put
+      resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/dataDisk
+      description: "Attach/Detach available dataDisk"
+    PostNodeDataDisk:
       method: post
-      resourcePath: /credential
-      description: This API registers credential information using hybrid encryption.
-        The process involves compressing and encrypting sensitive data with AES-256,
-        encrypting the AES key with a 4096-bit RSA public key (retrieved via `GET
-        /credential/publicKey`), and using OAEP padding with SHA-256. All values,
-        including the AES key, must be base64 encoded before sending, and the public
-        key token ID must be included in the request.
-    RegisterCspNativeResources:
-      method: post
-      resourcePath: /registerCspResources
-      description: Register CSP Native Resources (vNet, securityGroup, sshKey, vm)
-        to CB-Tumblebug
-    RegisterCspNativeResourcesAll:
-      method: post
-      resourcePath: /registerCspResourcesAll
-      description: Register CSP Native Resources (vNet, securityGroup, sshKey, vm)
-        from all Clouds to CB-Tumblebug
-    RemoveBastionNodes:
-      method: delete
-      resourcePath: /ns/{nsId}/mci/{mciId}/bastion/{bastionVmId}
-      description: Remove a bastion VM from all vNets
-    RemoveLabel:
-      method: delete
-      resourcePath: /label/{labelType}/{uid}/{key}
-      description: Remove a label from a resource identified by its uid
-    RemoveNLBVMs:
-      method: delete
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb/{nlbId}/vm
-      description: Delete VMs from NLB
+      resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/dataDisk
+      description: "Provisioning (Create and attach) dataDisk"
+    GetControlInfra:
+      method: get
+      resourcePath: /ns/{nsId}/control/infra/{infraId}
+      description: "Control the lifecycle of an Infra. Actions fall into three groups:\n\n**Lifecycle (normal operation):**\n- `suspend` / `resume` / `reboot`: power-cycle every Node.\n- `terminate`: terminate every Node (Infra metadata is kept; call DELETE to remove).\n- `refine`: delete Nodes whose status is `Failed` or `Undefined` from Infra metadata\n(no CSP-side termination is issued for those Nodes).\n\n**Hold gate (only valid right after `POST /infra` with option=hold):**\n- `continue`: signal the holding goroutine to proceed with provisioning.\n- `withdraw`: signal the holding goroutine to cancel provisioning.\n- These actions only work while a holding goroutine is alive in memory.\nAfter a server restart they will fail; use `reconcile`/`abort` instead.\n\n**Crash recovery (Infra stuck after server restart or partial failure):**\n- `reconcile`: forward-recover. For each transient Node, query Spider for the real\nCSP status and absorb CSP-side orphan VMs (created before the crash but not\nrecorded in TB). Nodes that cannot be matched on the CSP are marked `Failed`\nso a subsequent `refine` can remove them. No new Spider create calls are issued.\n- `abort`: backward-recover. Force-terminate every non-final Node in parallel\n(with orphan rescue) and sweep any `Failed` remnants via `refine`. The final\nDELETE call is left to the operator."
     RetrieveRegionListFromCsp:
       method: get
       resourcePath: /regionFromCsp
-      description: RetrieveR all region lists from CSPs
+      description: "RetrieveR all region lists from CSPs"
+    GetObjectStorageCORSLagacy:
+      method: get
+      resourcePath: /resources/objectStorage/{objectStorageName}/cors
+      description: "(To be deprecated) Get CORS configuration of an object storage (bucket)\n\n**Important Notes:**\n- The actual response will be XML format with root element `CORSConfiguration`\n\n**Actual XML Response Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<CORSConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n<CORSRule>\n<AllowedOrigin>*</AllowedOrigin>\n<AllowedMethod>GET</AllowedMethod>\n<AllowedMethod>PUT</AllowedMethod>\n<AllowedMethod>POST</AllowedMethod>\n<AllowedMethod>DELETE</AllowedMethod>\n<AllowedHeader>*</AllowedHeader>\n<ExposeHeader>ETag</ExposeHeader>\n<ExposeHeader>x-amz-server-side-encryption</ExposeHeader>\n<ExposeHeader>x-amz-request-id</ExposeHeader>\n<ExposeHeader>x-amz-id-2</ExposeHeader>\n<MaxAgeSeconds>3000</MaxAgeSeconds>\n</CORSRule>\n</CORSConfiguration>\n```\n\n**Error Response Example (if CORS not configured):**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n<Code>NoSuchCORSConfiguration</Code>\n<Message>The CORS configuration does not exist</Message>\n<Resource>/example-bucket</Resource>\n<RequestId>656c76696e6727732072657175657374</RequestId>\n</Error>\n```"
+    SetObjectStorageCORSLagacy:
+      method: put
+      resourcePath: /resources/objectStorage/{objectStorageName}/cors
+      description: "(To be deprecated) Set CORS configuration of an object storage (bucket)\n\n**Important Notes:**\n- The CORS configuration must be provided in the request body in XML format.\n- The actual request body should have root element `CORSConfiguration`\n\n**Actual XML Request Body Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<CORSConfiguration>\n<CORSRule>\n<AllowedOrigin>https://example.com</AllowedOrigin>\n<AllowedOrigin>https://app.example.com</AllowedOrigin>\n<AllowedMethod>GET</AllowedMethod>\n<AllowedMethod>PUT</AllowedMethod>\n<AllowedHeader>Content-Type</AllowedHeader>\n<AllowedHeader>Authorization</AllowedHeader>\n<ExposeHeader>ETag</ExposeHeader>\n<MaxAgeSeconds>1800</MaxAgeSeconds>\n</CORSRule>\n<CORSRule>\n<AllowedOrigin>*</AllowedOrigin>\n<AllowedMethod>GET</AllowedMethod>\n<MaxAgeSeconds>300</MaxAgeSeconds>\n</CORSRule>\n</CORSConfiguration>\n```"
+    DeleteObjectStorageCORSLagacy:
+      method: delete
+      resourcePath: /resources/objectStorage/{objectStorageName}/cors
+      description: "(To be deprecated) Delete CORS configuration of an object storage (bucket)"
+    GetCredentialHolderList:
+      method: get
+      resourcePath: /credentialHolder
+      description: "List all credential holders derived from registered connection configs.\nEach holder includes associated providers, connection counts, and verification status."
+    PostRegisterCSPNativeNode:
+      method: post
+      resourcePath: /ns/{nsId}/registerCspNode
+      description: "Import and register pre-existing virtual machines from cloud service providers into CB-Tumblebug management.\nThis endpoint allows you to bring existing CSP resources under CB-Tumblebug control without recreating them:\n\n**Registration Process:**\n1. **Discovery**: Validates that the specified node exists in the target CSP\n2. **Metadata Import**: Retrieves node configuration, network settings, and current status\n3. **Resource Mapping**: Creates CB-Tumblebug resource objects that reference the existing CSP resources\n4. **Status Synchronization**: Aligns CB-Tumblebug status with actual CSP node state\n5. **Management Integration**: Enables CB-Tumblebug operations on the registered nodes\n\n**Supported node States:**\n- Running nodes (most common use case)\n- Stopped nodes (will be registered with current state)\n- nodes with attached storage and network interfaces\n\n**Resource Compatibility:**\n- node must exist in a supported CSP (AWS, Azure, GCP, etc.)\n- Network resources (VPC, subnets, security groups) will be discovered and mapped\n- Storage volumes and attached disks will be registered automatically\n- SSH keys and security configurations will be imported\n\n**Post-Registration Capabilities:**\n- Standard CB-Tumblebug node lifecycle operations (start, stop, terminate)\n- Monitoring agent installation (if CB-Dragonfly is configured)\n- Command execution and automation\n- Integration with other CB-Tumblebug Infras\n\n**Important Notes:**\n- Registration does not modify the existing node configuration\n- Original CSP billing and resource management still applies\n- CB-Tumblebug provides additional management layer and automation\n- Ensure proper CSP credentials and permissions are configured"
+    PostSecurityGroupFromTemplate:
+      method: post
+      resourcePath: /ns/{nsId}/resources/securityGroup/template/{templateId}
+      description: "Create a new SecurityGroup by applying a SecurityGroup Template.\nThe template provides the base SecurityGroup configuration (connectionName, vNetId, firewallRules),\nand the apply request allows overriding the SecurityGroup name and description.\n\n**Override Behavior (Phase 1):**\n- `name` (required): Name for the new SecurityGroup\n- `description` (optional): Overrides the template's description\n- All other configuration (connectionName, vNetId, firewallRules) comes from the template"
+    ReconcileAllVNets:
+      method: put
+      resourcePath: /ns/{nsId}/resources/vNet/reconcile
+      description: "Reconcile all VNets and their subnets in the namespace by comparing TB metadata with CSP state. TB metadata is the source of truth; only TB-registered resources are reconciled.\n\n⚠️ **PERFORMANCE NOTE**: Reconciliation may take 1-2 minutes per cloud connection due to CSP API response time. Plan accordingly for namespaces with multiple cloud connections."
+    PostFileToInfra:
+      method: post
+      resourcePath: /ns/{nsId}/transferFile/infra/{infraId}
+      description: "Transfer a file to specified Infra to the specified path.\nThe file size should be less than 10MB.\nNot for gerneral file transfer but for specific purpose (small configuration files)."
+    PostInfraDynamic:
+      method: post
+      resourcePath: /ns/{nsId}/infraDynamic
+      description: "Create multi-cloud infrastructure dynamically using common specifications and images with automatic resource discovery and optimization.\nThis is the **recommended approach** for Infra creation, providing simplified configuration with powerful automation:\n\n**Dynamic Resource Creation:**\n1. **Automatic Resource Discovery**: Validates and selects optimal node specifications and images from common namespace\n2. **Intelligent Network Setup**: Creates VNets, subnets, security groups, and SSH keys automatically per provider\n3. **Cross-Cloud Orchestration**: Coordinates node provisioning across multiple cloud providers simultaneously\n4. **Dependency Management**: Handles resource creation order and inter-dependencies automatically\n5. **Failure Recovery**: Implements configurable failure policies for robust deployment\n\n**Key Advantages Over Static Infra:**\n- **Simplified Configuration**: Use common spec/image IDs instead of provider-specific resources\n- **Automatic Resource Management**: No need to pre-create VNets, security groups, or SSH keys\n- **Multi-Cloud Optimization**: Intelligent placement and configuration across providers\n- **Built-in Best Practices**: Security groups, network isolation, and access controls applied automatically\n- **Scalable Architecture**: Supports large-scale deployments with optimized resource utilization\n\n**Configuration Process:**\n1. **Resource Discovery**: Use `/recommendSpec` to find suitable node specifications\n2. **Image Selection**: Use system namespace to discover compatible images\n3. **Request Validation**: Use `/infraDynamicCheckRequest` to validate configuration before deployment\n4. **Optional Preview**: Use `/infraDynamicReview` to estimate costs and review configuration\n5. **Deployment**: Submit Infra dynamic request with failure policy and deployment options\n\n**Failure Policies (PolicyOnPartialFailure):**\n- **`continue`** (default): Create Infra with successful nodes, failed nodes remain for manual refinement\n- **`rollback`**: Delete entire Infra if any node fails (all-or-nothing deployment)\n- **`refine`**: Automatically clean up failed nodes, keep successful ones (recommended for large deployments)\n\n**Deployment Options:**\n- **`hold`**: Create Infra object but hold node provisioning for manual approval\n- **Normal**: Proceed with immediate node provisioning after resource creation\n\n**Multi-Cloud Example Configuration:**\n```json\n{\n\"name\": \"multi-cloud-web-tier\",\n\"description\": \"Web application across AWS, Azure, and GCP\",\n\"policyOnPartialFailure\": \"refine\",\n\"nodeGroups\": [\n{\n\"name\": \"aws-web-servers\",\n\"nodeGroupSize\": \"3\",\n\"specId\": \"aws+us-east-1+t3.medium\",\n\"imageId\": \"ami-0abcdef1234567890\",\n\"rootDiskSize\": \"100\",\n\"label\": {\"tier\": \"web\", \"provider\": \"aws\"}\n},\n{\n\"name\": \"azure-api-servers\",\n\"nodeGroupSize\": \"2\",\n\"specId\": \"azure+eastus+Standard_B2s\",\n\"imageId\": \"Canonical:0001-com-ubuntu-server-jammy:22_04-lts\",\n\"label\": {\"tier\": \"api\", \"provider\": \"azure\"}\n}\n]\n}\n```\n\n**Performance Considerations:**\n- node provisioning occurs in parallel across providers\n- Network resources are created concurrently where possible\n- Large deployments (>10 nodes) automatically use optimized batching\n- Built-in rate limiting prevents CSP API throttling\n\n**Monitoring and Post-Deployment:**\n- Optional CB-Dragonfly monitoring agent installation\n- Custom post-deployment command execution\n- Real-time status tracking and progress updates\n- Automatic resource labeling and metadata management"
+    PutSpec:
+      method: put
+      resourcePath: /ns/{nsId}/resources/spec/{specId}
+      description: "Update spec"
+    DelSpec:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/spec/{specId}
+      description: "Delete spec"
+    GetSpec:
+      method: get
+      resourcePath: /ns/{nsId}/resources/spec/{specId}
+      description: "Get spec"
+    PostK8sClusterDynamicTemplate:
+      method: post
+      resourcePath: /ns/{nsId}/template/k8sCluster
+      description: "Create a reusable K8s Cluster Dynamic Template. Templates store K8sMultiClusterDynamic\nrequest configurations that can be applied later to provision multi-cloud K8s clusters\nwith consistent settings."
+    DeleteAllK8sClusterDynamicTemplate:
+      method: delete
+      resourcePath: /ns/{nsId}/template/k8sCluster
+      description: "Delete all K8s Cluster Dynamic Templates in a namespace."
+    GetAllK8sClusterDynamicTemplate:
+      method: get
+      resourcePath: /ns/{nsId}/template/k8sCluster
+      description: "List all K8s Cluster Dynamic Templates in a namespace.\nOptionally filter by keyword matching against template name or description (case-insensitive)."
+    GetAllNs:
+      method: get
+      resourcePath: /ns
+      description: "List all namespaces or namespaces' ID"
+    PostNs:
+      method: post
+      resourcePath: /ns
+      description: "Create namespace"
+    DelAllNs:
+      method: delete
+      resourcePath: /ns
+      description: "Delete all namespaces"
+    GetObjectStorageLocation:
+      method: get
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/location
+      description: "Get the location of an object storage (bucket)"
+    PostSpec:
+      method: post
+      resourcePath: /ns/{nsId}/resources/spec
+      description: "Register spec"
+    LookupSpec:
+      method: post
+      resourcePath: /lookupSpec
+      description: "Lookup spec (for debugging purposes)"
+    GetSqlDb:
+      method: get
+      resourcePath: /ns/{nsId}/resources/sqlDb/{sqlDbId}
+      description: "Get resource info of a SQL datatbase"
+    DeleteSqlDb:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/sqlDb/{sqlDbId}
+      description: "Delete a SQL datatbase"
+    GetObjectStorageLocationLagacy:
+      method: get
+      resourcePath: /resources/objectStorage/{objectStorageName}/location
+      description: "(To be deprecated) Get the location of an object storage (bucket)\n\n**Important Notes:**\n- The actual response will be XML format with root element `LocationConstraint`\n\n**Actual XML Response Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<LocationConstraint xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">ap-northeast-2</LocationConstraint>\n```"
+    CheckK8sNodeImageDesignation:
+      method: get
+      resourcePath: /checkK8sNodeImageDesignation
+      description: "Check whether node image designation is possible to create a K8sCluster"
+    GetProvisioningLog:
+      method: get
+      resourcePath: /provisioning/log/{specId}
+      description: "Retrieve detailed provisioning history for a specific node specification including success/failure patterns and risk analysis.\nThis endpoint provides comprehensive insights into provisioning reliability:\n\n**Historical Data Includes:**\n- Success and failure counts with timestamps\n- CSP-specific error messages and failure patterns\n- Image compatibility tracking across different attempts\n- Failure rate analysis and risk assessment\n- Regional and provider-specific reliability metrics\n\n**Use Cases:**\n- **Pre-deployment Risk Assessment**: Check if a spec has historical failures before creating Infra\n- **Troubleshooting**: Analyze failure patterns to identify root causes\n- **Capacity Planning**: Understand reliability patterns for different specs and regions\n- **Cost Optimization**: Avoid specs with high failure rates that waste resources\n\n**Response Details:**\n- `failureCount`: Total number of provisioning failures\n- `successCount`: Number of successes (only tracked after failures occur)\n- `failureImages`: List of CSP images that failed with this spec\n- `successImages`: List of CSP images that succeeded with this spec\n- `failureMessages`: Detailed error messages from CSP\n- `lastUpdated`: Timestamp of most recent provisioning attempt"
+    DeleteProvisioningLog:
+      method: delete
+      resourcePath: /provisioning/log/{specId}
+      description: "Remove all provisioning history data for a specific node specification.\nThis operation permanently deletes historical failure and success records:\n\n**Warning**: This action is irreversible and will remove:\n- All failure and success statistics\n- Historical error messages and troubleshooting data\n- Risk analysis baseline for future deployments\n- Failure pattern analysis data\n\n**When to Use:**\n- **Data Cleanup**: Remove outdated or irrelevant provisioning history\n- **Fresh Start**: Clear history after infrastructure changes that resolve previous issues\n- **Privacy Compliance**: Remove logs containing sensitive error information\n- **Storage Management**: Clean up logs to manage kvstore space\n\n**Impact on System:**\n- Future risk analysis for this spec will have no historical baseline\n- Infra review process will not show historical warnings for this spec\n- Provisioning reliability metrics will be reset to zero"
+    PostInfraDynamicCheckRequest:
+      method: post
+      resourcePath: /infraDynamicCheckRequest
+      description: "**⚠️ DEPRECATED: This endpoint is deprecated and will be removed in a future version. Please use `/infraDynamicReview` instead for comprehensive validation and cost estimation.**\n\nValidate resource availability and discover optimal connection configurations before creating Infra dynamically.\nThis endpoint provides comprehensive resource validation and connection discovery for Infra planning:\n\n**Resource Validation Process:**\n1. **Specification Analysis**: Validates that requested common specs exist and are accessible\n2. **Provider Discovery**: Identifies available cloud providers and regions for each specification\n3. **Connectivity Assessment**: Tests connection configurations and CSP API accessibility\n4. **Quota Verification**: Checks available quotas and resource limits where possible\n5. **Compatibility Matrix**: Generates matrix of viable spec-provider-region combinations\n\n**Connection Configuration Discovery:**\n- **Available Providers**: Lists all configured cloud providers (AWS, Azure, GCP, etc.)\n- **Active Regions**: Shows available regions per provider with connectivity status\n- **Specification Mapping**: Maps common specs to provider-specific instance types\n- **Image Compatibility**: Validates image availability across different providers/regions\n- **Network Capabilities**: Identifies supported network features and configurations\n\n**Pre-Deployment Validation:**\n- **Resource Existence**: Confirms all specified resources exist in system namespace\n- **Permission Verification**: Validates CSP credentials and required permissions\n- **API Connectivity**: Tests connection to CSP APIs and service endpoints\n- **Dependency Resolution**: Identifies any missing dependencies or prerequisites\n\n**Optimization Recommendations:**\n- **Cost-Effective Regions**: Suggests regions with lower pricing for specified resources\n- **Performance Optimization**: Recommends regions with better network performance\n- **Availability Zone**: Identifies optimal AZ distribution for high availability\n- **Resource Bundling**: Suggests efficient resource combinations and groupings\n\n**Output Information:**\n- **Connection Candidates**: List of viable connection configurations\n- **Provider Capabilities**: Detailed capabilities matrix per provider\n- **Resource Status**: Real-time availability status for each requested resource\n- **Recommendation Summary**: Actionable recommendations for optimal deployment\n\n**Use Cases:**\n- Pre-validate Infra configuration before expensive deployment operations\n- Discover optimal provider/region combinations for cost or performance\n- Troubleshoot resource availability issues during Infra planning\n- Generate connection configuration templates for standardized deployments\n- Assess infrastructure capacity and planning constraints\n\n**Integration Workflow:**\n1. Use this endpoint to validate and discover connection options\n2. Review recommendations and adjust specifications if needed\n3. Use `/infraDynamicReview` for detailed cost estimation and final validation\n4. Proceed with `/infraDynamic` using validated configuration"
+    GetAvailableK8sVersion:
+      method: get
+      resourcePath: /availableK8sVersion
+      description: "Get available kubernetes cluster version"
+    PostK8sMultiClusterDynamicFromTemplate:
+      method: post
+      resourcePath: /ns/{nsId}/k8sCluster/template/{templateId}
+      description: "Provision a new set of K8s clusters by applying a K8s Cluster Dynamic Template.\nThe template provides the full K8sMultiClusterDynamicReq configuration, and the\napply request allows overriding the namePrefix and description.\n\n**Override Behavior (Phase 1):**\n- `namePrefix` (required): Overrides the namePrefix for all clusters\n- `description` (optional): Propagated to each cluster's description\n- All other configuration (specId, imageId, nodeGroupSize, etc.) comes from the template"
+    ListNodeCommandStatus:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/commandStatus
+      description: "List command status records for a node with various filtering options"
+    DeleteNodeCommandStatusByCriteria:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/commandStatus
+      description: "Delete multiple command status records for a node based on filtering criteria"
+    PostInfraDynamicNodeGroupNodeReview:
+      method: post
+      resourcePath: /ns/{nsId}/infra/{infraId}/nodeGroupDynamicReview
+      description: "Review and validate a node dynamic addition request for an existing Infra before actual provisioning.\nThis endpoint provides comprehensive validation for adding new nodes to existing Infras without actually creating resources.\nIt checks resource availability, validates specifications and images, estimates costs, and provides detailed recommendations.\n\n**Key Features:**\n- Validates node specification and image against CSP availability\n- Checks compatibility with existing Infra configuration\n- Provides cost estimation for the new node addition\n- Identifies potential configuration issues and warnings\n- Recommends optimization strategies\n- Non-invasive validation (no resources are created)\n\n**Review Status:**\n- `Ready`: node can be added successfully\n- `Warning`: node can be added but with configuration warnings\n- `Error`: Critical errors prevent node addition\n\n**Infra Integration Validation:**\n- Ensures target Infra exists and is in a compatible state\n- Validates network integration possibilities\n- Checks resource naming conflicts\n- Verifies security group and SSH key compatibility\n\n**Use Cases:**\n- Pre-validation before expensive node addition operations\n- Cost estimation for scaling decisions\n- Configuration optimization before deployment\n- Risk assessment for node addition to existing infrastructure"
+    PostInstallMonitorAgentToInfra:
+      method: post
+      resourcePath: /ns/{nsId}/monitoring/install/infra/{infraId}
+      description: "Install monitoring agent (CB-Dragonfly agent) to Infra"
+    GetAllSshKey:
+      method: get
+      resourcePath: /ns/{nsId}/resources/sshKey
+      description: "List all SSH Keys or SSH Keys' ID"
+    PostSshKey:
+      method: post
+      resourcePath: /ns/{nsId}/resources/sshKey
+      description: "Create SSH Key"
+    DelAllSshKey:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/sshKey
+      description: "Delete all SSH Keys"
+    GetInfraHandlingCommandCount:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{infraId}/handlingCount
+      description: "Get the number of commands currently in 'Handling' status for all nodes in an Infra. Returns per-node counts and total count."
+    PostK8sNodeGroup:
+      method: post
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup
+      description: "Add a K8sNodeGroup"
+    ListObjectStorages:
+      method: get
+      resourcePath: /ns/{nsId}/resources/objectStorage
+      description: "Get the list of object storages (buckets)\n\n**Filtering with filterKey and filterVal:**\nBoth parameters perform a case-insensitive substring match against the stored JSON of each resource.\nA resource is included in the result only when its JSON contains **both** the filterKey string and the filterVal string.\n\nCommon filterKey examples:\n- `connectionName` — filter by cloud connection (e.g. filterVal: `aws-ap-northeast-2`)\n- `status`         — filter by resource status  (e.g. filterVal: `Available`)"
+    CreateObjectStorage:
+      method: put
+      resourcePath: /ns/{nsId}/resources/objectStorage
+      description: "Create an object storage (bucket)"
+    PostMcNLB:
+      method: post
+      resourcePath: /ns/{nsId}/infra/{infraId}/mcSwNlb
+      description: "Create a special purpose Infra for NLB and depoly and setting SW NLB"
+    DeleteK8sNodeGroup:
+      method: delete
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}
+      description: "Remove a K8sNodeGroup"
+    GetK8sClusterKubeconfig:
+      method: get
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/kubeconfig
+      description: "Get a CSP native kubeconfig for the specified K8sCluster.\nReturns a kubeconfig using CSP native auth plugins (e.g., aws-iam-authenticator for EKS, gke-gcloud-auth-plugin for GKE)."
+    FetchPrice:
+      method: post
+      resourcePath: /fetchPrice
+      description: "Fetch price from all CSP connections and update the price information for associated specs in the system."
+    PostCmdInfra:
+      method: post
+      resourcePath: /ns/{nsId}/cmd/infra/{infraId}
+      description: "Send a command to specified Infra. Use query parameters to target specific nodeGroup or node.\nWhen async=true, returns immediately with xRequestId and streams results via SSE at GET /stream/ns/{nsId}/cmd/infra/{infraId}?xRequestId={xRequestId}"
+    CancelExecutionTask:
+      method: post
+      resourcePath: /ns/{nsId}/cmd/infra/{infraId}/task/{taskId}/cancel
+      description: "Cancel a running execution task by task ID. This will send a cancellation signal to the task and update the node command status."
+    PostFileToK8sCluster:
+      method: post
+      resourcePath: /ns/{nsId}/transferFile/k8sCluster/{k8sClusterId}
+      description: "Transfer a file to specified Container in K8sCluster. The tar command is required in the container.\n[note] This feature is not intended for general use\nThis API is provided as an exceptional and limited function for specific purposes such as migration.\nKubernetes resource information required as input for this API is not currently provided, and its availability in the future is uncertain."
+    GetInfraExecutionTasks:
+      method: get
+      resourcePath: /ns/{nsId}/cmd/infra/{infraId}/task
+      description: "List all running and completed execution tasks for a specific Infra. These tasks can be cancelled if still in progress. The task list is based on persistent node command status records."
+    DeleteDeregisterSubnet:
+      method: delete
+      resourcePath: /ns/{nsId}/deregisterResource/vNet/{vNetId}/subnet/{subnetId}
+      description: "Deregister Subnet, which was created in CSP"
+    GetMonitorData:
+      method: get
+      resourcePath: /ns/{nsId}/monitoring/infra/{infraId}/metric/{metric}
+      description: "Get monitoring data of specified Infra for specified monitoring metric (cpu, memory, disk, network)"
+    GeneratePresignedURL:
+      method: post
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/object/{objectKey}/presignedUrl
+      description: "Generate a presigned URL for uploading  or downloading an object to an object storage (bucket)\n\n**Important Notes:**\n- The generated presigned URL can be used to upload the object directly without further authentication\n- The expiration time is specified in seconds (default: 3600 seconds)\n\n**Example Usage: Upload**\n```bash\n# Using the presigned URL to upload a file\ncurl -i -H \"Content-Type: text/plain\" -X PUT \"<PRESIGNED_URL>\" --data-binary \"@local-file.txt\"\n```\n\n**Example Usage: download**\n```bash\n# Using the presigned URL to download a file\ncurl -X GET \"<PRESIGNED_URL>\" -o downloaded-file.txt\n```"
+    GetReadyz:
+      method: get
+      resourcePath: /readyz
+      description: "Check Tumblebug is ready. Returns ready status and initialization status."
+    DeleteDataObjectLagacy:
+      method: delete
+      resourcePath: /resources/objectStorage/{objectStorageName}/{objectKey}
+      description: "(To be deprecated) Delete an object from a bucket"
+    GetDataObjectInfoLagacy:
+      method: head
+      resourcePath: /resources/objectStorage/{objectStorageName}/{objectKey}
+      description: "(To be deprecated) Get an object info from a bucket\n\n**Important Notes:**\n- The generated `Download file` link in Swagger UI may not work because this API get the object metadata only."
+    DeregisterSshKey:
+      method: delete
+      resourcePath: /ns/{nsId}/deregisterResource/sshKey/{sshKeyId}
+      description: "Deregister SSH Key from Spider and TB without deleting the actual CSP resource"
+    RemoveBastionNodes:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{infraId}/bastion/{bastionNodeId}
+      description: "Remove a bastion node from all vNets"
+    GetInfraNode:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}
+      description: "Get node in specified Infra"
+    DelInfraNode:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}
+      description: "Delete node in specified Infra"
+    GetNodeSshHostKey:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/sshHostKey
+      description: "Get the stored SSH host key information for a specific node. This is used for TOFU (Trust On First Use) verification."
+    DeleteNodeSshHostKey:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/sshHostKey
+      description: "Reset the stored SSH host key for a specific node. This should be used when the node's host key has legitimately changed (e.g., after node recreation) and you trust the new key. The next SSH connection will store the new host key (TOFU)."
     SearchImage:
       method: post
       resourcePath: /ns/{nsId}/resources/searchImage
-      description: Search image
-    SearchImageOptions:
+      description: "Search image"
+    GetSecurityGroup:
       method: get
-      resourcePath: /ns/{nsId}/resources/searchImageOptions
-      description: Get all available options for image search fields
+      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}
+      description: "Get Security Group"
+    PutSecurityGroup:
+      method: put
+      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}
+      description: "Update Security Group: Synchronize the firewall rules of the specified Security Group to match the requested list exactly.\nThis API will add missing rules and delete extra rules so that the Security Group's rules become identical to the requested set.\nOnly firewall rules are updated; other metadata (name, description, etc.) is not changed.\n\nUsage:\nUse this API to update (synchronize) the firewall rules of a Security Group. The rules in the request body will become the only rules in the Security Group after the operation.\n- All existing rules not present in the request will be deleted.\n- All rules in the request that do not exist will be added.\n- If a rule exists but differs in CIDR or port range, it will be replaced.\n- Special protocols (ICMP, etc.) are handled in the same way.\n\nNotes:\n- \"Ports\" field supports single port (\"22\"), port range (\"80-100\"), and multiple ports/ranges (\"22,80-100,443\").\n- The valid port number range is 0 to 65535 (inclusive).\n- \"Protocol\" can be TCP, UDP, ICMP, etc. (as supported by the cloud provider).\n- \"Direction\" must be either \"inbound\" or \"outbound\".\n- \"CIDR\" is the allowed IP range.\n- All existing rules not in the request (including default ICMP, etc.) will be deleted.\n- Metadata (name, description, etc.) is not changed."
+    DelSecurityGroup:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}
+      description: "Delete Security Group"
+    PutScheduleRegisterCspResourcesPause:
+      method: put
+      resourcePath: /registerCspResources/schedule/{jobId}/pause
+      description: "Temporarily pause a scheduled job without deleting it. The job can be resumed later.\nThis sets enabled=false and preserves all job state and execution history."
+    GetBenchmark:
+      method: post
+      resourcePath: /ns/{nsId}/benchmark/infra/{infraId}
+      description: "Run Infra benchmark for a single performance metric and return results"
+    PostDownloadFileFromInfraNode:
+      method: post
+      resourcePath: /ns/{nsId}/downloadFile/infra/{infraId}/node/{nodeId}
+      description: "Download a file from a specific node in Infra via SCP through bastion host.\nThe file size should be less than 200MB."
+    GetInfraGroupIds:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{infraId}/nodegroup
+      description: "List NodeGroup IDs in a specified Infra"
+    SetObjectStorageVersioning:
+      method: put
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/versioning
+      description: "Set versioning configuration of an object storage (bucket)\n\n**Note: **\n- Versioning options: \"Enabled\", \"Suspended\", \"Unversioned\"\n"
+    GetObjectStorageVersioning:
+      method: get
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/versioning
+      description: "Get versioning configuration of an object storage (bucket)"
+    FetchImagesAsync:
+      method: post
+      resourcePath: /fetchImagesAsync
+      description: "Fetch images in the background without waiting for completion.\n\n**Provider Selection Options:**\n- `targetProviders`: Specify exact providers to fetch (e.g., [\"aws\", \"gcp\"]). When set, only these providers are processed and `excludedProviders` is ignored.\n- `excludedProviders`: Specify providers to skip (e.g., [\"azure\"]). Only used when `targetProviders` is not set.\n- `regionAgnosticProviders`: Providers where images are shared across regions (e.g., [\"gcp\"]). Only one region will be fetched per provider.\n\n**Note:** `regionAgnosticProviders` should only contain providers that are also in `targetProviders` (or not excluded)."
+    GetAllNLB:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{infraId}/nlb
+      description: "List all NLBs or NLBs' ID"
+    PostNLB:
+      method: post
+      resourcePath: /ns/{nsId}/infra/{infraId}/nlb
+      description: "Create NLB"
+    DelAllNLB:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{infraId}/nlb
+      description: "Delete all NLBs"
+    PostRegisterSubnet:
+      method: post
+      resourcePath: /ns/{nsId}/registerCspResource/vNet/{vNetId}/subnet
+      description: "Register Subnet, which was created in CSP"
+    GetAllSqlDb:
+      method: get
+      resourcePath: /ns/{nsId}/resources/sqlDb
+      description: "Get all SQL Databases (TBD)"
+    PostSqlDb:
+      method: post
+      resourcePath: /ns/{nsId}/resources/sqlDb
+      description: "Create a SQL Databases\n\nSupported CSPs: AWS, Azure, GCP, NCP\n- Note - `connectionName` example: aws-ap-northeast-2, azure-koreacentral, gcp-asia-northeast3, ncp-kr\n\n- Note - Please check the `requiredCSPResource` property which includes CSP specific values.\n\n- Note - You can find the API usage examples on this link, https://github.com/cloud-barista/mc-terrarium/discussions/110\n"
+    GetSubnet:
+      method: get
+      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}
+      description: "Get Subnet"
+    DelSubnet:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}
+      description: "Delete Subnet\n---\n**action options:**\n\n**reconcile** – Synchronize Tumblebug metadata with the actual CSP state.\nChecks whether the Subnet resource still exists on CSP (via Spider).\nIf the CSP resource is gone, removes the orphaned Tumblebug metadata.\nIf the CSP resource still exists, keeps the metadata intact.\nUse this to clean up stale metadata after system errors or partial failures.\n(e.g., `DELETE /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}?action=reconcile`)\n\n**force** – Force-delete the Subnet on CSP (passes `?force=true` to Spider).\nUse this when normal deletion fails due to CSP-side constraints (e.g., resource in use).\n(e.g., `DELETE /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}?action=force`)"
+    PostConfig:
+      method: post
+      resourcePath: /config
+      description: "Create or Update config (TB_SPIDER_REST_URL, TB_DRAGONFLY_REST_URL, ...)"
+    InitAllConfig:
+      method: delete
+      resourcePath: /config
+      description: "Init all configs"
+    GetAllConfig:
+      method: get
+      resourcePath: /config
+      description: "List all configs"
+    GetCloudInfo:
+      method: get
+      resourcePath: /cloudInfo
+      description: "Get cloud information"
+    UpdateExistingSpecListByAvailableRegionZones:
+      method: post
+      resourcePath: /ns/{nsId}/updateExistingSpecListByAvailableRegionZones
+      description: "Query all specs for a specific provider across all regions, check their availability, and remove specs that are not available in their respective regions"
+    GetObjectStorageVersioningLagacy:
+      method: get
+      resourcePath: /resources/objectStorage/{objectStorageName}/versioning
+      description: "(To be deprecated) Get versioning status of an object storage (bucket)\n\n**Important Notes:**\n- The actual response will be XML format with root element `VersioningConfiguration`\n\n**Actual XML Response Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VersioningConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n<Status>Enabled</Status>\n</VersioningConfiguration>\n```"
+    SetObjectStorageVersioningLagacy:
+      method: put
+      resourcePath: /resources/objectStorage/{objectStorageName}/versioning
+      description: "(To be deprecated) Set versioning status of an object storage (bucket)\n\n**Important Notes:**\n- The request body must be XML format with root element `VersioningConfiguration`\n- The `Status` field can be either `Enabled` or `Suspended`\n\n**Request Body Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VersioningConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n<Status>Enabled</Status>\n</VersioningConfiguration>\n```"
     SetBastionNodes:
       method: put
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{targetVmId}/bastion/{bastionVmId}
-      description: Set bastion nodes for a VM
-    TestJWTAuth:
+      resourcePath: /ns/{nsId}/infra/{infraId}/node/{targetNodeId}/bastion/{bastionNodeId}
+      description: "Set bastion nodes for a node"
+    PostUtilToDesignVNet:
+      method: post
+      resourcePath: /util/vNet/design
+      description: "Design VNet and subnets based on user-friendly properties"
+    ForwardAnyReqToAny:
+      method: post
+      resourcePath: /forward/{path}
+      description: "Forward any (GET) request to CB-Spider"
+    GetBastionNodes:
       method: get
-      resourcePath: /auth/test
-      description: Test JWT authentication
+      resourcePath: /ns/{nsId}/infra/{infraId}/node/{targetNodeId}/bastion
+      description: "Get bastion nodes for a node"
+    GetGlobalDnsRecord:
+      method: get
+      resourcePath: /resources/globalDns/record
+      description: "Get DNS records for a domain from Route53. Includes routing policy and geoproximity info."
+    PutGlobalDnsRecord:
+      method: put
+      resourcePath: /resources/globalDns/record
+      description: "Update (UPSERT) a DNS record for a domain in Route53.\nSupports two routing policies: \"simple\" (default) and \"geoproximity\" (location-based).\nChoose exactly one IP source method in 'setBy':\n1. Infra ID (infraId): Fetch Public IPs of all nodes in the Infra.\n2. Label Selector (labelSelector): Fetch IPs of matching resources.\n3. Manual IP Values (values): Manually provide IP addresses (simple routing only)."
+    DeleteGlobalDnsRecord:
+      method: delete
+      resourcePath: /resources/globalDns/record
+      description: "Delete DNS record(s) from Route53. If setIdentifier is provided, deletes only that specific record.\nIf setIdentifier is empty, deletes all records matching the name and type."
+    PostFileAndCmdToInfra:
+      method: post
+      resourcePath: /ns/{nsId}/transferFileAndCmd/infra/{infraId}
+      description: "Transfer a file to all targeted nodes in Infra via SCP, then optionally run a shell command on each node where the transfer succeeded.\nUseful for deploying files directly to privileged locations (e.g., nginx document root) in a single API call.\nExample: upload index.html to /tmp and run \"sudo mv /tmp/index.html /var/www/html/\" as the post-transfer command.\nThe file size should be less than 50MB."
+    GetInfraReqFromInfra:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{infraId}/configCopy
+      description: "Reconstruct an Infra dynamic creation request body from an existing Infra's information.\nReturns a dynamic request format where networking resources (vNet, subnet, SG, sshKey)\nare auto-created, making it easy to clone or recreate a similar Infra configuration.\n\n**Template Option:**\nWhen the `template` query parameter is provided, the extracted configuration is\nsaved as a reusable Infra Dynamic Template with the given name."
+    GetSitesInInfra:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{infraId}/site
+      description: "Get sites in Infra"
+    GetInfraPolicy:
+      method: get
+      resourcePath: /ns/{nsId}/policy/infra/{infraId}
+      description: "Get Infra Policy"
+    PostInfraPolicy:
+      method: post
+      resourcePath: /ns/{nsId}/policy/infra/{infraId}
+      description: "Create Infra Automation policy"
+    DelInfraPolicy:
+      method: delete
+      resourcePath: /ns/{nsId}/policy/infra/{infraId}
+      description: "Delete Infra Policy"
+    DeleteAllVNetTemplate:
+      method: delete
+      resourcePath: /ns/{nsId}/template/vNet
+      description: "Delete all vNet Templates in a namespace."
+    GetAllVNetTemplate:
+      method: get
+      resourcePath: /ns/{nsId}/template/vNet
+      description: "List all vNet Templates in a namespace.\nOptionally filter by keyword matching against template name or description (case-insensitive)."
+    PostVNetTemplate:
+      method: post
+      resourcePath: /ns/{nsId}/template/vNet
+      description: "Create a reusable vNet Template. Templates store vNet creation\nrequest configurations that can be applied later to create vNets with consistent settings.\n\n**Template Contents:**\n- Connection name (cloud provider and region)\n- CIDR block configuration\n- Subnet definitions (names, CIDR blocks, zones)\n- Description\n\nTemplates can be created manually with desired vNet configurations."
+    GetHostedZones:
+      method: get
+      resourcePath: /resources/globalDns/hostedZone
+      description: "List all hosted zones available in Route53"
+    PostUtilToDesignNetwork:
+      method: post
+      resourcePath: /util/net/design
+      description: "Design a hierarchical network configuration of a VPC network or multi-cloud network consisting of multiple VPC networks"
+    GetSystemLabelInfo:
+      method: get
+      resourcePath: /labelInfo
+      description: "Return LabelTypes and system defined label keys with example"
+    DeleteDeregisterVNet:
+      method: delete
+      resourcePath: /ns/{nsId}/deregisterResource/vNet/{vNetId}
+      description: "Deregister the VNet, which was created in CSP"
+    GetK8sCluster:
+      method: get
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}
+      description: "Get K8sCluster"
+    DeleteK8sCluster:
+      method: delete
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}
+      description: "Delete K8sCluster"
+    DelAllSharedResources:
+      method: delete
+      resourcePath: /ns/{nsId}/sharedResources
+      description: "Delete all Default Resource Objects in the given namespace"
+    GetResourcesByLabelSelector:
+      method: get
+      resourcePath: /resources/{labelType}
+      description: "Get resources based on a label selector. The label selector supports the following operators:\n- `=` : Selects resources where the label key equals the specified value (e.g., `env=production`).\n- `!=` : Selects resources where the label key does not equal the specified value (e.g., `tier!=frontend`).\n- `in` : Selects resources where the label key is in the specified set of values (e.g., `region in (us-west, us-east)`).\n- `notin` : Selects resources where the label key is not in the specified set of values (e.g., `env notin (production, staging)`).\n- `exists` : Selects resources where the label key exists (e.g., `env exists`).\n- `!exists` : Selects resources where the label key does not exist (e.g., `env !exists`)."
+    RegisterCredential:
+      method: post
+      resourcePath: /credential
+      description: "This API registers credential information using hybrid encryption. The process involves compressing and encrypting sensitive data with AES-256, encrypting the AES key with a 4096-bit RSA public key (retrieved via `GET /credential/publicKey`), and using OAEP padding with SHA-256. All values, including the AES key, must be base64 encoded before sending, and the public key token ID must be included in the request."
+    PostK8sNodeGroupDynamic:
+      method: post
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroupDynamic
+      description: "Create K8sNodeGroup Dynamically from common spec and image"
+    FilterSpecsByRange:
+      method: post
+      resourcePath: /ns/{nsId}/resources/filterSpecsByRange
+      description: "Filter specs by range. Use limit field to control the maximum number of results. If limit is 0 or not specified, returns all matching results."
+    CreateSharedResource:
+      method: post
+      resourcePath: /ns/{nsId}/sharedResource
+      description: "Create shared resources for MC-Infra"
+    GetAllInfraDynamicTemplate:
+      method: get
+      resourcePath: /ns/{nsId}/template/infra
+      description: "List all Infra Dynamic Templates in a namespace.\nOptionally filter by keyword matching against template name or description (case-insensitive)."
+    PostInfraDynamicTemplate:
+      method: post
+      resourcePath: /ns/{nsId}/template/infra
+      description: "Create a reusable Infra Dynamic Template. Templates store Infra dynamic creation\nrequest configurations that can be applied later to create Infras with consistent settings.\n\n**Template Contents:**\n- node specifications (specId, imageId) for each nodegroup\n- NodeGroup sizing and naming\n- Network and disk configuration\n- Post-deployment commands\n- Monitoring agent options\n\nTemplates can be created manually or extracted from existing Infras."
+    DeleteAllInfraDynamicTemplate:
+      method: delete
+      resourcePath: /ns/{nsId}/template/infra
+      description: "Delete all Infra Dynamic Templates in a namespace."
+    RegisterCspNativeResources:
+      method: post
+      resourcePath: /registerCspResources
+      description: "Register CSP Native Resources (vNet, securityGroup, sshKey, node) to CB-Tumblebug.\n\n**New filtering approach (recommended):**\n- Provider only: Registers resources from all connections of the specified provider\n- Provider + Region: Registers resources from all zones within the region\n- Provider + Region + Zone: Registers resources from specific zone\n- All empty: Registers resources from **all available connections**\n\n**Backward compatibility:**\n- `connectionName` is still supported but deprecated. Use provider/region/zone instead.\n\n**Usage Examples:**\n- All AWS: `{\"provider\": \"aws\", \"nsId\": \"default\"}`\n- AWS Seoul region: `{\"provider\": \"aws\", \"region\": \"ap-northeast-2\", \"nsId\": \"default\"}`\n- AWS Seoul zone 2a: `{\"provider\": \"aws\", \"region\": \"ap-northeast-2\", \"zone\": \"ap-northeast-2a\", \"nsId\": \"default\"}`\n- All connections: `{\"nsId\": \"default\", \"infraNamePrefix\": \"infra-all\"}`\n- Single connection (deprecated): `{\"connectionName\": \"aws-ap-northeast-2\", \"nsId\": \"default\"}`"
+    BulkDeleteGlobalDnsRecord:
+      method: delete
+      resourcePath: /resources/globalDns/records
+      description: "Delete multiple DNS records from Route53 in a single request.\nRecords are grouped by domain and submitted as a single ChangeBatch per domain for efficiency."
+    GetLabels:
+      method: get
+      resourcePath: /label/{labelType}/{uid}
+      description: "Get labels for a resource identified by its uid"
+    CreateOrUpdateLabel:
+      method: put
+      resourcePath: /label/{labelType}/{uid}
+      description: "Create or update a label for a resource identified by its uid"
+    PostBuildAgnosticImage:
+      method: post
+      resourcePath: /ns/{nsId}/buildAgnosticImage
+      description: "Creates an Infra infrastructure, executes post-deployment commands, creates snapshots from each nodegroup, and optionally cleans up the Infra. This is a complete workflow for building CSP-agnostic custom images."
+    GetInfraAssociatedResources:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{infraId}/associatedResources
+      description: "Get associated resource ID list for a given Infra (VNet, Subnet, SecurityGroup, SSHKey, etc.)"
+    SetBastionNodesWithInfra:
+      method: put
+      resourcePath: /ns/{nsId}/infra/{infraId}/node/{targetNodeId}/bastion/{bastionInfraId}/{bastionNodeId}
+      description: "Set bastion nodes for a target node, specifying a bastion node that belongs to a different Infra within the same namespace (cross-Infra bastion). This allows, for example, an AWS node to serve as a bastion for an OpenStack node."
+    PutMonitorAgentStatusInstalled:
+      method: put
+      resourcePath: /ns/{nsId}/monitoring/status/infra/{infraId}/node/{nodeId}
+      description: "Set monitoring agent (CB-Dragonfly agent) installation status installed (for Windows node only)"
+    RemoveBastionNodesWithNs:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{infraId}/bastion/{bastionNsId}/{bastionInfraId}/{bastionNodeId}
+      description: "Remove a specific cross-namespace bastion from all vNets of the target Infra"
+    PutUpgradeK8sCluster:
+      method: put
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/upgrade
+      description: "Upgrade a K8sCluster's version"
+    DeleteDataObject:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/object/{objectKey}
+      description: "Delete an object from an object storage (bucket)"
+    GetDataObjectInfo:
+      method: head
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/object/{objectKey}
+      description: "Get object info from an object storage (bucket)\n\n**Important Notes:**\n- This API retrieves the metadata of an object without downloading the actual content\n- Returns metadata in response headers (Content-Length, Content-Type, ETag, Last-Modified)"
+    GetNLB:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{infraId}/nlb/{nlbId}
+      description: "Get NLB"
+    DelNLB:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{infraId}/nlb/{nlbId}
+      description: "Delete NLB"
+    GetAllK8sCluster:
+      method: get
+      resourcePath: /ns/{nsId}/k8sCluster
+      description: "List all K8sClusters or K8sClusters' ID"
+    PostK8sCluster:
+      method: post
+      resourcePath: /ns/{nsId}/k8sCluster
+      description: "Create K8sCluster<br>Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1614"
+    DeleteAllK8sCluster:
+      method: delete
+      resourcePath: /ns/{nsId}/k8sCluster
+      description: "Delete all K8sClusters"
+    GetExecutionTask:
+      method: get
+      resourcePath: /ns/{nsId}/cmd/infra/{infraId}/task/{taskId}
+      description: "Get detailed information about a specific execution task by taskId"
+    GetControlK8sCluster:
+      method: get
+      resourcePath: /ns/{nsId}/control/k8sCluster/{k8sClusterId}
+      description: "Control the creation of K8sCluster (continue, withdraw)"
+    CheckHTTPVersion:
+      method: get
+      resourcePath: /httpVersion
+      description: "Checks and logs the HTTP version of the incoming request to the server console."
+    InspectResourcesOverview:
+      method: get
+      resourcePath: /inspectResourcesOverview
+      description: "Inspect Resources Overview (vNet, securityGroup, sshKey, node) registered in CB-Tumblebug and CSP for all connections"
+    GetAvailableZonesForSpec:
+      method: get
+      resourcePath: /availableZonesForSpec
+      description: "Query verified zones for a spec based on connection configs. Returns zones that are both verified and available for the specified spec. For Alibaba Cloud, additional CSP API filtering is applied."
+    ComplementSshKeyRemoteCommand:
+      method: put
+      resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}/complement
+      description: "Update username and privateKey to enable remote command execution on registered nodes"
+    GetCustomImage:
+      method: get
+      resourcePath: /ns/{nsId}/resources/customImage/{customImageId}
+      description: "Get customImage"
+    DelCustomImage:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/customImage/{customImageId}
+      description: "Delete customImage"
+    PostFirewallRules:
+      method: post
+      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}/rules
+      description: "Add new FirewallRules: Add the provided firewall rules to the existing rules in the Security Group.\nThis API will only add new rules without deleting or modifying existing ones.\nIf a rule with identical properties already exists, it will be skipped to avoid duplicates.\n\nUsage:\nUse this API to add new firewall rules to a Security Group while preserving existing rules.\n- Only new rules that don't already exist will be added.\n- Existing rules remain unchanged.\n- If an identical rule already exists, it will be skipped.\n\nNotes:\n- \"Ports\" field supports single port (\"22\"), port range (\"80-100\"), and multiple ports/ranges (\"22,80-100,443\").\n- The valid port number range is 0 to 65535 (inclusive).\n- \"Protocol\" can be TCP, UDP, ICMP, ALL, etc. (as supported by the cloud provider).\n- \"Direction\" must be either \"inbound\" or \"outbound\".\n- \"CIDR\" is the allowed IP range."
+    DelFirewallRules:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}/rules
+      description: "Delete specific FirewallRules: Remove specified rules from the Security Group while keeping other existing rules.\nThis API will remove only the specified rules from the Security Group, leaving all other rules intact.\n\nUsage:\nUse this API to remove specific firewall rules from a Security Group. Only the rules matching the provided criteria will be deleted.\n- Rules that exactly match the provided Direction, Protocol, Port, and CIDR will be removed.\n- All other existing rules will remain unchanged.\n\nNotes:\n- \"Ports\" field supports single port (\"22\"), port range (\"80-100\"), and multiple ports/ranges (\"22,80-100,443\").\n- \"Protocol\" can be TCP, UDP, ICMP, ALL, etc. (as supported by the cloud provider).\n- \"Direction\" must be either \"inbound\" or \"outbound\".\n- \"CIDR\" is the allowed IP range."
+    GetRegion:
+      method: get
+      resourcePath: /provider/{providerName}/region/{regionName}
+      description: "Get registered region info"
+    AnalyzeProvisioningRisk:
+      method: get
+      resourcePath: /provisioning/risk/{specId}
+      description: "Evaluate the likelihood of provisioning failure based on historical data for a specific node specification and image combination.\nThis endpoint provides intelligent risk assessment to help prevent deployment failures:\n\n**Risk Analysis Factors:**\n- Historical failure rate for the node specification\n- Image-specific compatibility with the spec\n- Recent failure patterns and trends\n- Cross-reference of spec+image combination success rates\n\n**Risk Levels:**\n- `high`: Very likely to fail (>80% failure rate or image-specific failures)\n- `medium`: Moderate risk (50-80% failure rate or mixed results)\n- `low`: Low risk (<50% failure rate or no previous failures)\n- `unknown`: Insufficient data for analysis\n\n**Recommended Actions by Risk Level:**\n- **High Risk**: Consider alternative specs or images, verify CSP quotas and permissions\n- **Medium Risk**: Proceed with caution, have backup plans ready\n- **Low Risk**: Safe to proceed with normal deployment\n\n**Integration Points:**\n- Automatically called during Infra review process\n- Can be used in CI/CD pipelines for deployment validation\n- Helpful for capacity planning and resource selection"
+    GetAvailableRegionZonesForSpec:
+      method: post
+      resourcePath: /availableRegionZonesForSpec
+      description: "Query the availability of a specific spec across all regions/zones"
+    PutDataDisk:
+      method: put
+      resourcePath: /ns/{nsId}/resources/dataDisk/{dataDiskId}
+      description: "Upsize Data Disk"
+    DelDataDisk:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/dataDisk/{dataDiskId}
+      description: "Delete Data Disk"
+    GetDataDisk:
+      method: get
+      resourcePath: /ns/{nsId}/resources/dataDisk/{dataDiskId}
+      description: "Get Data Disk"
+    ListDataObjects:
+      method: get
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/object
+      description: "List all objects in an object storage (bucket)"
+    GetObjects:
+      method: get
+      resourcePath: /objects
+      description: "List all objects for a given key"
+    DeleteObjects:
+      method: delete
+      resourcePath: /objects
+      description: "Delete child objects along with the given object"
+    GetProviderList:
+      method: get
+      resourcePath: /provider
+      description: "List all registered Providers"
     UpdateImagesFromAsset:
       method: post
       resourcePath: /updateImagesFromAsset
-      description: Update image information based on the cloudimage.csv asset file
+      description: "Update image information based on the cloudimage.csv asset file"
+    InspectResources:
+      method: post
+      resourcePath: /inspectResources
+      description: "Inspect Resources (vNet, securityGroup, sshKey, node) registered in CB-Tumblebug, CB-Spider, CSP"
+    RemoveBastionNodesWithInfra:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{infraId}/bastion/{bastionInfraId}/{bastionNodeId}
+      description: "Remove a specific cross-Infra bastion from all vNets of the target Infra"
+    GetObjectStorageSupport:
+      method: get
+      resourcePath: /objectStorage/support
+      description: "Get CSP support information for object storage features (CORS, Versioning)\nIf cspType query parameter is provided, returns support information for that specific CSP\nIf cspType is not provided, returns support information for all CSPs"
+    RecommendAlternativeNodeConfig:
+      method: post
+      resourcePath: /recommendAlternativeNodeConfig
+      description: "Given a nodegroup configuration (source spec + image), find the best-matching\nspec and image combinations in a target CSP/region.\nPer-field match policies (required / preferred / open) give fine-grained control over\nwhich attributes must match exactly, which may vary within a tolerance, and which are ignored.\nSimilarity scores (0–100) are computed from \"preferred\" fields only."
+    PostSpecImagePairReview:
+      method: post
+      resourcePath: /specImagePairReview
+      description: "Validate whether a spec and image pair is compatible for node provisioning.\nThis lightweight API checks:\n- Spec availability in DB and CSP\n- Image availability in DB and CSP (auto-registers if found in CSP but not in DB)\n- Cost estimation based on spec\n\n**Use Cases:**\n- Quick validation before node creation\n- Pre-check for dynamic provisioning\n- Verify custom image IDs entered by user"
+    CheckK8sNodeGroupsOnK8sCreation:
+      method: get
+      resourcePath: /checkK8sNodeGroupsOnK8sCreation
+      description: "Check whether nodegroups are required during the K8sCluster creation"
+    MergeCSPResourceLabel:
+      method: put
+      resourcePath: /mergeCSPLabel/{labelType}/{uid}
+      description: "Fetch the labels in the CSP and merge them with the existing labels"
+    PutNs:
+      method: put
+      resourcePath: /ns/{nsId}
+      description: "Update namespace"
+    DelNs:
+      method: delete
+      resourcePath: /ns/{nsId}
+      description: "Delete namespace"
+    GetNs:
+      method: get
+      resourcePath: /ns/{nsId}
+      description: "Get namespace"
+    GetRequestStatusOfSiteToSiteVpn:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{infraId}/vpn/{vpnId}/request/{requestId}
+      description: "Check the status of a specific request by its ID"
+    PostInstallBenchmarkAgentToInfra:
+      method: post
+      resourcePath: /ns/{nsId}/installBenchmarkAgent/infra/{infraId}
+      description: "Install the benchmark agent to specified Infra"
+    GetAllDataDisk:
+      method: get
+      resourcePath: /ns/{nsId}/resources/dataDisk
+      description: "List all Data Disks or Data Disks' ID"
+    PostDataDisk:
+      method: post
+      resourcePath: /ns/{nsId}/resources/dataDisk
+      description: "Create Data Disk"
+    DelAllDataDisk:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/dataDisk
+      description: "Delete all Data Disks"
+    GetScheduleRegisterCspResourcesList:
+      method: get
+      resourcePath: /registerCspResources/schedule
+      description: "Get a list of all scheduled CSP resource registration jobs (jobs are not scoped to namespaces)"
+    PostScheduleRegisterCspResources:
+      method: post
+      resourcePath: /registerCspResources/schedule
+      description: "Create a scheduled job to periodically register CSP-native resources (vNet, securityGroup, sshKey, node) into CB-Tumblebug\n\n**Resource Registration Behavior:**\nThis job registers CSP-native resources based on the `connectionName` field:\n- If `connectionName` is specified: Registers resources from the **specified connection only**\n- If `connectionName` is empty or omitted: Registers resources from **all available connections**\n\n**Usage Examples:**\n- Single connection: `{\"jobType\": \"registerCspResources\", \"nsId\": \"default\", \"intervalSeconds\": 60, \"connectionName\": \"aws-ap-northeast-2\", \"infraNamePrefix\": \"infra-01\"}`\n- All connections: `{\"jobType\": \"registerCspResources\", \"nsId\": \"default\", \"intervalSeconds\": 60, \"connectionName\": \"\", \"infraNamePrefix\": \"infra-all\"}` or `{\"jobType\": \"registerCspResources\", \"nsId\": \"default\", \"intervalSeconds\": 60, \"infraNamePrefix\": \"infra-all\"}`\n\n**Job Status Values:**\n- `Scheduled`: Job is scheduled and waiting for the next execution time\n- `Executing`: Job is currently running the task\n- `Stopped`: Job has been stopped and deleted\n\n**Job Lifecycle:**\n1. Create job (this API) → Status: `Scheduled`, **executes immediately**\n2. First execution starts → Status: `Executing`\n3. Execution completes → Status: `Scheduled` (waits for interval)\n4. After interval → Status: `Executing` (cycles back to step 3)\n5. Pause job → `enabled: false`, Status: `Scheduled` (no execution)\n6. Resume job → `enabled: true`, Status: `Scheduled` (resumes execution)\n7. Delete job → Status: `Stopped`, job removed permanently\n\n**Failure Handling:**\n- Tracks `successCount`, `failureCount`, `consecutiveFailures`\n- Auto-disables after 5 consecutive failures (`autoDisabled: true`)\n- Auto-recovers when next execution succeeds\n\n**Timeout Protection:**\n- Default execution timeout: 30 minutes\n- Jobs exceeding timeout are marked as failed\n- Server restart during execution marks job as interrupted\n\n**Duplicate Prevention:**\n- System checks for existing jobs with same configuration\n- Configuration uniqueness based on: jobType + nsId + connectionName + infraNamePrefix + option + infraFlag\n- Returns 409 Conflict if duplicate job exists with existing job ID"
+    DeleteScheduleRegisterCspResourcesAll:
+      method: delete
+      resourcePath: /registerCspResources/schedule
+      description: "⚠️ **DANGER: This operation deletes ALL scheduled jobs in the system!**\n\n**⚠️ CRITICAL WARNINGS:**\n- This will PERMANENTLY DELETE **ALL** scheduled jobs across all namespaces\n- All job execution history will be lost\n- This operation is IRREVERSIBLE and cannot be undone\n- Use with EXTREME CAUTION in production environments\n\n**Use Cases:**\n- Cleaning up test/development environments\n- Emergency shutdown of all scheduled operations\n- System maintenance or reset\n\n**Safer Alternatives:**\n- Delete individual jobs: Use `DELETE /registerCspResources/schedule/{jobId}`\n- Temporarily stop all jobs: Pause each job individually via `/pause` endpoint\n- Disable without deleting: Update each job with `enabled: false`\n\n**Response Information:**\n- Returns the count of deleted jobs\n- Returns 200 even if no jobs were found (count will be 0)"
+    GetInfraClusters:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{infraId}/cluster
+      description: "List implicit clusters synthesized at query-time from NodeGroups/Nodes in a specified Infra"
+    PostK8sMultiClusterDynamic:
+      method: post
+      resourcePath: /ns/{nsId}/k8sMultiClusterDynamic
+      description: "(PoC API. For developers only, and do not use in production.)\nCreate multiple K8sClusters in parallel from common spec and image.\nIf namePrefix is provided, cluster names will be auto-generated as '{namePrefix}-{csp}-{number}' (e.g., 'across-aws-1', 'across-alibaba-2').\n\nIf namePrefix is not provided, each cluster must have a name specified.\n\n**Example request body:**\n```json\n{\n\"namePrefix\": \"across\",\n\"clusters\": [\n{\n\"imageId\": \"default\",\n\"specId\": \"aws+eu-west-2+t3a.xlarge\"\n},\n{\n\"nodeGroupName\": \"ng-1\",\n\"imageId\": \"default\",\n\"specId\": \"azure+germanywestcentral+standard_b4ms\"\n},\n{\n\"nodeGroupName\": \"ng-1\",\n\"imageId\": \"https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2204-jammy-v20251120\",\n\"specId\": \"gcp+europe-west9+e2-highmem-4\"\n}\n]\n}\n```"
+    RegisterCspNativeResourcesAll:
+      method: post
+      resourcePath: /registerCspResourcesAll
+      description: "**DEPRECATED**: This endpoint is deprecated. Please use `/registerCspResources` with empty `connectionName` instead.\n\nThis endpoint now redirects to `/registerCspResources` for unified API behavior.\n\n**Migration Guide:**\n- Old: `POST /registerCspResourcesAll` with `{\"nsId\": \"default\", \"infraNamePrefix\": \"infra-all\"}`\n- New: `POST /registerCspResources` with `{\"connectionName\": \"\", \"nsId\": \"default\", \"infraNamePrefix\": \"infra-all\"}`"
+    PostSystemInfra:
+      method: post
+      resourcePath: /systemInfra
+      description: "Create specialized Infra instances for CB-Tumblebug system operations and infrastructure probing.\nThis endpoint provisions system-level infrastructure that supports CB-Tumblebug's internal functions:\n\n**System Infra Types:**\n- `probe`: Creates lightweight nodes for network connectivity testing and CSP capability discovery\n- `monitor`: Deploys monitoring infrastructure for system health and performance tracking\n- `test`: Provisions test environments for validating CSP integrations and features\n\n**Probe Infra Features:**\n- **Connectivity Testing**: Validates network paths between different CSP regions\n- **Latency Measurement**: Measures inter-region and inter-provider network performance\n- **Feature Discovery**: Tests CSP-specific capabilities and service availability\n- **Resource Validation**: Verifies that CB-Tumblebug can successfully provision resources\n\n**System Namespace:**\n- All system Infras are created in the special `system` namespace\n- Isolated from user workloads and regular Infra operations\n- Managed automatically by CB-Tumblebug internal processes\n- May be used for background maintenance and monitoring tasks\n\n**Automatic Configuration:**\n- Uses optimized node specifications for system tasks (typically minimal resources)\n- Automatically selects appropriate regions and providers based on probe requirements\n- Configures necessary network access and security policies\n- Deploys with minimal attack surface and security hardening\n\n**Lifecycle Management:**\n- System Infras may be automatically created, updated, or destroyed by CB-Tumblebug\n- Typically short-lived for specific system tasks\n- Resource cleanup is handled automatically\n- Status and results are logged for system administrators\n\n**Use Cases:**\n- Infrastructure health checks and validation\n- Performance benchmarking across cloud providers\n- Automated testing of new CSP integrations\n- Network topology discovery and optimization"
+    AnalyzeProvisioningRiskDetailed:
+      method: get
+      resourcePath: /tumblebug/provisioning/risk/detailed
+      description: "Provides comprehensive risk analysis with separate assessments for node specification and image risks, plus actionable recommendations.\nThis endpoint offers enhanced risk analysis by separating spec-level and image-level risk factors:\n\n**Risk Analysis Breakdown:**\n- **Spec Risk**: Analyzes whether the node specification itself has compatibility or resource issues\n- **Image Risk**: Evaluates the track record of the specific image with this spec\n- **Overall Risk**: Combines both factors to determine the primary risk source\n- **Recommendations**: Provides actionable guidance based on risk analysis\n\n**Spec Risk Factors:**\n- Number of different images that failed with this spec (indicates spec-level issues)\n- Overall failure rate across all images\n- Success/failure ratio with various images\n\n**Image Risk Factors:**\n- Previous success/failure history of this specific image with this spec\n- Whether this is a new, untested combination\n\n**Recommendation Types:**\n- Change node specification (when spec is the primary risk factor)\n- Try different image (when image is the primary risk factor)\n- Monitor deployment closely (for new combinations or medium risk)\n- Proceed with confidence (for low-risk combinations)"
+    DeregisterCustomImage:
+      method: delete
+      resourcePath: /ns/{nsId}/deregisterResource/customImage/{customImageId}
+      description: "Deregister customImage from Spider and TB without deleting the actual CSP resource"
+    GetInfraCluster:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{infraId}/cluster/{clusterId}
+      description: "Get a single implicit cluster synthesized at query-time from NodeGroups/Nodes in a specified Infra"
+    GetVNet:
+      method: get
+      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}
+      description: "Get VNet"
+    DelVNet:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}
+      description: "Delete VNet\n---\n**action options:**\n\n**withsubnets** – Delete the VNet together with all its subnets in a single call.\n\n**reconcile** – Synchronize Tumblebug metadata with the actual CSP state.\nChecks whether the VNet/Subnet resource still exists on CSP (via Spider).\nIf the CSP resource is gone, removes the orphaned Tumblebug metadata.\nIf the CSP resource still exists, keeps the metadata intact.\nUse this to clean up stale metadata after system errors or partial failures.\n(e.g., `DELETE /ns/{nsId}/resources/vNet/{vNetId}?action=reconcile`)\n\n**force** – Force-delete the VNet and its subnets on CSP (passes `?force=true` to Spider).\nUse this when normal deletion fails due to CSP-side constraints (e.g., resource in use).\n(e.g., `DELETE /ns/{nsId}/resources/vNet/{vNetId}?action=force`)"
+    LookupImageList:
+      method: post
+      resourcePath: /lookupImages
+      description: "Lookup image list (for debugging purposes)"
+    GetSecurityGroupTemplate:
+      method: get
+      resourcePath: /ns/{nsId}/template/securityGroup/{templateId}
+      description: "Retrieve a specific SecurityGroup Template by ID."
+    PutSecurityGroupTemplate:
+      method: put
+      resourcePath: /ns/{nsId}/template/securityGroup/{templateId}
+      description: "Update an existing SecurityGroup Template."
+    DeleteSecurityGroupTemplate:
+      method: delete
+      resourcePath: /ns/{nsId}/template/securityGroup/{templateId}
+      description: "Delete a specific SecurityGroup Template."
+    GetConnConfigList:
+      method: get
+      resourcePath: /connConfig
+      description: "List all registered ConnConfig"
+    PostInfraNodeGroupDynamic:
+      method: post
+      resourcePath: /ns/{nsId}/infra/{infraId}/nodeGroupDynamic
+      description: "Dynamically add new virtual machines to an existing Infra using common specifications and automated resource management.\nThis endpoint provides elastic scaling capabilities for running Infras:\n\n**Dynamic node Addition Process:**\n1. **Infra Validation**: Verifies target Infra exists and is in a valid state for expansion\n2. **Resource Discovery**: Resolves common spec and image to provider-specific resources\n3. **Network Integration**: Automatically configures new nodes to use existing Infra network resources\n4. **NodeGroup Management**: Creates new nodegroups or expands existing ones based on configuration\n5. **Status Synchronization**: Updates Infra status and metadata to reflect new node additions\n\n**Integration with Existing Infrastructure:**\n- **Network Reuse**: New nodes automatically join existing VNets and security groups\n- **SSH Key Sharing**: Uses existing SSH keys for consistent access management\n- **Monitoring Integration**: New nodes inherit monitoring configuration from parent Infra\n- **Label Propagation**: Applies Infra-level labels and policies to new nodes\n- **Resource Consistency**: Maintains naming conventions and resource organization\n\n**Scaling Scenarios:**\n- **Horizontal Scaling**: Add more instances to handle increased workload\n- **Multi-Region Expansion**: Deploy nodes in new regions while maintaining Infra cohesion\n- **Provider Diversification**: Add nodes from different cloud providers for redundancy\n- **Workload Specialization**: Deploy nodes with different specifications for specific tasks\n\n**Configuration Requirements:**\n- `specId`: Must specify valid node specification from system namespace\n- `imageId`: Must specify valid image compatible with target provider/region\n- `name`: Becomes nodegroup name; nodes will be named with sequential suffixes\n- `nodeGroupSize`: Number of identical nodes to create (default: 1)\n\n**Network and Security:**\n- New nodes automatically inherit security group rules from existing Infra\n- Network connectivity to existing nodes is established automatically\n- Firewall rules and access policies are applied consistently\n- SSH access is configured using existing key pairs\n\n**Example Use Cases:**\n- Scale out web tier during traffic spikes\n- Add GPU instances for machine learning workloads\n- Deploy edge nodes in additional geographic regions\n- Add specialized storage or database nodes to existing application stack\n\n**Post-Addition Operations:**\n- New nodes are immediately available for standard Infra operations\n- Can be individually managed or grouped with existing nodegroups\n- Monitoring and logging are automatically configured\n- Application deployment and configuration management can proceed immediately"
+    GetInfraGroupNodes:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{infraId}/nodegroup/{nodegroupId}
+      description: "List nodes with a NodeGroup label in a specified Infra"
+    PostInfraNodeGroupScaleOut:
+      method: post
+      resourcePath: /ns/{nsId}/infra/{infraId}/nodegroup/{nodegroupId}
+      description: "Horizontally scale an existing node nodegroup by adding more identical instances for increased capacity.\nThis endpoint provides elastic scaling capabilities for running application tiers:\n\n**Scale-Out Process:**\n1. **NodeGroup Validation**: Verifies target nodegroup exists and is in scalable state\n2. **Template Replication**: Uses existing node configuration as template for new instances\n3. **Resource Allocation**: Ensures sufficient CSP quotas and network resources\n4. **Parallel Deployment**: Deploys multiple new nodes simultaneously for faster scaling\n5. **Integration**: Seamlessly integrates new nodes into existing nodegroup and Infra\n\n**Configuration Inheritance:**\n- **node Specifications**: New nodes inherit exact specifications from existing nodegroup members\n- **Network Settings**: Automatically placed in same VNet, subnet, and security groups\n- **SSH Keys**: Use same SSH key pairs for consistent access management\n- **Monitoring**: Inherit monitoring agent configuration and policies\n- **Labels and Metadata**: Propagate all labels and metadata from parent nodegroup\n\n**Scaling Scenarios:**\n- **Traffic Spikes**: Quickly add capacity during high-demand periods\n- **Seasonal Scaling**: Scale out for predictable demand increases\n- **Performance Optimization**: Add instances to reduce per-node resource utilization\n- **Geographic Expansion**: Scale existing workloads to handle broader user base\n- **Fault Tolerance**: Increase redundancy by adding more instances\n\n**Intelligent Scaling:**\n- **Sequential Naming**: New nodes follow established naming pattern (e.g., web-4, web-5, web-6)\n- **Load Distribution**: New nodes are distributed optimally across availability zones\n- **Resource Efficiency**: Reuses existing network and security infrastructure\n- **Minimal Disruption**: Scaling occurs without affecting existing node operations\n- **Consistent Configuration**: Ensures all nodes in nodegroup remain homogeneous\n\n**Operational Benefits:**\n- **Zero Downtime**: Existing nodes continue running during scale-out operation\n- **Immediate Availability**: New nodes are ready for traffic as soon as deployment completes\n- **Unified Management**: All nodes (old and new) managed through single nodegroup\n- **Policy Consistency**: All scaling and management policies apply uniformly\n- **Monitoring Integration**: New nodes automatically included in existing monitoring dashboards\n\n**Scale-Out Considerations:**\n- **CSP Quotas**: Verifies sufficient instance, network, and storage quotas\n- **Region Capacity**: Ensures target region has capacity for requested instance types\n- **Network Limits**: Validates that VNet can accommodate additional nodes\n- **Cost Impact**: Additional nodes incur proportional CSP billing costs\n- **Application Readiness**: Applications should be designed to handle additional instances\n\n**Post-Scale Operations:**\n- New nodes immediately participate in nodegroup operations\n- Can be individually managed while maintaining nodegroup membership\n- Support for further scaling operations (scale-out or scale-in)\n- Ready for application deployment and load balancer integration\n\n**Best Practices:**\n- Monitor application performance before and after scaling\n- Ensure load balancers are configured to include new instances\n- Verify application clustering and session management handle new instances\n- Consider database connection limits and other resource constraints"
+    RecordProvisioningEvent:
+      method: post
+      resourcePath: /provisioning/event
+      description: "Manually record a provisioning success or failure event for historical tracking and analysis.\nThis endpoint allows external systems or manual processes to contribute to provisioning history:\n\n**Use Cases:**\n- **External Provisioning Tools**: Record events from non-CB-Tumblebug provisioning systems\n- **Manual Testing**: Log results from manual deployment tests\n- **Migration**: Import historical data from other systems\n- **Integration**: Connect with CI/CD pipelines for comprehensive tracking\n\n**Event Types:**\n- **Success Events**: Only recorded if previous failures exist for the spec\n- **Failure Events**: Always recorded to build failure pattern database\n\n**Data Quality:**\n- Provide accurate timestamps for proper chronological analysis\n- Include detailed error messages for failure events\n- Use consistent spec ID and image name formats\n\n**Impact on System:**\n- Contributes to risk analysis algorithms\n- Affects future Infra review recommendations\n- Builds historical baseline for reliability metrics"
+    GetAssetsSummary:
+      method: get
+      resourcePath: /assetsSummary
+      description: "Returns CSP-wise summary of specs and images in DB for a namespace, including priced/unpriced spec counts."
+    PostK8sClusterDynamic:
+      method: post
+      resourcePath: /ns/{nsId}/k8sClusterDynamic
+      description: "Create K8sCluster Dynamically from common spec and image"
+    SetSystemInitialized:
+      method: put
+      resourcePath: /readyz/init
+      description: "Set the system initialization status to true. Called by init.py after completing initialization."
+    UnsetSystemInitialized:
+      method: delete
+      resourcePath: /readyz/init
+      description: "Reset the system initialization status to false. Useful for re-initialization scenarios."
+    GetScheduleRegisterCspResourcesStatus:
+      method: get
+      resourcePath: /registerCspResources/schedule/{jobId}
+      description: "Get the current status of a specific scheduled CSP resource registration job\n\n**Response Fields Explanation:**\n- `status`: Current job state (Scheduled/Executing/Stopped)\n- `enabled`: Whether job is active (can be paused with false)\n- `executionCount`: Total number of executions attempted\n- `successCount`: Number of successful executions\n- `failureCount`: Number of failed executions\n- `consecutiveFailures`: Current streak of failures (resets on success)\n- `autoDisabled`: True if job was auto-disabled due to 5+ consecutive failures\n- `lastExecutedAt`: Timestamp of most recent execution\n- `nextExecutionAt`: Scheduled time for next execution\n- `lastError`: Error message from most recent failure (empty if success)\n- `lastResult`: Result message from most recent execution\n\n**Monitoring Recommendations:**\n- Check `consecutiveFailures` - alert if >= 3\n- Monitor `autoDisabled` - requires manual intervention if true\n- Compare `successCount` vs `failureCount` for reliability metrics"
+    PutScheduleRegisterCspResources:
+      method: put
+      resourcePath: /registerCspResources/schedule/{jobId}
+      description: "Update the configuration of a scheduled CSP resource registration job (interval, enabled status)\n\n**Updatable Fields:**\n- `intervalSeconds`: Change execution frequency (minimum 10 seconds)\n- `enabled`: Enable (true) or disable (false) the job\n\n**Usage Examples:**\n- Change interval: `{\"intervalSeconds\": 30}` (30 seconds)\n- Pause job: `{\"enabled\": false}`\n- Resume job: `{\"enabled\": true}`\n- Change both: `{\"intervalSeconds\": 10, \"enabled\": true}`\n\n**Note:** For simpler pause/resume operations, consider using dedicated `/pause` and `/resume` endpoints"
+    DeleteScheduleRegisterCspResources:
+      method: delete
+      resourcePath: /registerCspResources/schedule/{jobId}
+      description: "Stop and permanently delete a scheduled CSP resource registration job\n\n**Warning:** This operation is irreversible!\n- Job will be stopped immediately\n- All job data and execution history will be deleted\n- Cannot be recovered after deletion\n\n**Alternatives:**\n- To temporarily stop: Use `/pause` endpoint instead\n- To keep history: Set `enabled: false` via PUT endpoint"
+    LookupImage:
+      method: post
+      resourcePath: /lookupImage
+      description: "Lookup image (for debugging purposes)"
+    PutSshKey:
+      method: put
+      resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}
+      description: "Update SSH Key"
+    DelSshKey:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}
+      description: "Delete SSH Key"
+    GetSshKey:
+      method: get
+      resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}
+      description: "Get SSH Key"
+    GetCmdInfraStream:
+      method: get
+      resourcePath: /ns/{nsId}/stream/cmd/infra/{infraId}
+      description: "Subscribe to Server-Sent Events (SSE) for real-time command execution logs.\nUse the xRequestId returned from POST /ns/{nsId}/cmd/infra/{infraId}?async=true to connect.\nEvents: CommandStatus (status transitions), CommandLog (stdout/stderr lines), CommandDone (terminal)."
+    PutScheduleRegisterCspResourcesResume:
+      method: put
+      resourcePath: /registerCspResources/schedule/{jobId}/resume
+      description: "Resume a previously paused scheduled job to continue periodic execution.\nThis sets enabled=true and restarts the job scheduler."
+    DeleteAllRequests:
+      method: delete
+      resourcePath: /requests
+      description: "Delete details of all requests"
+    GetAllRequests:
+      method: get
+      resourcePath: /requests
+      description: "Get details of all requests with optional filters."
+    ClearAllNodeCommandStatus:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/commandStatusAll
+      description: "Delete all command status records for a node"
+    PostInfraDynamicReview:
+      method: post
+      resourcePath: /ns/{nsId}/infraDynamicReview
+      description: "Review and validate Infra dynamic request comprehensively before actual provisioning.\nThis endpoint performs comprehensive validation of Infra dynamic creation requests without actually creating resources.\nIt checks resource availability, validates specifications and images, estimates costs, and provides detailed recommendations.\n\n**Key Features:**\n- Validates all node specifications and images against CSP availability\n- Provides cost estimation (including partial estimates when some costs are unknown)\n- Identifies potential configuration issues and warnings\n- Recommends optimization strategies\n- Shows provider and region distribution\n- Non-invasive validation (no resources are created)\n\n**Review Status:**\n- `Ready`: All nodes can be created successfully\n- `Warning`: nodes can be created but with configuration warnings\n- `Error`: Critical errors prevent Infra creation\n\n**Use Cases:**\n- Pre-validation before expensive Infra creation\n- Cost estimation and planning\n- Configuration optimization\n- Multi-cloud resource planning"
+    DeleteVersionedObjectLagacy:
+      method: delete
+      resourcePath: /resources/objectStorage/{objectStorageName}/versions/{objectKey}
+      description: "(To be deprecated) Delete a specific version of an object in an object storage (bucket)"
+    LoadAssets:
+      method: get
+      resourcePath: /loadAssets
+      description: "Load Common Resources from internal asset files (Spec, Image). By default, Azure images are excluded for faster initialization. Use includeAzure=true to fetch Azure images (may take 40+ minutes)."
+    GetCredentialHolder:
+      method: get
+      resourcePath: /credentialHolder/{holderId}
+      description: "Get credential holder info derived from registered connection configs."
+    GetK8sClusterInfo:
+      method: get
+      resourcePath: /k8sClusterInfo
+      description: "Get kubernetes cluster information"
+    PostK8sClusterDynamicCheckRequest:
+      method: post
+      resourcePath: /k8sClusterDynamicCheckRequest
+      description: "Check available ConnectionConfig list before create K8sCluster Dynamically from common spec and image"
+    DelAllVNet:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/vNet
+      description: "Delete all VNets"
+    GetAllVNet:
+      method: get
+      resourcePath: /ns/{nsId}/resources/vNet
+      description: "List all VNets or VNets' ID"
+    PostVNet:
+      method: post
+      resourcePath: /ns/{nsId}/resources/vNet
+      description: "Create a new VNet"
+    GetNLBHealth:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{infraId}/nlb/{nlbId}/healthz
+      description: "Get NLB Health"
+    PostVpnHealthCheck:
+      method: post
+      resourcePath: /ns/{nsId}/infra/{infraId}/vpn/{vpnId}/health
+      description: "Perform a bidirectional ping test on a site-to-site VPN using existing Infra nodes and return the results.\n\nIt finds nodes that belong to the VPN's two sites and runs ping tests\nin both directions (site1→site2 and site2→site1) via private IP.\nThe VPN is considered healthy only when both directions succeed.\n\nA retry strategy is used with configurable interval and max attempts\n(default: 15s interval, 20 attempts)."
+    GetAllImage:
+      method: get
+      resourcePath: /ns/{nsId}/resources/image
+      description: "List all images or images' ID"
+    PostImage:
+      method: post
+      resourcePath: /ns/{nsId}/resources/image
+      description: "Register image"
+    DelAllImage:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/image
+      description: "Delete all images"
+    ListObjectVersions:
+      method: get
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/versions
+      description: "List all versions of objects in an object storage (bucket)"
+    PostUtilToValidateNetwork:
+      method: post
+      resourcePath: /util/net/validate
+      description: "Validate a hierarchical configuration of a VPC network or multi-cloud network consisting of multiple VPC networks"
+    GetAllBenchmark:
+      method: post
+      resourcePath: /ns/{nsId}/benchmarkAll/infra/{infraId}
+      description: "Run Infra benchmark for all performance metrics and return results"
+    SetBastionNodesWithNs:
+      method: put
+      resourcePath: /ns/{nsId}/infra/{infraId}/node/{targetNodeId}/bastion/{bastionNsId}/{bastionInfraId}/{bastionNodeId}
+      description: "Set bastion nodes for a target node, specifying a bastion node that belongs to a different namespace and Infra (cross-namespace bastion). This allows, for example, a node in a shared-services namespace to act as a bastion for nodes in other namespaces."
+    DelAllSecurityGroup:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/securityGroup
+      description: "Delete all Security Groups"
+    GetAllSecurityGroup:
+      method: get
+      resourcePath: /ns/{nsId}/resources/securityGroup
+      description: "List all Security Groups or Security Groups' ID"
+    PostSecurityGroup:
+      method: post
+      resourcePath: /ns/{nsId}/resources/securityGroup
+      description: "Create Security Group"
+    PostVNetFromTemplate:
+      method: post
+      resourcePath: /ns/{nsId}/resources/vNet/template/{templateId}
+      description: "Create a new vNet by applying a vNet Template.\nThe template provides the base vNet configuration (connectionName, cidrBlock, subnets),\nand the apply request allows overriding the vNet name and description.\n\n**Override Behavior (Phase 1):**\n- `name` (required): Name for the new vNet\n- `description` (optional): Overrides the template's description\n- All other configuration (connectionName, cidrBlock, subnets) comes from the template"
+    GetNodeHandlingCommandCount:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/handlingCount
+      description: "Get the number of commands currently in 'Handling' status for a specific node. Optimized for frequent polling."
+    GetK8sClusterDynamicTemplate:
+      method: get
+      resourcePath: /ns/{nsId}/template/k8sCluster/{templateId}
+      description: "Retrieve a specific K8s Cluster Dynamic Template by ID."
+    PutK8sClusterDynamicTemplate:
+      method: put
+      resourcePath: /ns/{nsId}/template/k8sCluster/{templateId}
+      description: "Update an existing K8s Cluster Dynamic Template."
+    DeleteK8sClusterDynamicTemplate:
+      method: delete
+      resourcePath: /ns/{nsId}/template/k8sCluster/{templateId}
+      description: "Delete a specific K8s Cluster Dynamic Template."
+    ListObjectVersionsLagacy:
+      method: get
+      resourcePath: /resources/objectStorage/{objectStorageName}/versions
+      description: "(To be deprecated) List object versions in an object storage (bucket)\n\n**Important Notes:**\n- The actual response will be XML format with root element `ListVersionsResult`\n\n**Actual XML Response Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListVersionsResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n<Name>spider-test-bucket</Name>\n<Prefix></Prefix>\n<KeyMarker></KeyMarker>\n<VersionIdMarker></VersionIdMarker>\n<NextKeyMarker></NextKeyMarker>\n<NextVersionIdMarker></NextVersionIdMarker>\n<MaxKeys>1000</MaxKeys>\n<IsTruncated>false</IsTruncated>\n<Version>\n<Key>test-file.txt</Key>\n<VersionId>yb4PgjnFVD2LfRZHXBjjsHBkQRHlu.TZ</VersionId>\n<IsLatest>true</IsLatest>\n<LastModified>2025-09-04T04:24:12Z</LastModified>\n<ETag>23228a38faecd0591107818c7281cece</ETag>\n<Size>23</Size>\n<StorageClass>STANDARD</StorageClass>\n<Owner>\n<ID>aws-config01</ID>\n<DisplayName>aws-config01</DisplayName>\n</Owner>\n</Version>\n</ListVersionsResult>\n```"
+    GetConnConfig:
+      method: get
+      resourcePath: /connConfig/{connConfigName}
+      description: "Get registered ConnConfig info"
+    LookupSpecList:
+      method: post
+      resourcePath: /lookupSpecs
+      description: "Lookup spec list (for debugging purposes)"
+    PutInfraAssociatedSecurityGroups:
+      method: put
+      resourcePath: /ns/{nsId}/infra/{infraId}/associatedSecurityGroups
+      description: "Update all Security Groups associated with a given Infra. The firewall rules of all Security Groups will be synchronized to match the requested set.\nUpdate all Security Groups associated with a given Infra. The firewall rules of all associated Security Groups will be synchronized to match the requested set.\n\nThis API will add missing rules and delete extra rules so that each Security Group's rules become identical to the requested set.\nOnly firewall rules are updated; other metadata (name, description, etc.) is not changed.\n\nUsage:\nUse this API to update (synchronize) the firewall rules of all Security Groups associated with the specified Infra. The rules in the request body will become the only rules in each Security Group after the operation.\n- All existing rules not present in the request will be deleted.\n- All rules in the request that do not exist will be added.\n- If a rule exists but differs in CIDR or port range, it will be replaced.\n- Special protocols (ICMP, etc.) are handled in the same way.\n\nNotes:\n- \"Ports\" field supports single port (\"22\"), port range (\"80-100\"), and multiple ports/ranges (\"22,80-100,443\").\n- The valid port number range is 0 to 65535 (inclusive).\n- \"Protocol\" can be TCP, UDP, ICMP, etc. (as supported by the cloud provider).\n- \"Direction\" must be either \"inbound\" or \"outbound\".\n- \"CIDR\" is the allowed IP range.\n- All existing rules not in the request (including default ICMP, etc.) will be deleted.\n- Metadata (name, description, etc.) is not changed."
+    PostInfraNodeSnapshot:
+      method: post
+      resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/snapshot
+      description: "Snapshot node and create a Custom Image Object using the Snapshot"
+    GetInfraDynamicTemplate:
+      method: get
+      resourcePath: /ns/{nsId}/template/infra/{templateId}
+      description: "Retrieve a specific Infra Dynamic Template by ID."
+    PutInfraDynamicTemplate:
+      method: put
+      resourcePath: /ns/{nsId}/template/infra/{templateId}
+      description: "Update an existing Infra Dynamic Template."
+    DeleteInfraDynamicTemplate:
+      method: delete
+      resourcePath: /ns/{nsId}/template/infra/{templateId}
+      description: "Delete a specific Infra Dynamic Template."
+    GetVNetTemplate:
+      method: get
+      resourcePath: /ns/{nsId}/template/vNet/{templateId}
+      description: "Retrieve a specific vNet Template by ID."
+    PutVNetTemplate:
+      method: put
+      resourcePath: /ns/{nsId}/template/vNet/{templateId}
+      description: "Update an existing vNet Template."
+    DeleteVNetTemplate:
+      method: delete
+      resourcePath: /ns/{nsId}/template/vNet/{templateId}
+      description: "Delete a specific vNet Template."
+    FetchImages:
+      method: post
+      resourcePath: /fetchImages
+      description: "Fetch images waiting for completion.\n\n**Provider Selection Options:**\n- `targetProviders`: Specify exact providers to fetch (e.g., [\"aws\", \"gcp\"]). When set, only these providers are processed and `excludedProviders` is ignored.\n- `excludedProviders`: Specify providers to skip (e.g., [\"azure\"]). Only used when `targetProviders` is not set.\n- `regionAgnosticProviders`: Providers where images are shared across regions (e.g., [\"gcp\"]). Only one region will be fetched per provider.\n\n**Note:** `regionAgnosticProviders` should only contain providers that are also in `targetProviders` (or not excluded)."
+    DeregisterInfraNode:
+      method: delete
+      resourcePath: /ns/{nsId}/deregisterResource/infra/{infraId}/node/{nodeId}
+      description: "Deregister node from Spider and TB without deleting the actual CSP resource"
+    GetAllInfra:
+      method: get
+      resourcePath: /ns/{nsId}/infra
+      description: "List all Infras or Infras' ID"
+    PostInfra:
+      method: post
+      resourcePath: /ns/{nsId}/infra
+      description: "Create Infra with detailed node specifications and resource configuration.\nThis endpoint creates a complete multi-cloud infrastructure by:\n1. **node Provisioning**: Creates nodes across multiple cloud providers using predefined specs and images\n2. **Resource Management**: Automatically handles VPC/VNet, security groups, SSH keys, and network configuration\n3. **Status Tracking**: Monitors node creation progress and handles failures based on policy settings\n4. **Post-Deployment**: Optionally installs monitoring agents and executes custom commands\n\n**Key Features:**\n- Multi-cloud node deployment with heterogeneous configurations\n- Automatic resource dependency management (VPC → Security Group → node)\n- Built-in failure handling with configurable policies (continue/rollback/refine)\n- Optional CB-Dragonfly monitoring agent installation\n- Post-deployment command execution support\n- Real-time status updates and progress tracking\n\n**node Lifecycle:**\n1. Creating → Running (successful deployment)\n2. Creating → Failed (deployment error, handled by failure policy)\n3. Running → Terminated (manual or policy-driven cleanup)\n\n**Failure Policies:**\n- `continue`: Keep successful nodes, mark failed ones for later refinement\n- `rollback`: Delete entire Infra if any node fails (all-or-nothing)\n- `refine`: Automatically clean up failed nodes, keep successful ones\n\n**Resource Requirements:**\n- Valid node specifications (must exist in system namespace)\n- Valid images (must be available in target CSP regions)\n- Sufficient CSP quotas and permissions\n- Network connectivity between components"
+    DelAllInfra:
+      method: delete
+      resourcePath: /ns/{nsId}/infra
+      description: "Delete all Infras"
+    PutChangeK8sNodeGroupAutoscaleSize:
+      method: put
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}/autoscaleSize
+      description: "Change a K8sNodeGroup's Autoscale Size"
+    GetAllInfraPolicy:
+      method: get
+      resourcePath: /ns/{nsId}/policy/infra
+      description: "List all Infra policies"
+    DelAllInfraPolicy:
+      method: delete
+      resourcePath: /ns/{nsId}/policy/infra
+      description: "Delete all Infra policies"
+    PostRegisterVNet:
+      method: post
+      resourcePath: /ns/{nsId}/registerCspResource/vNet
+      description: "Register the VNet, which was created in CSP"
+    PostTestStreamResponse:
+      method: post
+      resourcePath: /testStreamResponse
+      description: "Receives a number and streams the decrementing number every second until zero"
+    GetAllCustomImage:
+      method: get
+      resourcePath: /ns/{nsId}/resources/customImage
+      description: "List all customImages or customImages' ID"
+    PostCustomImage:
+      method: post
+      resourcePath: /ns/{nsId}/resources/customImage
+      description: "Register existing Custom Image in a CSP (option=register)"
+    DelAllCustomImage:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/customImage
+      description: "Delete all customImages"
+    GetRequiredK8sSubnetCount:
+      method: get
+      resourcePath: /requiredK8sSubnetCount
+      description: "Get the required subnet count to create a K8sCluster"
+    GetAvailableRegionZonesForSpecList:
+      method: post
+      resourcePath: /availableRegionZonesForSpecList
+      description: "Query the availability for multiple specs in parallel and return batch results"
+    PostInfraSnapshot:
+      method: post
+      resourcePath: /ns/{nsId}/infra/{infraId}/snapshot
+      description: "Create snapshots for the first running node in each nodegroup of an Infra in parallel"
+    GetConfig:
+      method: get
+      resourcePath: /config/{configId}
+      description: "Get config"
+    InitConfig:
+      method: delete
+      resourcePath: /config/{configId}
+      description: "Init config"
+    FetchSpecs:
+      method: post
+      resourcePath: /fetchSpecs
+      description: "Fetch specs from CSPs and register them in the system.\n\n**Provider Selection Options:**\n- `targetProviders`: Specify exact providers to fetch (e.g., [\"aws\", \"gcp\"]). When set, only these providers are processed and `excludedProviders` is ignored.\n- `excludedProviders`: Specify providers to skip (e.g., [\"azure\"]). Only used when `targetProviders` is not set.\n- `regionAgnosticProviders`: Providers where specs are shared across regions (e.g., [\"gcp\"]). Only one region will be fetched per provider.\n\n**Note:** `regionAgnosticProviders` should only contain providers that are also in `targetProviders` (or not excluded)."
+    DeregisterDataDisk:
+      method: delete
+      resourcePath: /ns/{nsId}/deregisterResource/dataDisk/{dataDiskId}
+      description: "Deregister Data Disk from Spider and TB without deleting the actual CSP resource"
+    AddNLBNodes:
+      method: post
+      resourcePath: /ns/{nsId}/infra/{infraId}/nlb/{nlbId}/node
+      description: "Add nodes to NLB"
+    RemoveNLBNodes:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{infraId}/nlb/{nlbId}/node
+      description: "Delete nodes from NLB"
+    PostInfraNode:
+      method: post
+      resourcePath: /ns/{nsId}/infra/{infraId}/node
+      description: "Create and add a group of identical virtual machines (nodegroup) to an existing Infra using detailed specifications.\nThis endpoint provides precise control over node configuration and placement within existing infrastructure:\n\n**NodeGroup Creation Process:**\n1. **Infra Integration**: Validates target Infra exists and can accommodate new nodes\n2. **Resource Validation**: Verifies all specified resources (specs, images, networks) exist and are accessible\n3. **Homogeneous Deployment**: Creates multiple identical nodes with consistent configuration\n4. **Network Integration**: Integrates new nodes with existing Infra networking and security policies\n5. **Group Management**: Establishes nodegroup for collective management and operations\n\n**Detailed Configuration Control:**\n- **Specific Resource References**: Uses exact resource IDs rather than common specifications\n- **Network Placement**: Precise control over VNet, subnet, and security group assignment\n- **Storage Configuration**: Detailed disk configuration including type, size, and performance tiers\n- **Instance Customization**: Full control over node specifications, images, and metadata\n- **Security Settings**: Explicit security group and SSH key configuration\n\n**NodeGroup Benefits:**\n- **Collective Operations**: Perform operations on entire nodegroup simultaneously\n- **Homogeneous Scaling**: All nodes in nodegroup share identical configuration\n- **Simplified Management**: Single configuration template for multiple nodes\n- **Consistent Naming**: Automatic sequential naming (e.g., web-1, web-2, web-3)\n- **Group Policies**: Apply scaling, monitoring, and lifecycle policies at nodegroup level\n\n**Use Cases:**\n- **Application Tiers**: Deploy multiple instances of web servers, application servers, or databases\n- **Load Distribution**: Create multiple identical nodes for load balancing scenarios\n- **High Availability**: Deploy redundant instances across availability zones\n- **Batch Processing**: Create worker nodes for distributed computing workloads\n- **Development Environments**: Provision identical development or testing instances\n\n**Configuration Requirements:**\n- **Resource IDs**: Must specify exact resource identifiers (not common specs)\n- **Network Configuration**: VNet, subnet, and security group must exist and be compatible\n- **SSH Keys**: Must specify valid SSH key pairs for access management\n- **Image Compatibility**: Specified image must be available in target region\n- **Quota Validation**: Sufficient CSP quotas must be available for all requested nodes\n\n**NodeGroup Size Considerations:**\n- **Small Groups (1-5 nodes)**: Fast deployment, minimal resource contention\n- **Medium Groups (6-20 nodes)**: Optimized parallel deployment with resource batching\n- **Large Groups (21+ nodes)**: Advanced deployment strategies to avoid CSP rate limits\n- **Resource Limits**: Respects CSP quotas and CB-Tumblebug configuration limits\n\n**Post-Deployment Integration:**\n- NodeGroup becomes integral part of parent Infra\n- All nodes inherit Infra-level monitoring and management policies\n- Can be scaled out further or individual nodes can be managed separately\n- Supports all standard CB-Tumblebug node lifecycle operations"
+    GetSiteToSiteVpn:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{infraId}/vpn/{vpnId}
+      description: "Get resource info of a site-to-site VPN"
+    DeleteSiteToSiteVpn:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{infraId}/vpn/{vpnId}
+      description: "Delete a site-to-site VPN\n\n- Note: A one-time retry is performed to handle transient failures caused by CSP-internal timing issues between dependent resources.\n\n**Query option:**\n\n| option | Description |\n|--------|-------------|\n| (none) | Standard delete via Terrarium. |\n| `reconcile` | Do not call the Terrarium delete API. Instead, check whether the Terrarium resource actually exists. If it is missing, remove orphaned Tumblebug metadata. If it exists but the metadata is stuck in a terminal-failure state (e.g., `Failed(DeletionFailed)`), restore the status to `Available`. Returns a reconcile result object instead of a normal delete response. |"
+    PostK8sClusterExtractTemplate:
+      method: post
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/extractTemplate
+      description: "Extract the configuration of an existing K8s cluster and save it as a\nK8s Cluster Dynamic Template for reuse."
+    GetImage:
+      method: get
+      resourcePath: /ns/{nsId}/resources/image/{imageId}
+      description: "GetImage returns an image object if there are matched images for the given namespace and imageKey(imageId)"
+    PutImage:
+      method: put
+      resourcePath: /ns/{nsId}/resources/image/{imageId}
+      description: "Update image"
+    DelImage:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/image/{imageId}
+      description: "Delete image"
+    TestJWTAuth:
+      method: get
+      resourcePath: /auth/test
+      description: "Test JWT authentication"
+    GetLatencyBenchmark:
+      method: get
+      resourcePath: /ns/{nsId}/benchmarkLatency/infra/{infraId}
+      description: "Run Infra benchmark for network latency"
+    PutSetK8sNodeGroupAutoscaling:
+      method: put
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}/onAutoscaling
+      description: "Set a K8sNodeGroup's Autoscaling On/Off"
+    GetObjectStorageCORS:
+      method: get
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/cors
+      description: "Get CORS configuration of an object storage (bucket)"
+    SetObjectStorageCORS:
+      method: put
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/cors
+      description: "Set CORS configuration of an object storage (bucket)"
+    DeleteObjectStorageCORS:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/cors
+      description: "Delete all CORS rules of an object storage (bucket)"
+    GetRequest:
+      method: get
+      resourcePath: /request/{reqId}
+      description: "Get details of a specific request"
+    DeleteRequest:
+      method: delete
+      resourcePath: /request/{reqId}
+      description: "Delete details of a specific request"
+    ListObjectStoragesLagacy:
+      method: get
+      resourcePath: /resources/objectStorage
+      description: "(To be deprecated) Get the list of all object storages (buckets)\n\n**Important Notes:**\n- The actual response will be XML format with root element `ListAllMyBucketsResult`\n- The response includes xmlns attribute: `xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"`\n- Swagger UI may show `resource.ListAllMyBucketsResult` due to rendering limitations\n\n**Actual XML Response Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListAllMyBucketsResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n<Owner>\n<ID>aws-ap-northeast-2</ID>\n<DisplayName>aws-ap-northeast-2</DisplayName>\n</Owner>\n<Buckets>\n</Buckets>\n</ListAllMyBucketsResult>\n```"
+    GeneratePresignedDownloadURLLagacy:
+      method: get
+      resourcePath: /resources/objectStorage/presigned/download/{objectStorageName}/{objectKey}
+      description: "(To be deprecated) Generate a presigned URL for downloading an object from a bucket\n\n**Important Notes:**\n- The actual response will be XML format with root element `PresignedURLResult`\n- The `expires` query parameter specifies the expiration time in seconds for the presigned URL (default: 3600 seconds)\n- The generated presigned URL can be used to download the object directly without further authentication\n\n**Actual XML Response Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<PresignedURLResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n<PresignedURL>https://globally-unique-bucket-hctdx3.s3.dualstack.ap-southeast-2.amazonaws.com/test-file.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA***EXAMPLE%2F20250904%2Fap-southeast-2%2Fs3%2Faws4_request&X-Amz-Date=20250904T061448Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=***-signature</PresignedURL>\n<Expires>3600</Expires>\n<Method>GET</Method>\n</PresignedURLResult>\n```"
+    GetAllSiteToSiteVpn:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{infraId}/vpn
+      description: "Get all site-to-site VPNs"
+    PostSiteToSiteVpn:
+      method: post
+      resourcePath: /ns/{nsId}/infra/{infraId}/vpn
+      description: "Create a site-to-site VPN\n\nThe supported CSP sets are as follows:\n\n- AWS and one of CSPs in Azure, GCP, Alibaba, Tencent, and IBM\n\n- Note: It will take about `15 ~ 45 minutes`.\n\n- Note: A one-time retry is performed to handle transient failures caused by CSP-internal timing issues between dependent resources.\n"
+    RemoveLabel:
+      method: delete
+      resourcePath: /label/{labelType}/{uid}/{key}
+      description: "Remove a label from a resource identified by its uid"
+    DeregisterSecurityGroup:
+      method: delete
+      resourcePath: /ns/{nsId}/deregisterResource/securityGroup/{securityGroupId}
+      description: "Deregister Security Group from Spider and TB without deleting the actual CSP resource"
+    GeneratePresignedUploadURLLagacy:
+      method: get
+      resourcePath: /resources/objectStorage/presigned/upload/{objectStorageName}/{objectKey}
+      description: "(To be deprecated) Generate a presigned URL for uploading an object to a bucket\n\n**Important Notes:**\n- The actual response will be XML format with root element `PresignedURLResult`\n- The `expires` query parameter specifies the expiration time in seconds for the presigned URL (default: 3600 seconds)\n- The generated presigned URL can be used to upload the object directly without further authentication\n\n**Actual XML Response Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<PresignedURLResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n<PresignedURL>https://globally-unique-bucket-hctdx3.s3.dualstack.ap-southeast-2.amazonaws.com/test-file.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA***EXAMPLE%2F20250904%2Fap-southeast-2%2Fs3%2Faws4_request&X-Amz-Date=20250904T061448Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=***-signature</PresignedURL>\n<Expires>3600</Expires>\n<Method>PUT</Method>\n</PresignedURLResult>\n```"
+    RecommendK8sNode:
+      method: post
+      resourcePath: /k8sClusterRecommendNode
+      description: "Recommend K8sCluster's Node plan (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234"
+    PostInfraDynamicFromTemplate:
+      method: post
+      resourcePath: /ns/{nsId}/infra/template/{templateId}
+      description: "Create a new Infra by applying an Infra Dynamic Template.\nThe template provides the base node configuration, and the apply request\nallows overriding the Infra name and description.\n\n**Override Behavior (Phase 1):**\n- `name` (required): Name for the new Infra\n- `description` (optional): Overrides the template's description\n- All other configuration (specs, images, nodegroups) comes from the template"
+    GetAvailableK8sNodeImage:
+      method: get
+      resourcePath: /availableK8sNodeImage
+      description: "(UNDER DEVELOPMENT!!!) Get available kubernetes cluster node image"
+    GetFetchImagesAsyncResult:
+      method: get
+      resourcePath: /fetchImagesResult
+      description: "Get detailed results from the last asynchronous image fetch operation"
+    PostSecurityGroupTemplate:
+      method: post
+      resourcePath: /ns/{nsId}/template/securityGroup
+      description: "Create a reusable SecurityGroup Template. Templates store SecurityGroup creation\nrequest configurations that can be applied later to create SecurityGroups with consistent settings.\n\n**Template Contents:**\n- Connection name (cloud provider and region)\n- vNet ID for the security group\n- Firewall rules (ports, protocol, direction, CIDR)\n- Description\n\nTemplates can be created manually with desired SecurityGroup configurations."
+    DeleteAllSecurityGroupTemplate:
+      method: delete
+      resourcePath: /ns/{nsId}/template/securityGroup
+      description: "Delete all SecurityGroup Templates in a namespace."
+    GetAllSecurityGroupTemplate:
+      method: get
+      resourcePath: /ns/{nsId}/template/securityGroup
+      description: "List all SecurityGroup Templates in a namespace.\nOptionally filter by keyword matching against template name or description (case-insensitive)."
+    GetObject:
+      method: get
+      resourcePath: /object
+      description: "Get value of an object"
+    DeleteObject:
+      method: delete
+      resourcePath: /object
+      description: "Delete an object"
+    GetControlInfraNode:
+      method: get
+      resourcePath: /ns/{nsId}/control/infra/{infraId}/node/{nodeId}
+      description: "Control the lifecycle of node (suspend, resume, reboot, terminate)"
+    GetPublicKeyForCredentialEncryption:
+      method: get
+      resourcePath: /credential/publicKey
+      description: "Generates an RSA key pair using a 4096-bit key size with the RSA algorithm. The public key is generated using the RSA algorithm with OAEP padding and SHA-256 as the hash function. This key is used to encrypt an AES key that will be used for hybrid encryption of credentials."
+    DeleteVersionedObject:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/versions/{objectKey}
+      description: "Delete a specific version of an object in an object storage (bucket)\n\n**Note: **\n- If no version is specified, we will define how it behaves and update it when necessary.\n"
+    SearchImageOptions:
+      method: get
+      resourcePath: /ns/{nsId}/resources/searchImageOptions
+      description: "Get all available options for image search fields"
+    RecommendSpecOptions:
+      method: get
+      resourcePath: /recommendSpecOptions
+      description: "Get available options for filtering and prioritizing specs in RecommendSpec API"
+    PostCmdK8sCluster:
+      method: post
+      resourcePath: /ns/{nsId}/cmd/k8sCluster/{k8sClusterId}
+      description: "Send a command to specified Container in K8sCluster\n[note] This feature is not intended for general use\nThis API is provided as an exceptional and limited function for specific purposes such as migration.\nKubernetes resource information required as input for this API is not currently provided, and its availability in the future is uncertain."
+    GetK8sClusterToken:
+      method: get
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/token
+      description: "Get an access token for the specified K8sCluster.\nOnly applicable to CSPs that use exec-based authentication (e.g., GCP GKE, AWS EKS)."
+    GetObjectStorage:
+      method: get
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}
+      description: "Get details of an object storage (bucket)"
+    RestDeleteObjectStorage:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}
+      description: "Delete an object storage (bucket).\n\n**Query option (mutually exclusive — specify at most one):**\n\n| option | Description |\n|--------|-------------|\n| (none) | Standard delete. Fails if the bucket is not empty. |\n| `empty` | Empty the bucket first, then delete. |\n| `force` | Force delete bucket with all contents (passed to Spider as `force=true`). Behaviour varies by CSP; use when standard delete is not sufficient. |\n| `reconcile` | Do not call the CSP delete API. Instead, check whether the CSP bucket actually exists and remove only the Tumblebug metadata if the bucket is absent. Use this to clean up orphaned metadata that cannot be deleted through normal means (e.g., a bucket stuck in `Failed` status after a partial creation or a CSP-side deletion error such as Tencent 405). Returns a reconcile result object instead of 204. |"
+    CheckObjectStorage:
+      method: head
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}
+      description: "Check existence of an object storage (bucket)"
+    DeleteObjectStorageLagacy:
+      method: delete
+      resourcePath: /resources/objectStorage/{objectStorageName}
+      description: "(To be deprecated) Delete an object storage (bucket)"
+    ExistObjectStorageLagacy:
+      method: head
+      resourcePath: /resources/objectStorage/{objectStorageName}
+      description: "(To be deprecated) Check existence of an object storage (bucket)"
+    GetObjectStorageLagacy:
+      method: get
+      resourcePath: /resources/objectStorage/{objectStorageName}
+      description: "(To be deprecated) Get details of an object storage (bucket)\n\n**Important Notes:**\n- The actual response will be XML format with root element `ListBucketResult`\n\n**Actual XML Response Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n<Name>spider-test-bucket</Name>\n<Prefix></Prefix>\n<Marker></Marker>\n<MaxKeys>1000</MaxKeys>\n<IsTruncated>false</IsTruncated>\n</ListBucketResult>\n```"
+    CreateObjectStorageLagacy:
+      method: put
+      resourcePath: /resources/objectStorage/{objectStorageName}
+      description: "(To be deprecated) Create an object storage (bucket)\n\n**Important Notes:**\n- The `objectStorageName` must be globally unique across all existing buckets in the S3 compatible storage.\n- The bucket namespace is shared by all users of the system."
+    DeleteMultipleDataObjectsLagacy:
+      method: post
+      resourcePath: /resources/objectStorage/{objectStorageName}
+      description: "(To be deprecated) `Delete` multiple objects from a bucket\n\n**Important Notes:**\n- The request body must contain the list of objects to delete in XML format\n- The `delete` query parameter must be set to `true`\n\n**Request Body Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Delete xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n<Object>\n<Key>test-object1.txt</Key>\n</Object>\n<Object>\n<Key>test-object2.txt</Key>\n</Object>\n</Delete>\n```\n\n**Actual XML Response Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<DeleteResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n<Deleted>\n<Key>test-object1.txt</Key>\n</Deleted>\n<Deleted>\n<Key>test-object2.txt</Key>\n</Deleted>\n</DeleteResult>\n```"
+    GetInfra:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{infraId}
+      description: "Get Infra object (option: status, accessInfo, nodeId)"
+    DelInfra:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{infraId}
+      description: "Delete Infra"
+    GetNodeCommandStatus:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/commandStatus/{index}
+      description: "Get a specific command status record by index for a node"
+    DeleteNodeCommandStatus:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/commandStatus/{index}
+      description: "Delete a specific command status record by index for a node"
   cm-ant:
-    AntServerReadiness:
-      method: get
-      resourcePath: /readyz
-      description: This endpoint checks if the CB-Ant API server is ready by verifying
-        the status of both the load service and the cost service. If either service
-        is unavailable, it returns a 503 status indicating the server is not ready.
-    CreateLoadTestScenarioCatalog:
-      method: post
-      resourcePath: /api/v1/load/templates/test-scenario-catalogs
-      description: Create a new load test scenario catalog template with the provided
-        configuration.
-    DeleteLoadTestScenarioCatalog:
-      method: delete
-      resourcePath: /api/v1/load/templates/test-scenario-catalogs/{id}
-      description: Delete a load test scenario catalog by ID.
-    GetAllLoadGeneratorInstallInfo:
-      method: get
-      resourcePath: /api/v1/load/generators
-      description: Retrieve a list of all installed load generators with pagination
-        support.
-    GetAllLoadTestExecutionInfos:
-      method: get
-      resourcePath: /api/v1/load/tests/infos
-      description: Retrieve a list of all load test execution information with pagination
-        support.
-    GetAllLoadTestExecutionState:
-      method: get
-      resourcePath: /api/v1/load/tests/state
-      description: Retrieve a list of all load test execution states with pagination
-        support.
-    GetAllLoadTestScenarioCatalogs:
-      method: get
-      resourcePath: /api/v1/load/templates/test-scenario-catalogs
-      description: Retrieve a list of all load test scenario catalogs with pagination
-        support.
-    GetAllMonitoringAgentInfos:
-      method: get
-      resourcePath: /api/v1/load/monitoring/agent
-      description: Retrieve monitoring agent information based on specified criteria.
-    GetEstimateCost:
-      method: get
-      resourcePath: /api/v1/cost/estimate
-      description: Fetch estimated cost details based on provider, region, instance
-        type, and resource specifications. Pagination support is provided through
-        `Page` and `Size` parameters.
-    GetEstimateForecastCost:
-      method: get
-      resourcePath: /api/v1/cost/estimate/forecast
-      description: Fetch estimated forecast cost data based on specified parameters,
-        including a date range that must be within 6 months. Supports pagination and
-        filtering by namespace IDs, migration configuration IDs, and resource types.
-    GetLastLoadTestExecutionState:
-      method: get
-      resourcePath: /api/v1/load/tests/state/last
-      description: Retrieve a last load test execution state by given ids.
-    GetLastLoadTestMetrics:
-      method: get
-      resourcePath: /api/v1/load/tests/result/metrics/last
-      description: Retrieve last load test metrics based on provided parameters.
-    GetLastLoadTestResult:
-      method: get
-      resourcePath: /api/v1/load/tests/result/last
-      description: Retrieve last load test result based on provided parameters.
-    GetLoadTestExecutionInfo:
-      method: get
-      resourcePath: /api/v1/load/tests/infos/{loadTestKey}
-      description: Retrieve the load test execution state information for a specific
-        load test key.
-    GetLoadTestExecutionState:
-      method: get
-      resourcePath: /api/v1/load/tests/state/{loadTestKey}
-      description: Retrieve a load test execution state by load test key.
-    GetLoadTestMetrics:
-      method: get
-      resourcePath: /api/v1/load/tests/result/metrics
-      description: Retrieve load test metrics based on provided parameters.
-    GetLoadTestResult:
-      method: get
-      resourcePath: /api/v1/load/tests/result
-      description: Retrieve load test result based on provided parameters.
-    GetLoadTestScenarioCatalog:
-      method: get
-      resourcePath: /api/v1/load/templates/test-scenario-catalogs/{id}
-      description: Retrieve a specific load test scenario catalog by ID.
-    InstallLoadGenerator:
-      method: post
-      resourcePath: /api/v1/load/generators
-      description: Install a load generator either locally or remotely.
-    InstallMonitoringAgent:
-      method: post
-      resourcePath: /api/v1/load/monitoring/agent/install
-      description: Install a monitoring agent on specific mci.
-    RunLoadTest:
-      method: post
-      resourcePath: /api/v1/load/tests/run
-      description: Start a load test using the provided load test configuration.
-    StopLoadTest:
-      method: post
-      resourcePath: /api/v1/load/tests/stop
-      description: Stop a running load test using the provided load test key.
-    UninstallLoadGenerator:
-      method: delete
-      resourcePath: /api/v1/load/generators/{loadGeneratorInstallInfoId}
-      description: Uninstall a previously installed load generator.
     UninstallMonitoringAgent:
       method: post
       resourcePath: /api/v1/load/monitoring/agent/uninstall
-      description: Uninstall monitoring agents from specified VMs or all VMs in an
-        mci.
-    UpdateAndGetEstimateCost:
+      description: "Uninstall monitoring agents from specified VMs or all VMs in an mci."
+    GetLoadTestResult:
+      method: get
+      resourcePath: /api/v1/load/tests/result
+      description: "Retrieve load test result based on provided parameters."
+    GetLastLoadTestResult:
+      method: get
+      resourcePath: /api/v1/load/tests/result/last
+      description: "Retrieve last load test result based on provided parameters."
+    GetLastLoadTestMetrics:
+      method: get
+      resourcePath: /api/v1/load/tests/result/metrics/last
+      description: "Retrieve last load test metrics based on provided parameters."
+    RunLoadTest:
       method: post
-      resourcePath: /api/v1/cost/estimate
-      description: Update the estimate cost based on provided specifications and retrieve
-        the updated cost estimation. Required fields for each specification include
-        `ProviderName`, `RegionName`, and `InstanceType`. Specifications can also
-        be provided in a formatted string using `+` delimiter.
+      resourcePath: /api/v1/load/tests/run
+      description: "Start a load test using the provided load test configuration."
+    AntServerReadiness:
+      method: get
+      resourcePath: /readyz
+      description: "This endpoint checks if the CB-Ant API server is ready by verifying the status of both the load service and the cost service. If either service is unavailable, it returns a 503 status indicating the server is not ready."
     UpdateEstimateForecastCost:
       method: post
       resourcePath: /api/v1/cost/estimate/forecast
-      description: Update and retrieve forecasted cost estimates for a specified namespace
-        and migration configuration ID over the past 14 days.
+      description: "Update and retrieve forecasted cost estimates for a specified namespace and migration configuration ID over the past 14 days."
+    GetEstimateForecastCost:
+      method: get
+      resourcePath: /api/v1/cost/estimate/forecast
+      description: "Fetch estimated forecast cost data based on specified parameters, including a date range that must be within 6 months. Supports pagination and filtering by namespace IDs, migration configuration IDs, and resource types."
+    InstallLoadGenerator:
+      method: post
+      resourcePath: /api/v1/load/generators
+      description: "Install a load generator either locally or remotely."
+    GetAllLoadGeneratorInstallInfo:
+      method: get
+      resourcePath: /api/v1/load/generators
+      description: "Retrieve a list of all installed load generators with pagination support."
+    GetAllLoadTestExecutionInfos:
+      method: get
+      resourcePath: /api/v1/load/tests/infos
+      description: "Retrieve a list of all load test execution information with pagination support."
+    GetAllLoadTestExecutionState:
+      method: get
+      resourcePath: /api/v1/load/tests/state
+      description: "Retrieve a list of all load test execution states with pagination support."
+    GetLastLoadTestExecutionState:
+      method: get
+      resourcePath: /api/v1/load/tests/state/last
+      description: "Retrieve a last load test execution state by given ids."
+    GetLoadTestExecutionState:
+      method: get
+      resourcePath: /api/v1/load/tests/state/{loadTestKey}
+      description: "Retrieve a load test execution state by load test key."
     UpdateEstimateForecastCostRaw:
       method: post
       resourcePath: /api/v1/cost/estimate/forecast/raw
-      description: Update and retrieve raw forecasted cost estimates for specified
-        cost resources and additional AWS information over the past 14 days.
+      description: "Update and retrieve raw forecasted cost estimates for specified cost resources and additional AWS information over the past 14 days."
+    InstallMonitoringAgent:
+      method: post
+      resourcePath: /api/v1/load/monitoring/agent/install
+      description: "Install a monitoring agent on specific mci."
+    GetAllLoadTestScenarioCatalogs:
+      method: get
+      resourcePath: /api/v1/load/templates/test-scenario-catalogs
+      description: "Retrieve a list of all load test scenario catalogs with pagination support."
+    CreateLoadTestScenarioCatalog:
+      method: post
+      resourcePath: /api/v1/load/templates/test-scenario-catalogs
+      description: "Create a new load test scenario catalog template with the provided configuration."
+    GetLoadTestScenarioCatalog:
+      method: get
+      resourcePath: /api/v1/load/templates/test-scenario-catalogs/{id}
+      description: "Retrieve a specific load test scenario catalog by ID."
     UpdateLoadTestScenarioCatalog:
       method: put
       resourcePath: /api/v1/load/templates/test-scenario-catalogs/{id}
-      description: Update an existing load test scenario catalog with the provided
-        configuration.
+      description: "Update an existing load test scenario catalog with the provided configuration."
+    DeleteLoadTestScenarioCatalog:
+      method: delete
+      resourcePath: /api/v1/load/templates/test-scenario-catalogs/{id}
+      description: "Delete a load test scenario catalog by ID."
+    GetLoadTestExecutionInfo:
+      method: get
+      resourcePath: /api/v1/load/tests/infos/{loadTestKey}
+      description: "Retrieve the load test execution state information for a specific load test key."
+    GetLoadTestMetrics:
+      method: get
+      resourcePath: /api/v1/load/tests/result/metrics
+      description: "Retrieve load test metrics based on provided parameters."
+    StopLoadTest:
+      method: post
+      resourcePath: /api/v1/load/tests/stop
+      description: "Stop a running load test using the provided load test key."
+    GetEstimateCost:
+      method: get
+      resourcePath: /api/v1/cost/estimate
+      description: "Fetch estimated cost details based on provider, region, instance type, and resource specifications. Pagination support is provided through `Page` and `Size` parameters."
+    UpdateAndGetEstimateCost:
+      method: post
+      resourcePath: /api/v1/cost/estimate
+      description: "Update the estimate cost based on provided specifications and retrieve the updated cost estimation. Required fields for each specification include `ProviderName`, `RegionName`, and `InstanceType`. Specifications can also be provided in a formatted string using `+` delimiter."
+    UninstallLoadGenerator:
+      method: delete
+      resourcePath: /api/v1/load/generators/{loadGeneratorInstallInfoId}
+      description: "Uninstall a previously installed load generator."
+    GetAllMonitoringAgentInfos:
+      method: get
+      resourcePath: /api/v1/load/monitoring/agent
+      description: "Retrieve monitoring agent information based on specified criteria."
   cm-beetle:
     CheckHTTPVersion:
       method: get
       resourcePath: /httpVersion
-      description: Checks and logs the HTTP version of the incoming request to the
-        server console.
-    CreateMigratedSSHKey:
+      description: "Checks and returns the HTTP protocol version of the incoming request.\n\n[Note]\n- The X-Request-Id header value (auto-generated if not provided) is propagated to Tumblebug when Beetle calls its APIs for distributed tracing."
+    GetNlb:
+      method: get
+      resourcePath: /migration/middleware/ns/{nsId}/infra/{infraId}/nlb/{nlbId}
+      description: "Get details of a specific NLB"
+    DeleteNlb:
+      method: delete
+      resourcePath: /migration/middleware/ns/{nsId}/infra/{infraId}/nlb/{nlbId}
+      description: "Delete a specific NLB from the target infra"
+    GetObjectStorage:
+      method: get
+      resourcePath: /migration/middleware/ns/{nsId}/objectStorage/{osId}
+      description: "Get details of a specific object storage (bucket)"
+    DeleteObjectStorage:
+      method: delete
+      resourcePath: /migration/middleware/ns/{nsId}/objectStorage/{osId}
+      description: "Delete a specific object storage (bucket).\n\nDeletion behavior is controlled by the `option` query parameter (mutually exclusive):\n- (none): Standard delete — fails if the bucket is not empty.\n- `empty`: Empty the bucket first, then delete.\n- `force`: Force-delete with all contents (passed to Spider as force=true).\n- `reconcile`: Remove only Tumblebug metadata without calling the CSP delete API."
+    ExistObjectStorage:
+      method: head
+      resourcePath: /migration/middleware/ns/{nsId}/objectStorage/{osId}
+      description: "Check if a specific object storage (bucket) exists\n\n[Note]\n- Returns 200 OK if the bucket exists, 404 Not Found if it doesn't exist"
+    RecommendK8sControlPlane:
       method: post
-      resourcePath: /migration/ns/{nsId}/resources/sshKey
-      description: Create a new migrated SSH key in the namespace
-    CreateMigratedSecurityGroup:
+      resourcePath: /recommendation/k8sControlPlane
+      description: "Get recommendation for K8s control plane based on honeybee source cluster data\nReturns configuration that can be directly used with cb-tumblebug k8sClusterDynamic API"
+    MigrateData:
       method: post
-      resourcePath: /migration/ns/{nsId}/resources/securityGroup
-      description: Create a new migrated security group in the namespace
-    CreateVNet:
+      resourcePath: /migration/data
+      description: "**Asynchronous Operation**: This API returns immediately with a request ID. The actual migration runs in the background.\n\n[How to Use]\n1. Call this API → Receive 202 Accepted with reqId\n2. Poll GET /request/{reqId} to check status\n3. Status flow: Handling → Success / Error\n\n[Endpoint Requirements]\n* Both source and destination must be remote endpoints (SSH or object storage)\n* Local filesystem access is not allowed for security reasons\n\n[Transfer Options]\n* Strategy: auto (default), direct, relay\n* SSH: Supports PrivateKey content or PrivateKeyPath\n\n[Encryption Support]\n* To encrypt sensitive fields, first call GET /migration/data/encryptionKey\n* Encrypted requests include `encryptionKeyId` field\n* Server automatically detects and decrypts encrypted requests\n\n[Examples]\n* Test results: https://github.com/cloud-barista/cm-beetle/blob/main/docs/test-results-data-migration.md\n"
+    ListObjectStorages:
+      method: get
+      resourcePath: /migration/middleware/ns/{nsId}/objectStorage
+      description: "Get the list of all object storages (buckets) in the namespace"
+    MigrateObjectStorage:
       method: post
+      resourcePath: /migration/middleware/ns/{nsId}/objectStorage
+      description: "Migrate object storages to cloud based on recommendation results\n\n[Note]\n- This API creates object storages (buckets) in the target cloud within the specified namespace\n- Input should be the output from RecommendObjectStorage API\n- Connection name is automatically generated from CSP and region in the request body\n\n[Note] `nameSeed` enables dynamic naming via **Late Binding**.\n- If `nameSeed` query param is set (e.g., `?nameSeed=my`), bucket names are prefixed at migration time: `my-os-01`.\n- If `nameSeed` is omitted, bucket names are used as-is from the recommendation result.\n\n[Examples]\n* Test results: https://github.com/cloud-barista/cm-beetle/blob/main/docs/test-results-data-migration.md\n"
+    DeleteMigratedVNets:
+      method: delete
       resourcePath: /migration/ns/{nsId}/resources/vNet
-      description: Create a new migrated virtual network in the namespace
-    DeleteInfra:
-      method: delete
-      resourcePath: /migration/ns/{nsId}/mci/{mciId}
-      description: Delete the migrated mult-cloud infrastructure (MCI)
-    DeleteMigratedSSHKey:
-      method: delete
-      resourcePath: /migration/ns/{nsId}/resources/sshKey/{sshKeyId}
-      description: Delete a specific migrated SSH key in the namespace
-    DeleteMigratedSecurityGroup:
-      method: delete
-      resourcePath: /migration/ns/{nsId}/resources/securityGroup/{sgId}
-      description: Delete a specific migrated security group in the namespace
-    DeleteMigratedVNet:
-      method: delete
-      resourcePath: /migration/ns/{nsId}/resources/vNet/{vNetId}
-      description: Delete a specific migrated virtual network in the namespace
-    GetInfra:
-      method: get
-      resourcePath: /migration/ns/{nsId}/mci/{mciId}
-      description: Get the migrated multi-cloud infrastructure (MCI)
-    GetMigratedSSHKey:
-      method: get
-      resourcePath: /migration/ns/{nsId}/resources/sshKey/{sshKeyId}
-      description: Get details of a specific migrated SSH key in the namespace
-    GetMigratedSecurityGroup:
-      method: get
-      resourcePath: /migration/ns/{nsId}/resources/securityGroup/{sgId}
-      description: Get details of a specific migrated security group in the namespace
-    GetMigratedVNet:
-      method: get
-      resourcePath: /migration/ns/{nsId}/resources/vNet/{vNetId}
-      description: Get details of a specific virtual network in the namespace
-    GetReadyz:
-      method: get
-      resourcePath: /readyz
-      description: Check Beetle is ready
-    ListInfra:
-      method: get
-      resourcePath: /migration/ns/{nsId}/mci
-      description: Get the migrated multi-cloud infrastructure (MCI)
-    ListMigratedSSHKeys:
-      method: get
-      resourcePath: /migration/ns/{nsId}/resources/sshKey
-      description: Get the list of all migrated SSH keys in the namespace
-    ListMigratedSecurityGroups:
-      method: get
-      resourcePath: /migration/ns/{nsId}/resources/securityGroup
-      description: Get the list of all migrated security groups in the namespace
+      description: "Delete multiple migrated virtual networks in the namespace"
     ListMigratedVNets:
       method: get
       resourcePath: /migration/ns/{nsId}/resources/vNet
-      description: Get the list of all migrated virtual networks in the namespace
-    MigrateInfra:
+      description: "Get the list of all migrated virtual networks in the namespace"
+    CreateVNet:
       method: post
-      resourcePath: /migration/ns/{nsId}/mci
-      description: Migrate an infrastructure to the multi-cloud infrastructure (MCI)
-        with defaults.
-    MigrateInfraWithDefaults:
+      resourcePath: /migration/ns/{nsId}/resources/vNet
+      description: "Create a new migrated virtual network in the namespace"
+    PreviewInfra:
       method: post
-      resourcePath: /migration/ns/{nsId}/mciWithDefaults
-      description: Migrate an infrastructure to the multi-cloud infrastructure (MCI)
-        with defaults.
-    RecommendContainerInfra:
+      resourcePath: /naming/preview
+      description: "Applies the `nameSeed` prefix to all resource names in the model and returns the result.\nNo resources are created — this is a dry-run to verify final names before migration.\n\nExample: if `nameSeed=blue` and `VNetName=vnet-01`, the preview returns `blue-vnet-01`.\n"
+    RecommendK8sNodeGroup:
       method: post
-      resourcePath: /recommendation/containerInfra
-      description: |-
-        Recommend an appropriate container infrastructure for container-based workloads
-
-        [Note] `desiredProvider` and `desiredRegion` are required.
-        - `desiredProvider` and `desiredRegion` can be set in the query parameter or the request body.
-        - If both are set, the values in the request body take precedence.
+      resourcePath: /recommendation/k8sNodeGroup
+      description: "Get recommendation for K8s worker node group based on honeybee source cluster data\nReturns configuration that can be directly used with cb-tumblebug k8sNodeGroupDynamic API"
     RecommendSecurityGroups:
       method: post
       resourcePath: /recommendation/resources/securityGroups
-      description: |-
-        Recommend an appropriate security group for cloud migration
-
-        [Note] `desiredProvider` and `desiredRegion` are required.
-        - `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.
-
-        - If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.
-    RecommendVMInfra:
+      description: "Recommend an appropriate security group for cloud migration\n\n[Note] `desiredProvider` and `desiredRegion` are required.\n- `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.\n\n- If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored."
+    TestAuth:
+      method: get
+      resourcePath: /test/auth
+      description: "Checks if the request is authenticated and returns the auth type"
+    ListNlbs:
+      method: get
+      resourcePath: /migration/middleware/ns/{nsId}/infra/{infraId}/nlb
+      description: "Get the list of all NLBs in the specified namespace and infra"
+    MigrateNlbs:
       method: post
-      resourcePath: /recommendation/mci
-      description: |-
-        Recommend an appropriate VM infrastructure (i.e., MCI, multi-cloud infrastructure) for cloud migration
-
-        [Note] `desiredCsp` and `desiredRegion` are required.
-        - `desiredCsp` and `desiredRegion` can set on the query parameter or the request body.
-
-        - If desiredCsp and desiredRegion are set on request body, the values in the query parameter will be ignored.
-    RecommendVMInfraWithDefaults:
+      resourcePath: /migration/middleware/ns/{nsId}/infra/{infraId}/nlb
+      description: "Migrate NLBs to the target cloud infra based on recommendation results.\n\n[Prerequisites]\n- The target Namespace (nsId) must exist.\n- The target Infra (infraId) must exist and have at least one NodeGroup in Running state.\n- Each `targetNlbList[].targetGroup.nodeGroupId` must reference an existing NodeGroup in the Infra.\n\n[Note] Input should be the `targetNlbList` field from the POST /recommendation/infraWithNlb response.\nEnsure `targetGroup.nodeGroupId` matches the NodeGroup IDs created during infra migration.\n\n[Note] All NLBs are attempted independently. Partial success is possible."
+    ListMigratedSecurityGroups:
+      method: get
+      resourcePath: /migration/ns/{nsId}/resources/securityGroup
+      description: "Get the list of all migrated security groups in the namespace"
+    CreateMigratedSecurityGroup:
       method: post
-      resourcePath: /recommendation/mciWithDefaults
-      description: |-
-        Recommend an appropriate VM infrastructure (i.e., MCI, multi-cloud infrastructure) with defaults for cloud migration
-
-        [Note] `desiredCsp` and `desiredRegion` are required.
-        - `desiredCsp` and `desiredRegion` can set on the query parameter or the request body.
-
-        - If desiredCsp and desiredRegion are set on request body, the values in the query parameter will be ignored.
-    RecommendVNet:
+      resourcePath: /migration/ns/{nsId}/resources/securityGroup
+      description: "Create a new migrated security group in the namespace"
+    DeleteMigratedSecurityGroups:
+      method: delete
+      resourcePath: /migration/ns/{nsId}/resources/securityGroup
+      description: "Delete multiple migrated security groups in the namespace"
+    GetMigratedSecurityGroup:
+      method: get
+      resourcePath: /migration/ns/{nsId}/resources/securityGroup/{sgId}
+      description: "Get details of a specific migrated security group in the namespace"
+    DeleteMigratedSecurityGroup:
+      method: delete
+      resourcePath: /migration/ns/{nsId}/resources/securityGroup/{sgId}
+      description: "Delete a specific migrated security group in the namespace"
+    GetMigratedSSHKey:
+      method: get
+      resourcePath: /migration/ns/{nsId}/resources/sshKey/{sshKeyId}
+      description: "Get details of a specific migrated SSH key in the namespace"
+    DeleteMigratedSSHKey:
+      method: delete
+      resourcePath: /migration/ns/{nsId}/resources/sshKey/{sshKeyId}
+      description: "Delete a specific migrated SSH key in the namespace"
+    DeleteAllRequests:
+      method: delete
+      resourcePath: /requests
+      description: "Deletes all API request tracking records from Beetle.\n\n[Note]\n- This only clears Beetle's request tracking memory.\n- It does NOT affect any data in Tumblebug or cancel any ongoing operations."
+    GetAllRequests:
+      method: get
+      resourcePath: /requests
+      description: "Retrieves all API requests tracked by Beetle with optional filters.\n\n[Note]\n- Request tracking is managed independently by Beetle (not shared with Tumblebug).\n- This API only returns requests made to Beetle, not to Tumblebug.\n\n[Status Values]\n- Handling: Request is currently being processed\n- Success: Request completed successfully\n- Error: Request failed with an error"
+    GenerateTargetInfraSummary:
+      method: get
+      resourcePath: /summary/target/ns/{nsId}/infra/{infraId}
+      description: "Generate a comprehensive target infrastructure summary in multiple formats based on 'format' query parameter:\n\n**Response Format by 'format' Parameter:**\n- `format=md` (default): Returns markdown string with Content-Type: text/markdown; charset=utf-8\n- `format=html`: Returns HTML string with Content-Type: text/html; charset=utf-8\n- `format=json`: Returns ApiResponse[TargetInfraSummary] with Content-Type: application/json\n\n**Note:** API documentation shows JSON schema for reference, but actual default response is markdown format.\n\n**Markdown example**: https://github.com/cloud-barista/cm-beetle/blob/main/cmd/test-cli/infra/testresult/beetle-summary-target-aws.md\n\n**Download Behavior:**\n- `download=false` (default): Content displayed inline (viewable in browser/Swagger UI)\n- `download=true`: Content downloaded as file (Content-Disposition: attachment)"
+    GetDataMigrationEncryptionKey:
+      method: get
+      resourcePath: /migration/data/encryptionKey
+      description: "Generate and return a one-time RSA public key for encrypting sensitive fields in DataMigrationModel.\n\n[Encryption Workflow]\n1. Client calls this API to get a public key bundle\n2. Client encrypts sensitive fields using the public key\n3. Client sends encrypted model to POST /migration/data\n4. Server decrypts using the stored private key (auto-deleted after use)\n\n[Note]\n* **One-time key**: Automatically invalidated after first decryption use\n* **Key validity**: 30 minutes from generation (configurable in server)\n* **Encrypted fields**: SSH privateKey, S3 credentials, auth passwords/tokens\n* **Algorithm**: RSA-OAEP-256 (key exchange) + AES-256-GCM (data encryption)\n\n[Client Example]\nSee: https://github.com/cloud-barista/cm-beetle/blob/main/transx/README.md#usage-encrypted-transmission-recommended-for-production\n"
+    MigrateInfraWithDefaults:
       method: post
-      resourcePath: /recommendation/resources/vNet
-      description: |-
-        Recommend an appropriate virtual network for cloud migration
-
-        [Note] `desiredProvider` and `desiredRegion` are required.
-        - `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.
-
-        - If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.
-    RecommendVmOsImages:
+      resourcePath: /migration/ns/{nsId}/infraWithDefaults
+      description: "Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults."
+    GetReadyz:
+      method: get
+      resourcePath: /readyz
+      description: "Check Beetle is ready"
+    GetRequest:
+      method: get
+      resourcePath: /request/{reqId}
+      description: "Retrieves the details of a specific API request tracked by Beetle.\n\n[Note]\n- Request tracking is managed independently by Beetle (not shared with Tumblebug).\n- The reqId corresponds to the X-Request-Id header value from a previous API call.\n- Do NOT call Tumblebug's /request/{reqId} API with this reqId; each system manages its own request tracking.\n\n[Status Values]\n- Handling: Request is currently being processed\n- Success: Request completed successfully\n- Error: Request failed with an error"
+    DeleteRequest:
+      method: delete
+      resourcePath: /request/{reqId}
+      description: "Deletes the tracking details of a specific API request from Beetle.\n\n[Note]\n- This only removes the request tracking record from Beetle's memory.\n- It does NOT affect any data in Tumblebug or cancel any ongoing operations."
+    TestDecryptData:
       method: post
-      resourcePath: /recommendation/resources/vmOsImages
-      description: |-
-        Recommend an appropriate OS image for cloud migration
-
-        [Note] `desiredProvider` and `desiredRegion` are required.
-        - `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.
-
-        - If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.
-    RecommendVmSpecs:
+      resourcePath: /migration/data/test/decrypt
+      description: "**⚠️ FOR TESTING ONLY**: This API tests server-side decryption without executing migration.\nUse this to verify the encryption workflow before calling the actual migration API.\n\nReceives an encrypted DataMigrationModel, decrypts it, and returns verification results.\nThis API does NOT execute actual data migration.\n\n[Test Workflow]\n1. Call GET /migration/data/encryptionKey to get a public key\n2. Encrypt your model using the public key (client-side), or use POST /migration/data/test/encrypt\n3. Call this API with the encrypted model\n4. Verify the decryption result shows expected fields\n\n[Note]\n* The encryption key is consumed (deleted) after this test\n* You need to generate a new key for actual migration\n"
+    GetMigratedVNet:
+      method: get
+      resourcePath: /migration/ns/{nsId}/resources/vNet/{vNetId}
+      description: "Get details of a specific virtual network in the namespace"
+    DeleteMigratedVNet:
+      method: delete
+      resourcePath: /migration/ns/{nsId}/resources/vNet/{vNetId}
+      description: "Delete a specific migrated virtual network in the namespace. Action options: withsubnets (delete with subnets), reconcile (sync metadata with CSP state), force (force-delete on CSP)"
+    RecommendVmInfraCandidates:
       method: post
-      resourcePath: /recommendation/resources/vmSpecs
-      description: |-
-        Recommend an appropriate VM specification for cloud migration
-
-        [Note] `desiredProvider` and `desiredRegion` are required.
-        - `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.
-
-        - If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.
-        - If `targetMachineId` is provided, only that specific machine will be processed.
+      resourcePath: /recommendation/infra
+      description: "Recommend best-effort VM infrastructure (MCI) candidates for migrating on-premise workloads to cloud environments.\n\n- See overview and examples on https://github.com/cloud-barista/cm-beetle/discussions/256\n\n**[Required Parameters: `desiredCsp`, `desiredRegion`]** The desired cloud service provider and region for the recommended infrastructure.\n- if **desiredCsp** and **desiredRegion** are set on request body, the values in the query parameter will be ignored.\n\n**[Optional Parameters: `limit`]** Maximum number of recommended infrastructures to return (default: 3)\n\n**[Optional Parameters: `minMatchRate`]** Minimum match rate threshold for highly-matched classification (default: 90.0, range: 0-100)\n\n**[Response Field: `status`]** Candidate status based on the match rate threshold\n- **highly-matched**: Candidates meet or exceed the match rate threshold\n- **partially-matched**: Valid candidates below the match rate threshold\n\n**[Response Field: `description`]** Summary containing Candidate ID, status, match rate statistics (Min/Max/Avg), and VM counts\n- Example: \"Candidate #1 | partially-matched | Overall Match Rate: Min=88.9% Max=100.0% Avg=98.7% | VMs: 3 total, 2 matched, 1 acceptable\"\n\n**[Response Field: `nodeGroups[].cspImageName`]** Set only when the spec-image review resolved a newer image than the DB cache.\n- **Non-empty**: TumbleBug sends this to Spider directly, bypassing the per-VM image DB lookup (prevents stale image failures, e.g., Alibaba alibase images).\n- **Empty**: TumbleBug uses `imageId` for the standard DB lookup path.\n- Pass the recommendation response as-is to the migration API to ensure the resolved image is used.\n"
+    RecommendInfraWithNlbCandidates:
+      method: post
+      resourcePath: /recommendation/infraWithNlb
+      description: "Perform NLB-aware infrastructure recommendation and return multiple Pareto-optimal candidates.\n\nThe recommendation engine:\n1. Correlates NLB backend server IPs with source Node IPs\n2. Normalizes backend ports via majority vote when ports differ\n3. Assigns NLB-related nodes to shared NodeGroups (N:1), unrelated nodes to individual NodeGroups (1:1)\n4. Finds ranked compatible spec-image pairs per NodeGroup (representative node for NLB groups)\n5. Generates up to `limit` candidates — candidate i uses the i-th ranked pair per NodeGroup\n6. Maps source NLB configuration to target cloud NLB model (same for all candidates)\n\n[Note] `sourceInfra.nlbs` must be populated (HAProxy frontend-backend pairs from cm-honeybee).\n\n[Note] The returned `targetInfra.nodeGroups[].name` values are referenced by `targetNlbList[].targetGroup.nodeGroupId`.\nUse the same NodeGroup IDs when calling POST /migration/infra so that the NLB migration can reference them immediately."
+    TestStreamingResponse:
+      method: get
+      resourcePath: /test/streaming
+      description: "Returns multiple JSON objects as newline-delimited JSON (JSON Lines format)"
     TestTracing:
       method: get
       resourcePath: /test/tracing
-      description: Test tracing to Tumblebug
+      description: "Tests distributed tracing by calling Tumblebug's readyz endpoint.\n\n[Note]\n- The 'traceparent' header (W3C Trace Context) is propagated to Tumblebug for distributed tracing.\n- The 'X-Request-Id' header is propagated for log correlation.\n- Use this API to verify that tracing works correctly between Beetle and Tumblebug."
+    RecommendVMInfraWithDefaults:
+      method: post
+      resourcePath: /recommendation/infraWithDefaults
+      description: "Recommend an appropriate VM infrastructure (i.e., MCI, multi-cloud infrastructure) with defaults for cloud migration\n\n[Note] `desiredCsp` and `desiredRegion` are required.\n- `desiredCsp` and `desiredRegion` can set on the query parameter or the request body.\n\n- If desiredCsp and desiredRegion are set on request body, the values in the query parameter will be ignored.\n\n**[Response Field: `nodeGroups[].cspImageName`]** Set only when the spec-image review resolved a newer image than the DB cache.\n- **Non-empty**: TumbleBug sends this to Spider directly, bypassing the per-VM image DB lookup (prevents stale image failures, e.g., Alibaba alibase images).\n- **Empty**: TumbleBug uses `imageId` for the standard DB lookup path."
+    RecommendVmSpecs:
+      method: post
+      resourcePath: /recommendation/resources/specs
+      description: "Recommend an appropriate VM specification for cloud migration\n\n[Note] `desiredProvider` and `desiredRegion` are required.\n- `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.\n\n- If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.\n- If `targetMachineId` is provided, only that specific machine will be processed."
+    GenerateMigrationReport:
+      method: post
+      resourcePath: /report/migration/ns/{nsId}/infra/{infraId}
+      description: "Generate a comprehensive migration report comparing source infrastructure with target cloud VMs, including resource mappings, network/security analysis, cost summary, and recommendations in Markdown or HTML format"
+    TestEncryptData:
+      method: post
+      resourcePath: /migration/data/test/encrypt
+      description: "**⚠️ FOR TESTING ONLY**: In production, encryption MUST be performed client-side.\nThis API is provided solely for testing the encryption workflow without implementing client-side encryption.\n\nReceives a plaintext DataMigrationModel and returns an encrypted version.\nThe server generates a new key pair, encrypts sensitive fields, and returns the encrypted model.\n\n[Security Warning]\n* Sending plaintext credentials to server defeats the purpose of encryption\n* Use this API only for development/testing environments\n* In production, use client-side encryption with GET /migration/data/encryptionKey\n\n[Test Workflow]\n1. Call GET /migration/data/encryptionKey to get a public key bundle\n2. Call this API with the public key bundle and plaintext model\n3. Receive encrypted model with keyId\n4. Call POST /migration/data/test/decrypt to verify decryption\n"
+    DeleteStorageObject:
+      method: delete
+      resourcePath: /migration/middleware/ns/{nsId}/objectStorage/{osId}/object/{objectKey}
+      description: "Delete a specific object from an object storage bucket\nby proxying Tumblebug DELETE /ns/{nsId}/resources/objectStorage/{osId}/object/{objectKey}.\nNote: URL-encode the objectKey if it contains slashes (e.g., folder%2Ffile.txt)."
+    GetStorageObject:
+      method: head
+      resourcePath: /migration/middleware/ns/{nsId}/objectStorage/{osId}/object/{objectKey}
+      description: "Retrieve metadata (key, size, ETag, last-modified, storage class) of a specific object\nby proxying Tumblebug HEAD /ns/{nsId}/resources/objectStorage/{osId}/object/{objectKey}.\nNote: URL-encode the objectKey if it contains slashes (e.g., folder%2Ffile.txt)."
+    RecommendVmOsImages:
+      method: post
+      resourcePath: /recommendation/resources/osImages
+      description: "Recommend an appropriate OS image for cloud migration\n\n[Note] `desiredProvider` and `desiredRegion` are required.\n- `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.\n\n- If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored."
+    RecommendVNet:
+      method: post
+      resourcePath: /recommendation/resources/vNet
+      description: "Recommend an appropriate virtual network for cloud migration\n\n[Note] `desiredProvider` and `desiredRegion` are required.\n- `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.\n\n- If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored."
+    GenerateSourceInfraSummary:
+      method: post
+      resourcePath: /summary/source
+      description: "Generate a comprehensive source infrastructure summary from on-premise data in multiple formats based on 'format' query parameter:\n\n**Response Format by 'format' Parameter:**\n- `format=json`: Returns ApiResponse[SourceInfraSummary] with Content-Type: application/json\n- `format=md` (default): Returns markdown string with Content-Type: text/markdown; charset=utf-8\n- `format=html`: Returns HTML string with Content-Type: text/html; charset=utf-8\n\n**Note:** API documentation shows JSON schema for reference, but actual default response is markdown format.\n\n**Markdown example**: https://github.com/cloud-barista/cm-beetle/blob/main/cmd/test-cli/infra/testresult/beetle-summary-source.md\n\n**Download Behavior:**\n- `download=false` (default): Content displayed inline (viewable in browser/Swagger UI)\n- `download=true`: Content downloaded as file (Content-Disposition: attachment)"
+    ListObjectStorageObjects:
+      method: get
+      resourcePath: /migration/middleware/ns/{nsId}/objectStorage/{osId}/object
+      description: "List all objects stored in a specific object storage bucket by proxying Tumblebug GET /ns/{nsId}/resources/objectStorage/{osId}/object"
+    MigrateInfra:
+      method: post
+      resourcePath: /migration/ns/{nsId}/infra
+      description: "Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults.\n\n**[Request Field: `nodeGroups[].cspImageName`]** Optional CSP-native image identifier.\n- **Non-empty**: TumbleBug sends this to Spider directly, bypassing the per-VM image DB lookup (prevents stale image failures, e.g., Alibaba alibase images).\n- **Empty**: TumbleBug uses `imageId` for the standard DB lookup (may encounter stale images for some CSPs).\n- Recommended: pass the recommendation API response as-is to use the latest resolved image."
+    ListInfra:
+      method: get
+      resourcePath: /migration/ns/{nsId}/infra
+      description: "Get the migrated multi-cloud infrastructure (MCI)"
+    GetInfra:
+      method: get
+      resourcePath: /migration/ns/{nsId}/infra/{infraId}
+      description: "Get the migrated multi-cloud infrastructure (MCI)"
+    DeleteInfra:
+      method: delete
+      resourcePath: /migration/ns/{nsId}/infra/{infraId}
+      description: "Delete the migrated mult-cloud infrastructure (MCI)"
+    ListMigratedSSHKeys:
+      method: get
+      resourcePath: /migration/ns/{nsId}/resources/sshKey
+      description: "Get the list of all migrated SSH keys in the namespace"
+    CreateMigratedSSHKey:
+      method: post
+      resourcePath: /migration/ns/{nsId}/resources/sshKey
+      description: "Create a new migrated SSH key in the namespace"
+    DeleteMigratedSSHKeys:
+      method: delete
+      resourcePath: /migration/ns/{nsId}/resources/sshKey
+      description: "Delete multiple migrated SSH keys in the namespace"
+    AlignNames:
+      method: post
+      resourcePath: /naming/alignment
+      description: "When a parent/primary resource is renamed (e.g., VNet), this API updates all\nchild/dependent references in the model (e.g., SecurityGroup.VNetId, SubGroup.VNetId).\n\n**Supported resourceType values** (cb-tumblebug convention):\n- `vNet` : Rename VNet → propagates to SecurityGroup.VNetId, SubGroup.VNetId\n- `subnet` : Rename Subnet → propagates to SubGroup.SubnetId\n- `sshKey` : Rename SSH Key → propagates to SubGroup.SshKeyId\n- `securityGroup` : Rename SecurityGroup → propagates to SubGroup.SecurityGroupIds\n- `infra` : Rename Infra (no child propagation)\n\nAfter propagation, names are validated for referential integrity.\nThe returned model uses **base names only** (NameSeed is applied at migration time via query param).\n\nSee also: [API Guide: Align Names](https://github.com/cloud-barista/cm-beetle/blob/main/docs/api-guide-align-names.md)\n"
+    ValidateNames:
+      method: post
+      resourcePath: /naming/validation
+      description: "Validates that all internal references within a RecommendedInfra model\nare consistent and point to existing resources.\nNameSeed is NOT applied here; this validates the base names only.\n"
+    RecommendObjectStorage:
+      method: post
+      resourcePath: /recommendation/middleware/objectStorage
+      description: "Recommend an appropriate object storage for cloud migration\n\n[Note] `desiredCsp` and `desiredRegion` are required.\n- `desiredCsp` and `desiredRegion` can set on the query parameter or the request body.\n\n- If desiredCsp and desiredRegion are set on request body, the values in the query parameter will be ignored.\n\n[Note] The recommended bucket name uses a default pattern (`mig-bucket-01`, `mig-bucket-02`, ...).\n- Bucket names must be globally unique across all accounts in the target cloud provider.\n- CB-Tumblebug internally generates a uid and uses it as the actual bucket name in the cloud.\n- The `bucketName` field in the recommendation result represents the intended name, not the final cloud resource name.\n\n[Note] To apply a naming prefix, use the `nameSeed` query parameter on the migration API (`POST /migration/.../objectStorage?nameSeed=xxx`).\n"
   cm-cicada:
-    Clear-Task-Instances:
-      method: post
-      resourcePath: /workflow/{wfId}/workflowRun/{wfRunId}/range
-      description: Clear the task Instance.
-    Create-Task-Component:
-      method: post
-      resourcePath: /task_component
-      description: Register the task component.
-    Create-Workflow:
-      method: post
-      resourcePath: /workflow
-      description: Create a workflow.
-    Delete-Task-Component:
-      method: delete
-      resourcePath: /task_component/{tcId}
-      description: Delete the task component.
-    Delete-Workflow:
-      method: delete
-      resourcePath: /workflow/{wfId}
-      description: Delete the workflow.
-    Get-Event-Logs:
-      method: get
-      resourcePath: /workflow/{wfId}/eventlogs
-      description: Get Eventlog.
-    Get-Import-Errors:
-      method: get
-      resourcePath: /importErrors
-      description: Get the importErrors.
-    Get-Task:
-      method: get
-      resourcePath: /workflow/{wfId}/task/{taskId}
-      description: Get the task.
-    Get-Task-Component:
-      method: get
-      resourcePath: /task_component/{tcId}
-      description: Get the task component.
-    Get-Task-Component-By-Name:
-      method: get
-      resourcePath: /task_component/name/{tcName}
-      description: Get the task component by name.
-    Get-Task-Directly:
-      method: get
-      resourcePath: /task/{taskId}
-      description: Get the task directly.
-    Get-Task-From-Task-Group:
-      method: get
-      resourcePath: /workflow/{wfId}/task_group/{tgId}/task/{taskId}
-      description: Get the task from the task group.
-    Get-Task-Group:
-      method: get
-      resourcePath: /workflow/{wfId}/task_group/{tgId}
-      description: Get the task group.
-    Get-Task-Group-Directly:
-      method: get
-      resourcePath: /task_group/{tgId}
-      description: Get the task group directly.
-    Get-Task-Instances:
-      method: get
-      resourcePath: /workflow/{wfId}/workflowRun/{wfRunId}/taskInstances
-      description: Get the task Logs.
-    Get-Task-Logs:
-      method: get
-      resourcePath: /workflow/{wfId}/workflowRun/{wfRunId}/task/{taskId}/taskTryNum/{taskTyNum}/logs
-      description: Get the task Logs.
-    Get-Task-Logs-Download:
-      method: get
-      resourcePath: /workflow/{wfId}/workflowRun/{wfRunId}/task/{taskId}/taskTryNum/{taskTyNum}/logs/download
-      description: Download the task logs as a file.
-    Get-Workflow:
-      method: get
-      resourcePath: /workflow/{wfId}
-      description: Get the workflow.
-    Get-Workflow-By-Name:
-      method: get
-      resourcePath: /workflow/name/{wfName}
-      description: Get the workflow by name.
-    Get-Workflow-Runs:
-      method: get
-      resourcePath: /workflow/{wfId}/runs
-      description: Get the task Logs.
-    Get-Workflow-Template:
-      method: get
-      resourcePath: /workflow_template/{wftId}
-      description: Get the workflow template.
     Get-Workflow-Template-By-Name:
       method: get
       resourcePath: /workflow_template/name/{wfName}
-      description: Get the workflow template by name.
-    Get-WorkflowStatus:
-      method: get
-      resourcePath: /workflow/{wfId}/status
-      description: Get the WorkflowStatus.
-    Get-WorkflowVersion:
-      method: get
-      resourcePath: /workflow/{wfId}/version/{verId}
-      description: Get the WorkflowVersion.
-    Health-Check-Readyz:
-      method: get
-      resourcePath: /readyz
-      description: Check Cicada is ready
-    List-Task:
-      method: get
-      resourcePath: /workflow/{wfId}/task
-      description: Get a task list of the workflow.
-    List-Task-Component:
-      method: get
-      resourcePath: /task_component
-      description: Get a list of task component.
-    List-Task-From-Task-Group:
-      method: get
-      resourcePath: /workflow/{wfId}/task_group/{tgId}/task
-      description: Get a task list from the task group.
-    List-Task-Group:
-      method: get
-      resourcePath: /workflow/{wfId}/task_group
-      description: Get a task group list of the workflow.
-    List-Workflow:
-      method: get
-      resourcePath: /workflow
-      description: Get a workflow list.
-    List-Workflow-Template:
-      method: get
-      resourcePath: /workflow_template
-      description: Get a list of workflow template.
-    List-WorkflowVersion:
-      method: get
-      resourcePath: /workflow/{wfId}/version
-      description: Get a workflowVersion list.
-    Run-Workflow:
+      description: "Get the workflow template by name."
+    Run-Script:
       method: post
-      resourcePath: /workflow/{wfId}/run
-      description: Run the workflow.
-    Update-Task-Component:
-      method: put
-      resourcePath: /task_component/{tcId}
-      description: Update the task component.
+      resourcePath: /run_script
+      description: "Run script on target with NS ID, MCI ID and VM ID."
+    Sleep-Time:
+      method: post
+      resourcePath: /sleep_time
+      description: "Runs sleep command on cicada and waits for configured time. Wait for 10 seconds if time value is not provided."
     Update-Workflow:
       method: put
       resourcePath: /workflow/{wfId}
-      description: Update the workflow content.
-  cm-damselfly:
-    CreateCloudModel:
-      method: post
-      resourcePath: /cloudmodel
-      description: Create a new cloud user model with the given information.
-    CreateOnPremModel:
-      method: post
-      resourcePath: /onpremmodel
-      description: Create a new on-premise model with the given information.
-    CreateSourceSoftwareModel:
-      method: post
-      resourcePath: /softwaremodel/source
-      description: Create a new source software user model with the given information.
-    CreateTargetSoftwareModel:
-      method: post
-      resourcePath: /softwaremodel/target
-      description: Create a new target software user model with the given information.
-    DeleteCloudModel:
+      description: "Update the workflow content."
+    Delete-Workflow:
       method: delete
-      resourcePath: /cloudmodel/{id}
-      description: Delete a cloud user model with the given information.
-    DeleteOnPremModel:
-      method: delete
-      resourcePath: /onpremmodel/{id}
-      description: Delete a on-premise model with the given information.
-    DeleteSourceSoftwareModel:
-      method: delete
-      resourcePath: /softwaremodel/source/{id}
-      description: Delete a source software user model with the given information.
-    DeleteTargetSoftwareModel:
-      method: delete
-      resourcePath: /softwaremodel/target/{id}
-      description: Delete a target software user model with the given information.
-    GetCloudModel:
+      resourcePath: /workflow/{wfId}
+      description: "Delete the workflow."
+    Get-Workflow:
       method: get
-      resourcePath: /cloudmodel/{id}
-      description: Get a specific cloud user model.
+      resourcePath: /workflow/{wfId}
+      description: "Get the workflow."
+    Get-Task-From-Task-Group:
+      method: get
+      resourcePath: /workflow/{wfId}/task_group/{tgId}/task/{taskId}
+      description: "Get the task from the task group."
+    Health-Check-Readyz:
+      method: get
+      resourcePath: /readyz
+      description: "Check Cicada is ready"
+    Delete-Task-Component:
+      method: delete
+      resourcePath: /task_component/{tcId}
+      description: "Delete the task component."
+    Get-Task-Component:
+      method: get
+      resourcePath: /task_component/{tcId}
+      description: "Get the task component."
+    Update-Task-Component:
+      method: put
+      resourcePath: /task_component/{tcId}
+      description: "Update the task component."
+    Get-Task-Group-Directly:
+      method: get
+      resourcePath: /task_group/{tgId}
+      description: "Get the task group directly."
+    List-Workflow:
+      method: get
+      resourcePath: /workflow
+      description: "Get a workflow list."
+    Create-Workflow:
+      method: post
+      resourcePath: /workflow
+      description: "Create a workflow."
+    Get-Workflow-Runs:
+      method: get
+      resourcePath: /workflow/{wfId}/runs
+      description: "Get the task Logs."
+    Get-Workflow-Template:
+      method: get
+      resourcePath: /workflow_template/{wftId}
+      description: "Get the workflow template."
+    List-Task-From-Task-Group:
+      method: get
+      resourcePath: /workflow/{wfId}/task_group/{tgId}/task
+      description: "Get a task list from the task group."
+    List-WorkflowVersion:
+      method: get
+      resourcePath: /workflow/{wfId}/version
+      description: "Get a workflowVersion list."
+    Get-WorkflowVersion:
+      method: get
+      resourcePath: /workflow/{wfId}/version/{verId}
+      description: "Get the WorkflowVersion."
+    Clear-Task-Instances:
+      method: post
+      resourcePath: /workflow/{wfId}/workflowRun/{wfRunId}/range
+      description: "Clear the task Instance."
+    Get-Task-Logs-Download:
+      method: get
+      resourcePath: /workflow/{wfId}/workflowRun/{wfRunId}/task/{taskId}/taskTryNum/{taskTryNum}/logs/download
+      description: "Download the task logs as a file."
+    Get-Task-Directly:
+      method: get
+      resourcePath: /task/{taskId}
+      description: "Get the task directly."
+    Get-Workflow-By-Name:
+      method: get
+      resourcePath: /workflow/name/{wfName}
+      description: "Get the workflow by name."
+    Get-Event-Logs:
+      method: get
+      resourcePath: /workflow/{wfId}/eventlogs
+      description: "Get Eventlog."
+    Get-Task:
+      method: get
+      resourcePath: /workflow/{wfId}/task/{taskId}
+      description: "Get the task."
+    List-Workflow-Template:
+      method: get
+      resourcePath: /workflow_template
+      description: "Get a list of workflow template."
+    Get-WorkflowStatus:
+      method: get
+      resourcePath: /workflow/{wfId}/status
+      description: "Get the WorkflowStatus."
+    Get-Task-Logs:
+      method: get
+      resourcePath: /workflow/{wfId}/workflowRun/{wfRunId}/task/{taskId}/taskTryNum/{taskTryNum}/logs
+      description: "Get the task Logs."
+    Get-Import-Errors:
+      method: get
+      resourcePath: /importErrors
+      description: "Get the importErrors."
+    Get-Task-Component-By-Name:
+      method: get
+      resourcePath: /task_component/name/{tcName}
+      description: "Get the task component by name."
+    Run-Workflow:
+      method: post
+      resourcePath: /workflow/{wfId}/run
+      description: "Run the workflow."
+    List-Task:
+      method: get
+      resourcePath: /workflow/{wfId}/task
+      description: "Get a task list of the workflow."
+    List-Task-Component:
+      method: get
+      resourcePath: /task_component
+      description: "Get a list of task component."
+    Create-Task-Component:
+      method: post
+      resourcePath: /task_component
+      description: "Register the task component."
+    List-Task-Group:
+      method: get
+      resourcePath: /workflow/{wfId}/task_group
+      description: "Get a task group list of the workflow."
+    Get-Task-Group:
+      method: get
+      resourcePath: /workflow/{wfId}/task_group/{tgId}
+      description: "Get the task group."
+    Get-Task-Instances:
+      method: get
+      resourcePath: /workflow/{wfId}/workflowRun/{wfRunId}/taskInstances
+      description: "Get the task Logs."
+  cm-damselfly:
+    version: 0.5.1
     GetCloudModels:
       method: get
       resourcePath: /cloudmodel
-      description: Get a list of cloud user models.
-    GetModels:
-      method: get
-      resourcePath: /model/{isTargetModel}
-      description: Get a list of all user models.
+      description: "Get a list of cloud user models."
+    CreateCloudModel:
+      method: post
+      resourcePath: /cloudmodel
+      description: "Create a new cloud user model with the given information."
     GetModelsVersion:
       method: get
       resourcePath: /model/version
-      description: Get the versions of all models(schemata of on-premise/cloud/software
-        migration models)
+      description: "Get the versions of all models(schemata of on-premise/cloud/software migration models)"
+    GetModels:
+      method: get
+      resourcePath: /model/{isTargetModel}
+      description: "Get a list of all user models."
     GetOnPremModel:
       method: get
       resourcePath: /onpremmodel/{id}
-      description: Get a specific on-premise model.
-    GetOnPremModels:
-      method: get
-      resourcePath: /onpremmodel
-      description: Get a list of on-premise models.
-    GetSourceSoftwareModel:
-      method: get
-      resourcePath: /softwaremodel/source/{id}
-      description: Get a specific source software user model.
-    GetSourceSoftwareModels:
-      method: get
-      resourcePath: /softwaremodel/source
-      description: Get a list of source software user models.
-    GetTargetSoftwareModel:
-      method: get
-      resourcePath: /softwaremodel/target/{id}
-      description: Get a specific target software user model.
-    GetTargetSoftwareModels:
-      method: get
-      resourcePath: /softwaremodel/target
-      description: Get a list of target software user models.
-    RestCheckHTTPVersion:
-      method: get
-      resourcePath: /httpVersion
-      description: Checks and logs the HTTP version of the incoming request to the
-        server console.
-    RestGetReadyz:
-      method: get
-      resourcePath: /readyz
-      description: Check Damselfly is ready
-    UpdateCloudModel:
-      method: put
-      resourcePath: /cloudmodel/{id}
-      description: Update a cloud user model with the given information.
+      description: "Get a specific on-premise model."
     UpdateOnPremModel:
       method: put
       resourcePath: /onpremmodel/{id}
-      description: Update a on-premise model with the given information.
+      description: "Update a on-premise model with the given information."
+    DeleteOnPremModel:
+      method: delete
+      resourcePath: /onpremmodel/{id}
+      description: "Delete a on-premise model with the given information."
+    GetSourceSoftwareModel:
+      method: get
+      resourcePath: /softwaremodel/source/{id}
+      description: "Get a specific source software user model."
     UpdateSourceSoftwareModel:
       method: put
       resourcePath: /softwaremodel/source/{id}
-      description: Update a source software user model with the given information.
+      description: "Update a source software user model with the given information."
+    DeleteSourceSoftwareModel:
+      method: delete
+      resourcePath: /softwaremodel/source/{id}
+      description: "Delete a source software user model with the given information."
+    GetTargetSoftwareModels:
+      method: get
+      resourcePath: /softwaremodel/target
+      description: "Get a list of target software user models."
+    CreateTargetSoftwareModel:
+      method: post
+      resourcePath: /softwaremodel/target
+      description: "Create a new target software user model with the given information."
+    GetTargetSoftwareModel:
+      method: get
+      resourcePath: /softwaremodel/target/{id}
+      description: "Get a specific target software user model."
     UpdateTargetSoftwareModel:
       method: put
       resourcePath: /softwaremodel/target/{id}
-      description: Update a target software user model with the given information.
+      description: "Update a target software user model with the given information."
+    DeleteTargetSoftwareModel:
+      method: delete
+      resourcePath: /softwaremodel/target/{id}
+      description: "Delete a target software user model with the given information."
+    GetCloudModel:
+      method: get
+      resourcePath: /cloudmodel/{id}
+      description: "Get a specific cloud user model."
+    UpdateCloudModel:
+      method: put
+      resourcePath: /cloudmodel/{id}
+      description: "Update a cloud user model with the given information."
+    DeleteCloudModel:
+      method: delete
+      resourcePath: /cloudmodel/{id}
+      description: "Delete a cloud user model with the given information."
+    RestCheckHTTPVersion:
+      method: get
+      resourcePath: /httpVersion
+      description: "Checks and logs the HTTP version of the incoming request to the server console."
+    GetOnPremModels:
+      method: get
+      resourcePath: /onpremmodel
+      description: "Get a list of on-premise models."
+    CreateOnPremModel:
+      method: post
+      resourcePath: /onpremmodel
+      description: "Create a new on-premise model with the given information."
+    RestGetReadyz:
+      method: get
+      resourcePath: /readyz
+      description: "Check Damselfly is ready"
+    GetSourceSoftwareModels:
+      method: get
+      resourcePath: /softwaremodel/source
+      description: "Get a list of source software user models."
+    CreateSourceSoftwareModel:
+      method: post
+      resourcePath: /softwaremodel/source
+      description: "Create a new source software user model with the given information."
   cm-grasshopper:
+    Get-Software-Migration-Status:
+      method: get
+      resourcePath: /software/migrate/status/{executionId}
+      description: "Get the software migration status."
     Get-Migration-List:
       method: post
       resourcePath: /software/migration_list
-      description: Get software migration list.
-    Get-Software-Migration-Log:
-      method: get
-      resourcePath: /software/package/migrate/log/{executionId}
-      description: Get the software migration log.
+      description: "Get software migration list."
     Health-Check-Readyz:
       method: get
       resourcePath: /readyz
-      description: Check Grasshopper is ready
+      description: "Check Grasshopper is ready"
     Migrate-Software:
       method: post
       resourcePath: /software/migrate
-      description: Migrate pieces of software to target.
+      description: "Migrate pieces of software to target."
+    Get-Software-Migration-Log:
+      method: get
+      resourcePath: /software/migrate/log/{executionId}
+      description: "Get the software migration log."
+    List-Software-Migration-Status:
+      method: get
+      resourcePath: /software/migrate/status
+      description: "Get a list of software migration status."
   cm-honeybee-agent:
+    Get-Data-Info:
+      method: get
+      resourcePath: /data
+      description: "Get data migration information (required fields only for data migration)."
     Get-Helm-Info:
       method: get
       resourcePath: /helm
-      description: Get helm information.
+      description: "Get helm information."
     Get-Infra-Info:
       method: get
       resourcePath: /infra
-      description: Get infra information.
+      description: "Get infra information."
     Get-Kubernetes-Info:
       method: get
       resourcePath: /kubernetes
-      description: Get kubernetes information.
+      description: "Get kubernetes information."
+    Health-Check-Readyz:
+      method: get
+      resourcePath: /readyz
+      description: "Check Honeybee Agent is ready"
     Get-Software-Info:
       method: get
       resourcePath: /software
-      description: Get software information.
-    Health-Check-Readyz:
-      method: get
-      resourcePath: /readyz
-      description: Check Honeybee Agent is ready
+      description: "Get software information."
   cm-honeybee:
-    Create-Connection-Info:
-      method: post
-      resourcePath: /source_group/{sgId}/connection_info
-      description: Create the connection information.
-    Delete-Connection-Info:
-      method: delete
-      resourcePath: /source_group/{sgId}/connection_info/{connId}
-      description: Delete the connection information.
-    Delete-Source-Group:
-      method: delete
-      resourcePath: /source_group/{sgId}
-      description: Delete the source group.
-    Get-Benchmark-Info:
-      method: get
-      resourcePath: /bench/{connId}
-      description: Get the benchmark information of the connection information.
-    Get-Connection-Info:
-      method: get
-      resourcePath: /source_group/{sgId}/connection_info/{connId}
-      description: Get the connection information.
-    Get-Connection-Info-Directly:
-      method: get
-      resourcePath: /connection_info/{connId}
-      description: Get the connection information directly.
-    Get-Helm-Info:
-      method: get
-      resourcePath: /source_group/{sgId}/connection_info/{connId}/helm
-      description: Get the helm information of the connection information.
     Get-Helm-Info-Source-Group:
       method: get
       resourcePath: /source_group/{sgId}/helm
-      description: Get the helm information for all connections in the source group.
-    Get-Infra-Info:
+      description: "Get the helm information for all connections in the source group."
+    Get-Connection-Info-Directly:
       method: get
-      resourcePath: /source_group/{sgId}/connection_info/{connId}/infra
-      description: Get the infra information of the connection information.
-    Get-Infra-Info-Refined:
-      method: get
-      resourcePath: /source_group/{sgId}/connection_info/{connId}/infra/refined
-      description: Get the refined infra information of the connection information.
-    Get-Infra-Info-Source-Group:
-      method: get
-      resourcePath: /source_group/{sgId}/infra
-      description: Get the infra information for all connections in the source group.
-    Get-Infra-Info-Source-Group-Refined:
-      method: get
-      resourcePath: /source_group/{sgId}/infra/refined
-      description: Get the refined infra information for all connections in the source
-        group.
-    Get-Kubernetes-Info:
-      method: get
-      resourcePath: /source_group/{sgId}/connection_info/{connId}/kubernetes
-      description: Get the kubernetes information of the connection information.
-    Get-Kubernetes-Info-Source-Group:
-      method: get
-      resourcePath: /source_group/{sgId}/kubernetes
-      description: Get the kubernetes information for all connections in the source
-        group.
-    Get-Software-Info:
-      method: get
-      resourcePath: /source_group/{sgId}/connection_info/{connId}/software
-      description: Get the software information of the connection information.
-    Get-Software-Info-Refined:
-      method: get
-      resourcePath: /source_group/{sgId}/connection_info/{connId}/software/refined
-      description: Get the refined software information of the connection information.
-    Get-Software-Info-Source-Group:
-      method: get
-      resourcePath: /source_group/{sgId}/software
-      description: Get the software information for all connections in the source
-        group.
-    Get-Software-Info-Source-Group-Refined:
-      method: get
-      resourcePath: /source_group/{sgId}/software/refined
-      description: Get the refined software information for all connections in the
-        source group.
-    Get-Source-Group:
-      method: get
-      resourcePath: /source_group/{sgId}
-      description: Get the source group.
-    Health-Check-Readyz:
-      method: get
-      resourcePath: /readyz
-      description: Check Honeybee is ready
-    Import-Helm:
-      method: post
-      resourcePath: /source_group/{sgId}/connection_info/{connId}/import/helm
-      description: Import the helm information.
-    Import-Helm-Source-Group:
-      method: post
-      resourcePath: /source_group/{sgId}/import/helm
-      description: Import helm information for all connections in the source group.
-    Import-Infra:
-      method: post
-      resourcePath: /source_group/{sgId}/connection_info/{connId}/import/infra
-      description: Import the infra information.
-    Import-Infra-Source-Group:
-      method: post
-      resourcePath: /source_group/{sgId}/import/infra
-      description: Import infra information for all connections in the source group.
-    Import-Kubernetes:
-      method: post
-      resourcePath: /source_group/{sgId}/connection_info/{connId}/import/kubernetes
-      description: Import the kubernetes information.
-    Import-Kubernetes-Source-Group:
-      method: post
-      resourcePath: /source_group/{sgId}/import/kubernetes
-      description: Import kubernetes information for all connections in the source
-        group.
+      resourcePath: /connection_info/{connId}
+      description: "Get the connection information directly."
     Import-Software:
       method: post
       resourcePath: /source_group/{sgId}/connection_info/{connId}/import/software
-      description: Import the software information.
-    Import-Software-Source-Group:
+      description: "Import the software information."
+    Import-Helm-Source-Group:
       method: post
-      resourcePath: /source_group/{sgId}/import/software
-      description: Import software information for all connections in the source group.
-    List-Connection-Info:
+      resourcePath: /source_group/{sgId}/import/helm
+      description: "Import helm information for all connections in the source group."
+    Import-Infra-Source-Group:
+      method: post
+      resourcePath: /source_group/{sgId}/import/infra
+      description: "Import infra information for all connections in the source group."
+    Get-Benchmark-Info:
       method: get
-      resourcePath: /source_group/{sgId}/connection_info
-      description: Get a list of connection information.
-    List-Source-Group:
+      resourcePath: /bench/{connId}
+      description: "Get the benchmark information of the connection information."
+    Delete-Source-Group:
+      method: delete
+      resourcePath: /source_group/{sgId}
+      description: "Delete the source group."
+    Get-Source-Group:
       method: get
-      resourcePath: /source_group
-      description: Get a list of source group.
-    Refresh-Connection-Info-Status:
-      method: put
-      resourcePath: /source_group/{sgId}/connection_info/{connId}/refresh
-      description: Refresh the connection info status.
-    Refresh-Connection-Info-Status-Directly:
-      method: put
-      resourcePath: /connection_info/{connId}/refresh
-      description: Refresh the connection info status directly.
-    Refresh-Source-Group-Connection-Info-Status:
-      method: put
-      resourcePath: /source_group/{sgId}/refresh
-      description: Refresh connection info status of the source group.
-    Register-Source-Group:
-      method: post
-      resourcePath: /source_group
-      description: Register the source group.
-    Register-Target-To-Source-Group:
-      method: post
-      resourcePath: /source_group/{sgId}/target
-      description: Register target information to the source group.
-    Run-Benchmark-Info:
-      method: post
-      resourcePath: /bench/{connId}/run
-      description: Run the benchmark information of the connection information. If
-        no Benchmark Agent is present on the connected server, it will be automatically
-        installed, and the benchmark will be executed.
-    Stop-Benchmark:
-      method: post
-      resourcePath: /bench/{connId}/stop
-      description: Stop the benchmark
-    Update-Connection-Info:
-      method: put
-      resourcePath: /source_group/{sgId}/connection_info/{connId}
-      description: Update the connection information.
+      resourcePath: /source_group/{sgId}
+      description: "Get the source group."
     Update-Source-Group:
       method: put
       resourcePath: /source_group/{sgId}
-      description: Update the source group.
+      description: "Update the source group."
+    Get-Data-Info:
+      method: get
+      resourcePath: /source_group/{sgId}/connection_info/{connId}/data
+      description: "Get the data information of the connection information."
+    Import-Infra:
+      method: post
+      resourcePath: /source_group/{sgId}/connection_info/{connId}/import/infra
+      description: "Import the infra information."
+    Refresh-Connection-Info-Status-Directly:
+      method: put
+      resourcePath: /connection_info/{connId}/refresh
+      description: "Refresh the connection info status directly."
+    Get-Infra-Info-Source-Group:
+      method: get
+      resourcePath: /source_group/{sgId}/infra
+      description: "Get the infra information for all connections in the source group."
+    Get-Kubernetes-Info-Source-Group:
+      method: get
+      resourcePath: /source_group/{sgId}/kubernetes
+      description: "Get the kubernetes information for all connections in the source group."
+    Get-Software-Info-Source-Group:
+      method: get
+      resourcePath: /source_group/{sgId}/software
+      description: "Get the software information for all connections in the source group."
+    Get-Helm-Info:
+      method: get
+      resourcePath: /source_group/{sgId}/connection_info/{connId}/helm
+      description: "Get the helm information of the connection information."
+    Import-Helm:
+      method: post
+      resourcePath: /source_group/{sgId}/connection_info/{connId}/import/helm
+      description: "Import the helm information."
+    Get-Infra-Info-Refined:
+      method: get
+      resourcePath: /source_group/{sgId}/connection_info/{connId}/infra/refined
+      description: "Get the refined infra information of the connection information."
+    Import-Data-Source-Group:
+      method: post
+      resourcePath: /source_group/{sgId}/import/data
+      description: "Import data information for all connections in the source group."
+    Stop-Benchmark:
+      method: post
+      resourcePath: /bench/{connId}/stop
+      description: "Stop the benchmark"
+    Health-Check-Readyz:
+      method: get
+      resourcePath: /readyz
+      description: "Check Honeybee is ready"
+    Get-Connection-Info:
+      method: get
+      resourcePath: /source_group/{sgId}/connection_info/{connId}
+      description: "Get the connection information."
+    Update-Connection-Info:
+      method: put
+      resourcePath: /source_group/{sgId}/connection_info/{connId}
+      description: "Update the connection information."
+    Delete-Connection-Info:
+      method: delete
+      resourcePath: /source_group/{sgId}/connection_info/{connId}
+      description: "Delete the connection information."
+    Import-Kubernetes:
+      method: post
+      resourcePath: /source_group/{sgId}/connection_info/{connId}/import/kubernetes
+      description: "Import the kubernetes information."
+    Get-Infra-Info:
+      method: get
+      resourcePath: /source_group/{sgId}/connection_info/{connId}/infra
+      description: "Get the infra information of the connection information."
+    Get-Software-Info:
+      method: get
+      resourcePath: /source_group/{sgId}/connection_info/{connId}/software
+      description: "Get the software information of the connection information."
+    Import-Kubernetes-Source-Group:
+      method: post
+      resourcePath: /source_group/{sgId}/import/kubernetes
+      description: "Import kubernetes information for all connections in the source group."
+    Get-Software-Info-Source-Group-Refined:
+      method: get
+      resourcePath: /source_group/{sgId}/software/refined
+      description: "Get the refined software information for all connections in the source group."
+    Get-Data-Info-Source-Group:
+      method: get
+      resourcePath: /source_group/{sgId}/data
+      description: "Get the data information for all connections in the source group."
+    List-Connection-Info:
+      method: get
+      resourcePath: /source_group/{sgId}/connection_info
+      description: "Get a list of connection information."
+    Create-Connection-Info:
+      method: post
+      resourcePath: /source_group/{sgId}/connection_info
+      description: "Create the connection information."
+    Import-Data:
+      method: post
+      resourcePath: /source_group/{sgId}/connection_info/{connId}/import/data
+      description: "Import the data information."
+    Get-Kubernetes-Info:
+      method: get
+      resourcePath: /source_group/{sgId}/connection_info/{connId}/kubernetes
+      description: "Get the kubernetes information of the connection information."
+    Refresh-Connection-Info-Status:
+      method: put
+      resourcePath: /source_group/{sgId}/connection_info/{connId}/refresh
+      description: "Refresh the connection info status."
+    Get-Infra-Info-Source-Group-Refined:
+      method: get
+      resourcePath: /source_group/{sgId}/infra/refined
+      description: "Get the refined infra information for all connections in the source group."
+    Run-Benchmark-Info:
+      method: post
+      resourcePath: /bench/{connId}/run
+      description: "Run the benchmark information of the connection information. If no Benchmark Agent is present on the connected server, it will be automatically installed, and the benchmark will be executed."
+    Refresh-Source-Group-Connection-Info-Status:
+      method: put
+      resourcePath: /source_group/{sgId}/refresh
+      description: "Refresh connection info status of the source group."
+    List-Source-Group:
+      method: get
+      resourcePath: /source_group
+      description: "Get a list of source group."
+    Register-Source-Group:
+      method: post
+      resourcePath: /source_group
+      description: "Register the source group."
+    Get-Software-Info-Refined:
+      method: get
+      resourcePath: /source_group/{sgId}/connection_info/{connId}/software/refined
+      description: "Get the refined software information of the connection information."
+    Import-Software-Source-Group:
+      method: post
+      resourcePath: /source_group/{sgId}/import/software
+      description: "Import software information for all connections in the source group."
+    Register-Target-To-Source-Group:
+      method: post
+      resourcePath: /source_group/{sgId}/target
+      description: "Register target information to the source group."


### PR DESCRIPTION
## What

Refresh `conf/api.yaml` so the `services.version` and `serviceActions` (operationId → method / resourcePath / description) entries match the **cm-beetle v0.5.3 reference lineup**. Configuration only — no Go source or binary changes.

## Why

`conf/api.yaml` is the catalog that backs the `mayfly api` / `mayfly rest` helpers (service list, per-service action lookup, request routing). It had drifted to an old baseline (cb-tumblebug/cb-spider `0.11.13`, the cm-* frameworks `0.4.0`), so endpoints added or renamed in the current lineup were missing or stale and `mayfly api` surfaced an outdated action set.

The version basis follows the rule used across the project: pin to the lineup **cm-beetle's latest release was built and verified against** (cb-tumblebug, cb-spider), and take each remaining sub-framework's own latest release for the components cm-beetle does not pin.

## Version changes (`services.version`)

| Service | old → new | basis |
|---|---|---|
| cb-tumblebug | 0.11.13 → **0.12.19** | cm-beetle v0.5.3 lineup |
| cb-spider | 0.11.13 → **0.12.32** | cm-beetle v0.5.3 lineup |
| cm-beetle | 0.4.0 → **0.5.3** | latest release |
| cm-honeybee | 0.4.0 → **0.5.0** | latest release |
| cm-cicada | 0.4.0 → **0.5.0** | latest release |
| cm-grasshopper | 0.4.0 → **0.5.0** | latest release |
| cm-damselfly | (no field) → **0.5.1** | latest release (version field newly added) |
| cm-ant | 0.4.0 → **0.5.0** | latest release |
| cm-butterfly-api | 0.4.0 (unchanged) | out of scope here |

## serviceActions changes (operationId count)

"Added / removed" = operationIds that appear / disappear in the new lineup's Swagger.

| Service | operationId (old → new) | added | removed |
|---|:---:|:---:|:---:|
| cb-tumblebug | 206 → 328 | 162 | 40 |
| cb-spider | 171 → 218 | 47 | none |
| cm-beetle | 27 → 61 | 36 | 2 |
| cm-honeybee | 39 → 43 | 4 | none |
| cm-cicada | 35 → 37 | 2 | none |
| cm-grasshopper | 4 → 6 | 2 | none |
| cm-damselfly | 24 → 25 | 1 | none |
| cm-honeybee-agent | 5 → 6 | 1 | none |
| cm-ant | 28 → 28 | none | none |

Removed operationIds (cb-tumblebug 40, cm-beetle 2) are the main compatibility watch points for any consumer that calls those endpoints by id (e.g. a UI proxy) — they were renamed or dropped upstream.

## How it was generated

1. Fetch each sub-framework's `swagger.json` at its target tag (cb-tumblebug `src/interface/rest/docs/swagger.json` @ v0.12.19; cb-spider / cm-beetle / cm-damselfly / cm-ant `api/swagger.json`; cm-cicada / cm-grasshopper `pkg/api/rest/docs/swagger.json`; cm-honeybee server + agent).
2. Generate per-service `serviceActions` with `mayfly api tool -f <swagger>`.
3. Replace the `serviceActions` block and bump `services.version`, **keeping the existing `.env`-based basic-auth placeholders (`${...}`) intact** — only API definitions/versions change, credentials still resolve from `.env`.
4. Operations without an operationId (6 on cb-spider) are skipped to avoid empty keys.

## Validation

| # | Check | Command | Result |
|---|---|---|---|
| 1 | YAML parses | `yaml.safe_load` | services 9 / serviceActions 9 / 752 actions — PASS |
| 2 | mayfly loads catalog | `mayfly api --list` | 9 services listed — PASS |
| 3 | per-service actions | `mayfly api --service cm-beetle --list` | actions listed — PASS |
| 4 | credentials preserved | grep services block | `${SPIDER_USERNAME}` etc. `${...}` retained — PASS |

Runtime call-through against a live lineup is covered by the v0.6.0 lineup integration test.