### PR TITLE
feat(api): bump cm-ant lineup to v0.5.1 in api.yaml

### DIFF
--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -54,7 +54,7 @@ services:
       username: ${TB_API_USERNAME}
       password: ${TB_API_PASSWORD}
   cm-ant:
-    version: 0.5.0
+    version: 0.5.1
     baseurl: http://cm-ant:8880/ant
     auth:
       type: none


### PR DESCRIPTION
## What

Bump the cm-ant entry in `conf/api.yaml` (`services.cm-ant.version`) from 0.5.0 to 0.5.1.

## Why

cm-ant released v0.5.1. The `api.yaml` catalog still pointed at 0.5.0, so the recorded lineup version was stale.

## Changes

- `services.cm-ant.version`: 0.5.0 → 0.5.1 (single line).
- **serviceActions unchanged.** The cm-ant `serviceActions` were regenerated from the cm-ant v0.5.1 `api/swagger.json` and compared against the current catalog: all 28 operationIds match (same method, resourcePath, and description), i.e. the v0.5.1 REST API surface is identical to v0.5.0. Only the version field is bumped — no action entries are reshuffled.
- The `.env`-based basic-auth placeholders and the other services' entries are untouched.

Configuration only — no source or binary changes.

## Validation

- `mayfly api --list` — 9 services load correctly
- `mayfly api -s cm-ant --list` — cm-ant actions list correctly
- YAML parses (9 services / 9 serviceActions / cm-ant 28 actions)