### PR TITLE
fix(docker): remove duplicate airflow DB init script that breaks clean install

### DIFF
--- a/conf/docker/conf/cm-cicada/_airflow/create_airflow_db.sql
+++ b/conf/docker/conf/cm-cicada/_airflow/create_airflow_db.sql
@@ -1,2 +1,0 @@
-CREATE DATABASE airflow CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-GRANT ALL PRIVILEGES ON airflow.* TO 'airflow';

--- a/conf/docker/conf/cm-cicada/_airflow/docker-compose.yml
+++ b/conf/docker/conf/cm-cicada/_airflow/docker-compose.yml
@@ -21,7 +21,11 @@ services:
             - MYSQL_PASSWORD=airflow_pass
             - MYSQL_DATABASE=airflow
         volumes:
-            - ./create_airflow_db.sql:/docker-entrypoint-initdb.d/create_airflow_db.sql
+            # ./create_airflow_db.sql has been deleted. It ran `CREATE DATABASE airflow` without IF NOT EXISTS
+            # on top of the database the mysql entrypoint already creates from MYSQL_DATABASE, so initdb failed
+            # with ERROR 1007 on an empty data directory. MYSQL_DATABASE above covers both the database and the
+            # grant to MYSQL_USER. This file is an unused copy of the cm-cicada standalone compose, kept for reference.
+            # - ./create_airflow_db.sql:/docker-entrypoint-initdb.d/create_airflow_db.sql
             - ./db_data:/var/lib/mysql
     airflow-server:
         container_name: airflow-server

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -704,7 +704,13 @@ services:
       - MYSQL_PASSWORD=${AIRFLOW_DB_PASSWORD}
       - MYSQL_DATABASE=${AIRFLOW_DB_NAME}
     volumes:
-      - ./conf/cm-cicada/_airflow/create_airflow_db.sql:/docker-entrypoint-initdb.d/create_airflow_db.sql
+      # The init script ./conf/cm-cicada/_airflow/create_airflow_db.sql was mounted here and has been deleted.
+      # It ran `CREATE DATABASE airflow` (no IF NOT EXISTS) after the mysql entrypoint had already created
+      # MYSQL_DATABASE, so on a clean data directory initdb failed with ERROR 1007 (database exists) and the
+      # container died, which in turn left airflow-server and cm-cicada unstarted. The entrypoint already creates
+      # MYSQL_DATABASE and grants it to MYSQL_USER, so nothing was lost by dropping the duplicate script and
+      # there is no file to keep in sync with cm-cicada anymore.
+      # - ./conf/cm-cicada/_airflow/create_airflow_db.sql:/docker-entrypoint-initdb.d/create_airflow_db.sql
       - ./data/airflow-mysql:/var/lib/mysql
     healthcheck:
       # Use the centrally-managed .env credentials instead of hardcoded ones,

--- a/conf/k8s/cloud-migrator/charts/cm-cicada/charts/airflow-mysql/values.yaml
+++ b/conf/k8s/cloud-migrator/charts/cm-cicada/charts/airflow-mysql/values.yaml
@@ -43,24 +43,32 @@ readinessProbe:
   periodSeconds: 10
   timeoutSeconds: 3
 
+# These volumes/volumeMounts apply to the Deployment only. The init Job (templates/job.yaml) has its own
+# volumes and still mounts create_airflow_db.sql, which is correct there: the Job has no MYSQL_DATABASE,
+# so the script is what creates the database.
+#
+# The Deployment is different. It sets MYSQL_DATABASE=airflow (see `env` below), so the mysql entrypoint
+# already creates the database and grants it to MYSQL_USER. Mounting the init script on top of that ran
+# `CREATE DATABASE airflow` (no IF NOT EXISTS) a second time, and initdb died with ERROR 1007 whenever the
+# data directory was empty — which is every pod start here, since the PVC mount below is commented out.
 volumes:
   # - name: airflow-mysql-volume
   #   persistentVolumeClaim:
   #     claimName: airflow-mysql
-  - name: airflow-mysql-config
-    configMap:
-      name: airflow-mysql
-      items:
-        - key: create_airflow_db.sql
-          path: create_airflow_db.sql
+  # - name: airflow-mysql-config
+  #   configMap:
+  #     name: airflow-mysql
+  #     items:
+  #       - key: create_airflow_db.sql
+  #         path: create_airflow_db.sql
 
-volumeMounts: 
+volumeMounts:
   # - name: airflow-mysql-volume
   #   mountPath: /var/lib/mysql
-  - name: airflow-mysql-config
-    mountPath: /docker-entrypoint-initdb.d/create_airflow_db.sql
-    subPath: create_airflow_db.sql
-    readOnly: true
+  # - name: airflow-mysql-config
+  #   mountPath: /docker-entrypoint-initdb.d/create_airflow_db.sql
+  #   subPath: create_airflow_db.sql
+  #   readOnly: true
 
 persistence:
   enabled: false


### PR DESCRIPTION
On a clean install (no existing data directory), `mayfly infra run` leaves `airflow-server` and `cm-cicada` stuck in `Created`. Every other container is healthy, so it looks like only those two failed to start.

## What is happening today

`airflow-mysql` creates the airflow database through two paths at once.

```yaml
  airflow-mysql:
    image: mysql:8.0-debian
    environment:
      - MYSQL_USER=${AIRFLOW_DB_USER}          # airflow
      - MYSQL_PASSWORD=${AIRFLOW_DB_PASSWORD}
      - MYSQL_DATABASE=${AIRFLOW_DB_NAME}      # airflow   <- (A) creates the database
    volumes:
      - ./conf/cm-cicada/_airflow/create_airflow_db.sql:/docker-entrypoint-initdb.d/create_airflow_db.sql  # <- (B) creates it again
      - ./data/airflow-mysql:/var/lib/mysql
```

(A) When `MYSQL_DATABASE` is set, the mysql image entrypoint **creates the database and grants it to `MYSQL_USER`**. This is in the image's own `docker-entrypoint.sh`:

```
CREATE DATABASE IF NOT EXISTS `$MYSQL_DATABASE` ;
GRANT ALL ON `$MYSQL_DATABASE`.* TO '$MYSQL_USER'@'%' ;
```

(B) Right after that, the entrypoint runs everything in `/docker-entrypoint-initdb.d/`. The script mounted there is `create_airflow_db.sql`, and it has **no `IF NOT EXISTS`**:

```sql
CREATE DATABASE airflow CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
GRANT ALL PRIVILEGES ON airflow.* TO 'airflow';
```

So (B) tries to create the database that (A) has already created, and fails.

## What that leads to

initdb only runs when the data directory is empty, so this breaks **only on a clean install**, in this order:

1. initdb fails with `ERROR 1007 (HY000): Can't create database 'airflow'; database exists`.
2. On initdb failure the mysql entrypoint terminates the container (observed as `RestartCount=1`).
3. `restart: unless-stopped` makes Docker restart it, and the second boot skips initdb because the data directory is now populated — so mysql itself ends up healthy.
4. But compose has already treated the exit in (2) as a dependency failure and **stopped the `up`**. So `airflow-server` (`depends_on: airflow-mysql/redis service_healthy`) never starts, and `cm-cicada` (`depends_on: airflow-server service_healthy`) stays behind it. Both remain in `Created`, and they do not come up on their own even after mysql recovers.

If a data directory already exists, initdb never runs and the symptom does not appear.

## Why the file is removed rather than kept

What `create_airflow_db.sql` does — create the database and grant it to `airflow` — is **exactly what the image entrypoint already does** from `MYSQL_DATABASE`/`MYSQL_USER`. The script is a full duplicate whose only difference is the missing `IF NOT EXISTS`. It also hardcodes the database name, so it drifts from `AIRFLOW_DB_NAME` if that is ever changed.

Keeping the file while commenting out the mount would leave a file that looks like it must stay in sync with cm-cicada. So the file is deleted, and the compose comment records that it was removed and why.

## Changes

- `conf/docker/docker-compose.yaml` — comment out the initdb mount on `airflow-mysql`, with the reason inline.
- `conf/docker/conf/cm-cicada/_airflow/create_airflow_db.sql` — deleted.
- `conf/docker/conf/cm-cicada/_airflow/docker-compose.yml` — an unused copy of the cm-cicada standalone compose; updated so it no longer points at the deleted file.
- `conf/k8s/.../charts/airflow-mysql/values.yaml` — the chart's Deployment carried the same duplicate (`MYSQL_DATABASE` plus the same init script), so its mount is disabled too. The chart's init Job keeps the script, because that Job has no `MYSQL_DATABASE` and the script is what creates the database there.

## Verification

Clean install on a fresh host, three times.

| | ERROR 1007 | airflow-mysql restarts | airflow-server | cm-cicada |
|---|---|---|---|---|
| before | 1 | 1 | Created (never started) | Created (never started) |
| after (3 runs) | none | none | healthy | healthy |

Confirmed in the database that the entrypoint alone produces what the script used to do:

```
SHOW DATABASES;                 -> airflow
SHOW GRANTS FOR CURRENT_USER(); -> GRANT ALL PRIVILEGES ON `airflow`.* TO `airflow`@`%`
```

Beyond startup, a cm-cicada workflow was run end to end afterwards (`migrate_infra_workflow`): the Airflow DAG executed and infrastructure was actually provisioned on a cloud provider, then removed. That confirms the airflow stack works and not merely starts.
