### PR TITLE
chore(lineup): bump cm-ant image and api.yaml to 0.5.3

### DIFF
--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -60,7 +60,7 @@ services:
       latest: https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/src/interface/rest/docs/swagger.json
       release: https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/{release}/src/interface/rest/docs/swagger.json
   cm-ant:
-    version: 0.5.2(0.6.0)
+    version: 0.5.3(0.6.0)
     baseurl: http://cm-ant:8880/ant
     auth:
       type: none

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -865,7 +865,7 @@ services:
   cm-ant:
     container_name: cm-ant
     # image: cloudbaristaorg/cm-ant:edge
-    image: cloudbaristaorg/cm-ant:0.5.2
+    image: cloudbaristaorg/cm-ant:0.5.3
     platform: linux/amd64
     pull_policy: always
     ports:


### PR DESCRIPTION
## Summary

Update the cm-ant lineup to the official **0.5.3** release in both `conf/docker/docker-compose.yaml` (service image tag) and `conf/api.yaml` (lineup version).

Other services stay on the current cm-beetle v0.5.4 Related Components lineup (cb-tumblebug 0.12.22 / cb-spider 0.12.32 / cb-mapui 0.12.47 / mc-terrarium 0.1.4) — this change is cm-ant only.

## Lineup

| Service | Before | After |
|---|---|---|
| cm-ant | 0.5.2 | **0.5.3** |

## Verification

Brought up the full stack on a remote test server with the updated lineup: cm-ant `cloudbaristaorg/cm-ant:0.5.3` healthy (`/ant/readyz` 200), all 22 containers healthy, cb-tumblebug (`/tumblebug/readyz`) and cm-beetle (`/beetle/readyz`) 200.