### PR TITLE
chore(lineup): bump cm-ant image to 0.5.2 in docker-compose

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -865,7 +865,7 @@ services:
   cm-ant:
     container_name: cm-ant
     # image: cloudbaristaorg/cm-ant:edge
-    image: cloudbaristaorg/cm-ant:0.5.1
+    image: cloudbaristaorg/cm-ant:0.5.2
     platform: linux/amd64
     pull_policy: always
     ports:


### PR DESCRIPTION
## What

Bump the cm-ant service image tag in `conf/docker/docker-compose.yaml` from 0.5.1 to 0.5.2, matching the cm-ant catalog entry in `api.yaml`. The `edge` toggle line above is preserved.

## Changes

- `conf/docker/docker-compose.yaml`: `cloudbaristaorg/cm-ant:0.5.1` → `0.5.2` (single line).

The `cloudbaristaorg/cm-ant:0.5.2` image is published on Docker Hub.

Configuration only — no source or binary changes.

## Note

cm-ant v0.5.2 introduces a dependency-aware `/readyz` (it checks cb-spider / cb-tumblebug reachability and authentication), so the cm-ant container's health now depends on those credentials being wired through `.env` (already provided by the current lineup's Basic Auth mappings).