### PR TITLE
fix(docker): mount cm-butterfly api.yaml where the app actually reads it

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -455,9 +455,13 @@ services:
         condition: service_healthy
     volumes:
       - ./tool/mayfly:/app/tool/mayfly
-      #- ./conf/cm-butterfly/api/conf:/conf/
+      # The two config files below are loaded through different paths, so their
+      # mount targets differ. authsetting.yaml is read relative to the working
+      # directory (/conf/authsetting.yaml), while api.yaml is looked up next to
+      # the executable first (/app/conf/api.yaml). Since the image already ships
+      # /app/conf/api.yaml, a mount on /conf/api.yaml is silently ignored.
       - ./conf/cm-butterfly/api/conf/authsetting.yaml:/conf/authsetting.yaml
-      #- ./conf/cm-butterfly/api/conf/api.yaml:/conf/api.yaml
+      #- ./conf/cm-butterfly/api/conf/api.yaml:/app/conf/api.yaml
       #- ./data/cm-butterfly/log/api.log:/app/api.log
     environment:
       # API listen address (fixed inside the cm-butterfly-api container; not secrets)


### PR DESCRIPTION
The commented override for cm-butterfly's api.yaml does not work, so this corrects the mount target.

## Problem

cm-butterfly-api looks up api.yaml with viper, searching **next to the executable first** (`/app/conf`) and only then the working directory (`/conf`). The image already ships `/app/conf/api.yaml`, so a file mounted on `/conf/api.yaml` is **silently ignored** — uncommenting the line looks like it takes effect while the container keeps using the built-in spec.

This is easy to miss because the neighbouring `authsetting.yaml` mount on `/conf/` does work: it is read by a different loader, relative to the working directory. The two lines look like the same pattern but behave differently.

## Changes

- api.yaml mount target `/conf/api.yaml` → `/app/conf/api.yaml` (still commented out, so it works whenever someone needs it)
- Dropped the whole-directory mount `./conf/cm-butterfly/api/conf:/conf/` — it could never override api.yaml for the same reason
- Added a note explaining why the two config files use different mount targets

Only commented lines change, so there is no runtime behaviour change.

## Verification

Reproduced and fixed on a remote test server while working on an api.yaml update:

- With the file mounted on `/conf/api.yaml`, a proxied call to a newly added operationId returned 404 (`getApiSpec not found`), and the container was reading the built-in `/app/conf/api.yaml`
- With the same file mounted on `/app/conf/api.yaml`, the identical call returned 200
- `docker compose config` passes; the active mounts and every other service are untouched