### PR TITLE
chore(lineup): bump cm-damselfly to 0.5.2 in docker-compose and api.yaml

### DIFF
--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -122,7 +122,7 @@ services:
       release: https://raw.githubusercontent.com/cloud-barista/cm-grasshopper/{release}/pkg/api/rest/docs/swagger.json
 
   cm-damselfly:
-    version: 0.5.1(latest)
+    version: 0.5.2(latest)
     baseurl: http://cm-damselfly:8088/damselfly
     auth: # cm-damselfly checks these only when DAMSELFLY_API_AUTH_ENABLED=true; otherwise they are ignored.
       type: basic
@@ -2907,6 +2907,10 @@ serviceActions:
       method: post
       resourcePath: /cloudmodel
       description: "Create a new cloud user model with the given information."
+    CreateInfraModel:
+      method: post
+      resourcePath: /infra-model
+      description: "Create a new infra migration user model. Use 'modelType' to select on-premise or cloud, and 'isTargetModel' to select source or target model."
     CreateOnPremModel:
       method: post
       resourcePath: /onpremmodel
@@ -2923,6 +2927,10 @@ serviceActions:
       method: delete
       resourcePath: /cloudmodel/{id}
       description: "Delete a cloud user model with the given information."
+    DeleteInfraModel:
+      method: delete
+      resourcePath: /infra-model/{id}
+      description: "Delete a specific infra migration user model by ID. Works for both on-premise and cloud models without requiring the caller to specify the model type."
     DeleteOnPremModel:
       method: delete
       resourcePath: /onpremmodel/{id}
@@ -2943,6 +2951,14 @@ serviceActions:
       method: get
       resourcePath: /cloudmodel
       description: "Get a list of cloud user models."
+    GetInfraModel:
+      method: get
+      resourcePath: /infra-model/{id}
+      description: "Get a specific infra migration user model by ID. Use 'modelType' to specify whether it is an on-premise or cloud model."
+    GetInfraModels:
+      method: get
+      resourcePath: /infra-model
+      description: "Get a list of infra migration user models filtered by model type and source/target classification."
     GetModels:
       method: get
       resourcePath: /model/{isTargetModel}
@@ -2987,6 +3003,10 @@ serviceActions:
       method: put
       resourcePath: /cloudmodel/{id}
       description: "Update a cloud user model with the given information."
+    UpdateInfraModel:
+      method: put
+      resourcePath: /infra-model/{id}
+      description: "Update a specific infra migration user model by ID. Use 'modelType' to specify whether it is an on-premise or cloud model."
     UpdateOnPremModel:
       method: put
       resourcePath: /onpremmodel/{id}

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -597,7 +597,7 @@ services:
   # https://hub.docker.com/r/cloudbaristaorg/cm-damselfly
   cm-damselfly:
     # image: cloudbaristaorg/cm-damselfly:edge
-    image: cloudbaristaorg/cm-damselfly:0.5.1
+    image: cloudbaristaorg/cm-damselfly:0.5.2
     container_name: cm-damselfly
     pull_policy: always
     platform: linux/amd64


### PR DESCRIPTION
cm-damselfly released 0.5.2 on 2026-07-01, so this brings the container lineup and the API catalog up to that release.

## Changes

- `conf/docker/docker-compose.yaml` — cm-damselfly `0.5.1` → `0.5.2` (the commented `edge` line is left as is)
- `conf/api.yaml` — cm-damselfly `version: 0.5.2(latest)`, serviceActions 24 → 29

0.5.2 adds the infra-model CRUD endpoints, so five actions are new (`CreateInfraModel`, `GetInfraModel`, `GetInfraModels`, `UpdateInfraModel`, `DeleteInfraModel`) and none are dropped. The serviceActions were not hand-edited — they were generated from the v0.5.2 swagger with the api tool:

```bash
mayfly api tool --release v0.5.2 --service cm-damselfly --apply
```

## Verification

The full lineup was started on a remote test server with this change.

- All 22 lineup containers healthy — swapping cm-damselfly to 0.5.2 caused no regression in the other services
- New endpoint — `GET /damselfly/infra-model` returns a parameter-validation error (400) rather than 404, so the endpoint is served by 0.5.2
- Existing endpoints — `GET /damselfly/cloudmodel` and `readyz` both return 200
- Locally — `docker compose config` passes, and a parse-level cross-check confirms only cm-damselfly changed (24 → 29 actions), with no other service or auth setting touched