### PR TITLE
feat(api): bump cm-ant lineup to v0.5.2 in api.yaml

### DIFF
--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -54,7 +54,7 @@ services:
       username: ${TB_API_USERNAME}
       password: ${TB_API_PASSWORD}
   cm-ant:
-    version: 0.5.0
+    version: 0.5.2
     baseurl: http://cm-ant:8880/ant
     auth:
       type: none
@@ -2310,7 +2310,7 @@ serviceActions:
     AntServerReadiness:
       method: get
       resourcePath: /readyz
-      description: "This endpoint checks if the CB-Ant API server is ready by verifying the status of both the load service and the cost service. If either service is unavailable, it returns a 503 status indicating the server is not ready."
+      description: "Returns CM-Ant server readiness including DB and outbound\ndependency (cb-spider, cb-tumblebug) reachability and\nauthentication. Per STANDARD-READYZ pattern B, the response\nbody always carries per-dependency status; the HTTP status is\n200 when every dependency is reachable and authenticated, and\n503 otherwise. Results are cached briefly to limit outbound\ncall rate; see STANDARD-READYZ for details."
     UpdateEstimateForecastCost:
       method: post
       resourcePath: /api/v1/cost/estimate/forecast


### PR DESCRIPTION
## What

Update the cm-ant entry in `conf/api.yaml` to v0.5.2: `services.cm-ant.version` 0.5.0 → 0.5.2, and refresh the `/readyz` (`AntServerReadiness`) action description.

## Why

The cm-ant v0.5.1 tag shipped a stale Swagger spec (its `api/swagger.json` was not regenerated), so it could not be used to refresh the catalog. The spec has since been regenerated on cm-ant upstream main, so the cm-ant `serviceActions` are regenerated from that corrected source.

## Changes

- `services.cm-ant.version`: 0.5.0 → 0.5.2.
- `serviceActions.cm-ant.AntServerReadiness` (`/readyz`) description updated to document the dependency-aware readiness behavior (DB and cb-spider / cb-tumblebug reachability + authentication; 200 when all dependencies are reachable and authenticated, 503 otherwise).
- The other 27 operationIds are unchanged (verified by a normalized comparison: same method, resourcePath, description).
- `.env`-based basic-auth placeholders and the other services' entries are untouched.

Configuration only — no source or binary changes.

## Validation

- `mayfly api --list` — 9 services load correctly
- `mayfly api -s cm-ant --list` — cm-ant actions list correctly
- YAML parses (9 services / 9 serviceActions / cm-ant 28 actions)