### PR TITLE
Harden CLI service selection, command execution and secret handling

### DIFF
--- a/cmd/apicall/parse.go
+++ b/cmd/apicall/parse.go
@@ -3,7 +3,6 @@ package apicall
 import (
 	"bufio"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"sort"
@@ -305,14 +304,15 @@ func resolveSwaggerURL(svc string) (string, bool) {
 	return latest, true
 }
 
-// swaggerExists reports whether the swagger URL responds with 200.
+// swaggerExists reports whether the swagger URL responds with 200. It goes
+// through common.NewHTTPClient so an unreachable host fails on the timeout
+// instead of blocking forever.
 func swaggerExists(url string) bool {
-	resp, err := http.Get(url) // #nosec G107 -- registry URL from api.yaml
+	resp, err := common.NewHTTPClient().R().Get(url) // #nosec G107 -- registry URL from api.yaml
 	if err != nil {
 		return false
 	}
-	defer resp.Body.Close()
-	return resp.StatusCode == http.StatusOK
+	return resp.StatusCode() == http.StatusOK
 }
 
 // registeredSwaggerServices returns the services that have a swagger entry.
@@ -367,15 +367,14 @@ func confirmYN(prompt string) bool {
 // readSwaggerSource reads a swagger document from a local file or an http(s) URL.
 func readSwaggerSource(src string) ([]byte, error) {
 	if strings.HasPrefix(src, "http://") || strings.HasPrefix(src, "https://") {
-		resp, err := http.Get(src) // #nosec G107 -- src is an operator-supplied swagger URL
+		resp, err := common.NewHTTPClient().R().Get(src) // #nosec G107 -- src is an operator-supplied swagger URL
 		if err != nil {
 			return nil, err
 		}
-		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("GET %s returned status %d", src, resp.StatusCode)
+		if resp.StatusCode() != http.StatusOK {
+			return nil, fmt.Errorf("GET %s returned status %d", src, resp.StatusCode())
 		}
-		return io.ReadAll(resp.Body)
+		return resp.Body(), nil
 	}
 	return os.ReadFile(src) // #nosec G304 -- src is an operator-supplied swagger path
 }
@@ -432,8 +431,10 @@ func applyToApiYaml(apiFile, service string, singleAction bool, actions map[stri
 		return fmt.Errorf("failed to read %s: %w", apiFile, err)
 	}
 
+	// apiFile is common.API_FILE at the only call site — the tool's own
+	// conf/api.yaml — so the backup name derived from it is equally fixed.
 	backup := fmt.Sprintf("%s.bak.%s", apiFile, time.Now().Format("20060102-150405"))
-	if err := os.WriteFile(backup, orig, 0600); err != nil {
+	if err := os.WriteFile(backup, orig, 0600); err != nil { // #nosec G703 -- derived from the fixed internal api.yaml path
 		return fmt.Errorf("failed to write backup %s: %w", backup, err)
 	}
 
@@ -453,12 +454,12 @@ func applyToApiYaml(apiFile, service string, singleAction bool, actions map[stri
 		}
 	}
 
-	if err := os.WriteFile(apiFile, []byte(updated), 0600); err != nil {
+	if err := os.WriteFile(apiFile, []byte(updated), 0600); err != nil { // #nosec G703 -- fixed internal api.yaml path
 		return fmt.Errorf("failed to write %s: %w", apiFile, err)
 	}
 
 	if verr := verifyApiYaml(apiFile); verr != nil {
-		_ = os.WriteFile(apiFile, orig, 0600) // restore original on failure
+		_ = os.WriteFile(apiFile, orig, 0600) // #nosec G703 -- fixed internal api.yaml path; restores the original on failure
 		return fmt.Errorf("updated %s failed verification (%v); restored original (backup kept at %s)", apiFile, verr, backup)
 	}
 

--- a/cmd/apicall/root.go
+++ b/cmd/apicall/root.go
@@ -94,7 +94,7 @@ var apiCmd = &cobra.Command{
 		// Do not print help when a tool subcommand is entered.
 		if len(args) == 0 && cmd.Flags().NFlag() == 0 && cmd.HasSubCommands() {
 			//fmt.Println(cmd.Help())
-			cmd.Help()
+			_ = cmd.Help()
 			return
 		}
 
@@ -157,8 +157,10 @@ var apiCmd = &cobra.Command{
 			fmt.Println("Base URL:", serviceInfo.BaseURL)
 			fmt.Println("Auth Type:", serviceInfo.Auth.Type)
 			fmt.Println("Username:", serviceInfo.Auth.Username)
-			fmt.Println("Password:", serviceInfo.Auth.Password)
-			fmt.Println("Token:", serviceInfo.Auth.Token)
+			// Masked for the same reason as everywhere else -v prints a
+			// credential: the line outlives the debugging session.
+			fmt.Println("Password:", common.MaskSecret(serviceInfo.Auth.Password))
+			fmt.Println("Token:", common.MaskSecret(serviceInfo.Auth.Token))
 			fmt.Println("ResourcePath:", serviceInfo.ResourcePath)
 			fmt.Println("Method:", serviceInfo.Method)
 		}
@@ -298,6 +300,24 @@ func parseRequestInfo() error {
 	return nil
 }
 
+// isSafePathParamValue reports whether a path parameter value can be substituted
+// into the URI as it is. The value must not change which endpoint is called: a
+// ".." segment walks up the path (for example "nsId:../../v1/ns") and a "?" or a
+// "#" turns the remaining path into a query string or a fragment. A "/" on its
+// own is allowed because some resource ids, such as an object storage key,
+// legitimately contain one.
+func isSafePathParamValue(value string) bool {
+	if strings.ContainsAny(value, "?#") {
+		return false
+	}
+	for _, segment := range strings.Split(value, "/") {
+		if segment == ".." {
+			return false
+		}
+	}
+	return true
+}
+
 // Handle the variable path.
 func parsePathParam() error {
 	if isVerbose {
@@ -321,6 +341,9 @@ func parsePathParam() error {
 				//key := strings.ToLower(keyValue[0])
 				key := keyValue[0]
 				value := keyValue[1]
+				if !isSafePathParamValue(value) {
+					return errors.New("the path parameter value for [" + key + "] cannot be used in a URI path\nA path parameter must not contain a '..' segment, a '?' or a '#', because those change the endpoint being called")
+				}
 				pathParams[key] = value
 			}
 		}
@@ -350,7 +373,7 @@ func SetBasicAuth() {
 		if isVerbose {
 			fmt.Println("setting basic auth")
 			fmt.Println("username : " + serviceInfo.Auth.Username)
-			fmt.Println("password : " + serviceInfo.Auth.Password)
+			fmt.Println("password : " + common.MaskSecret(serviceInfo.Auth.Password))
 		}
 		client.SetBasicAuth(serviceInfo.Auth.Username, serviceInfo.Auth.Password)
 	}
@@ -387,7 +410,9 @@ func SetReqData() error {
 		}
 
 		// read the data from the file
-		data, err := ioutil.ReadFile(inputFileData)
+		// Reading the file the operator names with the request-data flag is
+		// the feature itself; there is no directory this path should be confined to.
+		data, err := ioutil.ReadFile(inputFileData) // #nosec G304 -- operator-supplied request body file is the documented purpose of this flag
 		if err != nil {
 			return err
 		}
@@ -434,7 +459,10 @@ func callRest() error {
 
 	url := serviceInfo.BaseURL + serviceInfo.ResourcePath
 
-	switch strings.ToLower(serviceInfo.Method) {
+	// The method comes from api.yaml, so it can be missing, misspelled or padded
+	// with spaces. Trim it and reject anything unsupported instead of leaving
+	// resp nil, which used to panic in ProcessResultInfo below.
+	switch strings.ToLower(strings.TrimSpace(serviceInfo.Method)) {
 	case "get":
 		resp, err = req.Get(url)
 	case "post":
@@ -445,6 +473,8 @@ func callRest() error {
 		resp, err = req.Delete(url)
 	case "patch":
 		resp, err = req.Patch(url)
+	default:
+		return fmt.Errorf("unsupported HTTP method %q for the action you are trying to call\nSupported methods are: GET, POST, PUT, DELETE, PATCH\nPlease check the method value of the action in the api.yaml configuration file", serviceInfo.Method)
 	}
 
 	if err != nil {

--- a/cmd/apicall/root_test.go
+++ b/cmd/apicall/root_test.go
@@ -1,0 +1,116 @@
+package apicall
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// An api.yaml method that is not one of the five supported verbs used to fall
+// through the switch with a nil response and panic in ProcessResultInfo. It has
+// to come back as a plain error naming the supported methods instead.
+func TestCallRestUnsupportedMethodReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	unsupported := []string{"TRACE", "HEAD", "OPTIONS", "gett", "", "   "}
+
+	for _, method := range unsupported {
+		t.Run("method_"+method, func(t *testing.T) {
+			serviceInfo = ServiceInfo{BaseURL: server.URL, ResourcePath: "/", Method: method}
+
+			err := callRest()
+			if err == nil {
+				t.Fatalf("callRest() with method %q returned no error, want an unsupported method error", method)
+			}
+			if !strings.Contains(err.Error(), "unsupported HTTP method") {
+				t.Errorf("callRest() error = %q, want it to mention the unsupported method", err)
+			}
+			if !strings.Contains(err.Error(), "GET, POST, PUT, DELETE, PATCH") {
+				t.Errorf("callRest() error = %q, want it to list the supported methods", err)
+			}
+		})
+	}
+}
+
+// Methods written in any case, or padded with spaces, are still accepted.
+func TestCallRestAcceptsSupportedMethods(t *testing.T) {
+	var seen string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.Method
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tests := map[string]string{
+		"get":      http.MethodGet,
+		"POST":     http.MethodPost,
+		"  put  ":  http.MethodPut,
+		"Delete":   http.MethodDelete,
+		"\tpatch ": http.MethodPatch,
+	}
+
+	for method, want := range tests {
+		t.Run("method_"+strings.TrimSpace(method), func(t *testing.T) {
+			seen = ""
+			serviceInfo = ServiceInfo{BaseURL: server.URL, ResourcePath: "/", Method: method}
+
+			if err := callRest(); err != nil {
+				t.Fatalf("callRest() with method %q returned error: %v", method, err)
+			}
+			if seen != want {
+				t.Errorf("server received %s, want %s", seen, want)
+			}
+		})
+	}
+}
+
+// A path parameter must not be able to redirect the call to another endpoint.
+func TestIsSafePathParamValue(t *testing.T) {
+	safe := []string{"ns01", "mci01", "ap-northeast-3", "aws-config01", "AWS", "my/object/key.txt", "a..b", "..leading"}
+	for _, value := range safe {
+		if !isSafePathParamValue(value) {
+			t.Errorf("isSafePathParamValue(%q) = false, want true", value)
+		}
+	}
+
+	unsafe := []string{"../../v1/ns", "..", "ns01/..", "ns01/../../other", "ns01?option=terminate", "ns01#frag"}
+	for _, value := range unsafe {
+		if isSafePathParamValue(value) {
+			t.Errorf("isSafePathParamValue(%q) = true, want false", value)
+		}
+	}
+}
+
+// parsePathParam has to refuse a traversal value rather than substituting it
+// into the resource path.
+func TestParsePathParamRejectsTraversal(t *testing.T) {
+	serviceInfo = ServiceInfo{ResourcePath: "/ns/{nsId}/mci/{mciId}"}
+	pathParam = "nsId:../../v1/ns mciId:mci01"
+	defer func() { pathParam = "" }()
+
+	err := parsePathParam()
+	if err == nil {
+		t.Fatal("parsePathParam() accepted a traversal path parameter, want an error")
+	}
+	if !strings.Contains(err.Error(), "nsId") {
+		t.Errorf("parsePathParam() error = %q, want it to name the offending parameter", err)
+	}
+}
+
+// The normal substitution path keeps working unchanged.
+func TestParsePathParamSubstitutesNormalValues(t *testing.T) {
+	serviceInfo = ServiceInfo{ResourcePath: "/ns/{nsId}/mci/{mciId}"}
+	pathParam = "nsId:ns01 mciId:mci01"
+	defer func() { pathParam = "" }()
+
+	if err := parsePathParam(); err != nil {
+		t.Fatalf("parsePathParam() returned error: %v", err)
+	}
+	if serviceInfo.ResourcePath != "/ns/ns01/mci/mci01" {
+		t.Errorf("ResourcePath = %q, want %q", serviceInfo.ResourcePath, "/ns/ns01/mci/mci01")
+	}
+}

--- a/cmd/apicall/verbose_secret_test.go
+++ b/cmd/apicall/verbose_secret_test.go
@@ -1,0 +1,82 @@
+package apicall
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/cm-mayfly/cm-mayfly/common"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var sb strings.Builder
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := r.Read(buf)
+			if n > 0 {
+				sb.Write(buf[:n])
+			}
+			if readErr != nil {
+				break
+			}
+		}
+		done <- sb.String()
+	}()
+	fn()
+	w.Close()
+	os.Stdout = orig
+	out := <-done
+	r.Close()
+	return out
+}
+
+const (
+	testPassword = "sup3r-secret-password"
+	testToken    = "eyJhbGciOiJIUzI1NiJ9.payload.signature"
+)
+
+// `mayfly api -v` resolves credentials out of api.yaml, including ${VAR}
+// references, so it is exactly the command someone runs when a credential is not
+// working — and exactly the output they then paste into a ticket.
+func TestSetBasicAuthVerboseDoesNotPrintPassword(t *testing.T) {
+	prevInfo, prevVerbose := serviceInfo, isVerbose
+	t.Cleanup(func() { serviceInfo, isVerbose = prevInfo, prevVerbose })
+
+	serviceInfo.Auth.Username = "default"
+	serviceInfo.Auth.Password = testPassword
+	isVerbose = true
+
+	out := captureStdout(t, SetBasicAuth)
+
+	if strings.Contains(out, testPassword) {
+		t.Errorf("-v printed the password verbatim:\n%s", out)
+	}
+	if !strings.Contains(out, "default") {
+		t.Errorf("-v should still show the username, got:\n%s", out)
+	}
+	if !strings.Contains(out, "***") {
+		t.Errorf("-v should show a masked password, got:\n%s", out)
+	}
+}
+
+// The bearer token path prints through the same helper. Asserting on it here
+// keeps the property attached to this package: whatever else changes about how
+// the token is obtained, it must not reach stdout intact.
+func TestBearerTokenIsMaskedBeforePrinting(t *testing.T) {
+	got := common.MaskSecret(testToken)
+	if strings.Contains(got, "signature") || got == testToken {
+		t.Errorf("token was not masked: %q", got)
+	}
+	if !strings.Contains(got, "***") {
+		t.Errorf("expected a masked value, got %q", got)
+	}
+}

--- a/cmd/docker/category_test.go
+++ b/cmd/docker/category_test.go
@@ -1,0 +1,159 @@
+package docker
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// The category every service in the shipped compose file must land in. The
+// grouping follows the framework a service belongs to before its technical
+// role, which is why cb-tumblebug-postgres is a data store of the core lineup
+// while cm-butterfly-db sits with the console it serves.
+var expectedComposeCategories = map[string]string{
+	"cb-spider":    CategoryCoreInfra,
+	"cb-tumblebug": CategoryCoreInfra,
+	"cb-mapui":     CategoryCoreInfra,
+	"mc-terrarium": CategoryCoreInfra,
+
+	"cm-beetle":      CategoryFrameworks,
+	"cm-honeybee":    CategoryFrameworks,
+	"cm-damselfly":   CategoryFrameworks,
+	"cm-grasshopper": CategoryFrameworks,
+	"cm-ant":         CategoryFrameworks,
+
+	"cm-butterfly-front": CategoryWebConsole,
+	"cm-butterfly-api":   CategoryWebConsole,
+	"cm-butterfly-db":    CategoryWebConsole,
+
+	"cm-cicada":      CategoryWorkflow,
+	"airflow-server": CategoryWorkflow,
+	"airflow-mysql":  CategoryWorkflow,
+	"airflow-redis":  CategoryWorkflow,
+
+	"openbao":        CategorySecrets,
+	"openbao-unseal": CategorySecrets,
+
+	"cb-tumblebug-etcd":     CategoryDataStores,
+	"cb-tumblebug-postgres": CategoryDataStores,
+	"ant-postgres":          CategoryDataStores,
+
+	"cm-grasshopper-rustfs": CategoryObjectStorage,
+}
+
+// withShippedCompose points DockerFilePath at conf/docker/docker-compose.yaml so
+// a test reads the lineup that actually ships.
+func withShippedCompose(t *testing.T) {
+	t.Helper()
+
+	prev := DockerFilePath
+	DockerFilePath = filepath.Join("..", "..", "conf", "docker", "docker-compose.yaml")
+	t.Cleanup(func() { DockerFilePath = prev })
+}
+
+// Every service in the shipped compose file lands in its expected group. The
+// image prefix used to be checked first, so airflow-server was filed under the
+// core services on the strength of its cloudbaristaorg/ image and never reached
+// the airflow rule, while airflow-mysql and airflow-redis scattered into the
+// database and cache groups. The workflow engine was split across three groups.
+func TestCategorizeServiceMatchesShippedCompose(t *testing.T) {
+	withShippedCompose(t)
+
+	compose, err := loadComposeFile()
+	if err != nil {
+		t.Fatalf("failed to parse the shipped compose file: %v", err)
+	}
+
+	for name, want := range expectedComposeCategories {
+		svc, ok := compose.Services[name]
+		if !ok {
+			t.Errorf("%s is missing from the shipped compose file", name)
+			continue
+		}
+		if svc.Category != want {
+			t.Errorf("%s: category = %q, want %q (image %q)", name, svc.Category, want, svc.Image)
+		}
+	}
+}
+
+// No service may go missing from the grouped view and none may be counted
+// twice: the sum over the categories has to equal the number of services the
+// compose file declares.
+func TestEveryComposeServiceHasExactlyOneCategory(t *testing.T) {
+	withShippedCompose(t)
+
+	compose, err := loadComposeFile()
+	if err != nil {
+		t.Fatalf("failed to parse the shipped compose file: %v", err)
+	}
+
+	if len(compose.Services) != len(expectedComposeCategories) {
+		t.Errorf("compose declares %d services but the expected table lists %d; update the table",
+			len(compose.Services), len(expectedComposeCategories))
+	}
+
+	counts := make(map[string]int)
+	for name, svc := range compose.Services {
+		if svc.Category == "" {
+			t.Errorf("%s has no category", name)
+			continue
+		}
+		if _, known := expectedComposeCategories[name]; !known {
+			t.Errorf("%s is in the compose file but not in the expected table (category %q)", name, svc.Category)
+		}
+		counts[svc.Category]++
+	}
+
+	total := 0
+	for _, n := range counts {
+		total += n
+	}
+	if total != len(compose.Services) {
+		t.Errorf("categories hold %d services, compose declares %d", total, len(compose.Services))
+	}
+
+	// The fallback group exists for services the mapping does not know, and the
+	// shipped lineup is fully mapped, so it must be empty.
+	if n := counts[CategoryDependencies]; n != 0 {
+		t.Errorf("%d service(s) fell through to %s", n, CategoryDependencies)
+	}
+}
+
+// A service the mapping does not list still has to land somewhere, and the
+// pattern rules must not override an explicit mapping.
+func TestCategorizeServiceFallbacks(t *testing.T) {
+	cases := []struct {
+		service string
+		image   string
+		want    string
+	}{
+		{"airflow-worker", "cloudbaristaorg/airflow-worker:1.0.0", CategoryWorkflow},
+		{"openbao-agent", "openbao/openbao:2.5.1", CategorySecrets},
+		{"cm-butterfly-cache", "redis:7.2-alpine", CategoryWebConsole},
+		{"cm-beetle-postgres", "postgres:16-alpine", CategoryDataStores},
+		{"some-mysql", "mysql:8.0-debian", CategoryDataStores},
+		{"cache-redis", "redis:7.2-alpine", CategoryDataStores},
+		{"cluster-etcd", "gcr.io/etcd-development/etcd:v3.6.11", CategoryDataStores},
+		{"cb-larva", "cloudbaristaorg/cb-larva:1.0.0", CategoryCoreInfra},
+		{"mc-terrarium", "cloudbaristaorg/mc-terrarium:0.1.4", CategoryCoreInfra},
+		{"cm-dragonfly", "cloudbaristaorg/cm-dragonfly:1.0.0", CategoryFrameworks},
+		{"nginx", "nginx:1.27", CategoryDependencies},
+		{"", "", CategoryDependencies},
+	}
+
+	for _, tc := range cases {
+		if got := categorizeService(tc.service, tc.image); got != tc.want {
+			t.Errorf("categorizeService(%q, %q) = %q, want %q", tc.service, tc.image, got, tc.want)
+		}
+	}
+}
+
+// A cloudbaristaorg/ image no longer decides the group on its own. This is the
+// regression that filed airflow-server under the core services.
+func TestCategorizeServiceIgnoresImagePrefix(t *testing.T) {
+	if got := categorizeService("airflow-server", "cloudbaristaorg/airflow-server"); got != CategoryWorkflow {
+		t.Errorf("airflow-server = %q, want %q", got, CategoryWorkflow)
+	}
+	if got := categorizeService("cm-butterfly-db", "postgres"); got != CategoryWebConsole {
+		t.Errorf("cm-butterfly-db = %q, want %q", got, CategoryWebConsole)
+	}
+}

--- a/cmd/docker/common.go
+++ b/cmd/docker/common.go
@@ -1,10 +1,15 @@
 package docker
 
 import (
+	"errors"
 	"fmt"
 	"os"
-	"regexp"
+	"sort"
 	"strings"
+	"sync"
+
+	"github.com/cm-mayfly/cm-mayfly/common"
+	"gopkg.in/yaml.v3"
 )
 
 // ServiceInfo represents service information with category
@@ -14,116 +19,436 @@ type ServiceInfo struct {
 	Category string
 }
 
-// parseDockerComposeImages parses docker-compose.yaml to extract all service information
-func parseDockerComposeImages() (map[string]ServiceInfo, error) {
-	services := make(map[string]ServiceInfo)
+// ComposeService is one entry under the compose file's top-level `services:` key.
+//
+// Repository and Tag are the two halves of Image; they are split once here so
+// callers never have to re-parse the string (and never disagree about where the
+// split is for images that carry a registry host or port).
+type ComposeService struct {
+	Name       string
+	Image      string
+	Repository string
+	Tag        string
+	Category   string
+	DependsOn  []string
+}
 
-	// Read docker-compose.yaml file
+// ComposeFile is the parsed compose file. Order preserves the order the
+// services are written in, which is what the info tables list them in.
+type ComposeFile struct {
+	Order    []string
+	Services map[string]ComposeService
+}
+
+// composeCache memoises the parse for the lifetime of the process. cm-mayfly is
+// a one-shot CLI, but `infra info` asks for the same file once per service, so
+// without this the whole file is re-read and re-parsed ~20 times per run.
+var (
+	composeCacheMu  sync.Mutex
+	composeCacheKey string
+	composeCacheSet bool
+	composeCacheFmt *ComposeFile
+	composeCacheErr error
+)
+
+// composeCacheKeyFor identifies a parse by path, size and modification time, so
+// a file edited between two calls is re-read rather than served from the cache.
+func composeCacheKeyFor(path string) string {
+	info, err := os.Stat(path)
+	if err != nil {
+		return path + "|missing"
+	}
+	return fmt.Sprintf("%s|%d|%d", path, info.Size(), info.ModTime().UnixNano())
+}
+
+// loadComposeFile parses DockerFilePath and returns its services.
+func loadComposeFile() (*ComposeFile, error) {
+	composeCacheMu.Lock()
+	defer composeCacheMu.Unlock()
+
+	key := composeCacheKeyFor(DockerFilePath)
+	if composeCacheSet && composeCacheKey == key {
+		return composeCacheFmt, composeCacheErr
+	}
+
+	var parsed *ComposeFile
 	content, err := os.ReadFile(DockerFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read docker-compose.yaml: %v", err)
+		err = fmt.Errorf("failed to read %s: %v", DockerFilePath, err)
+	} else {
+		parsed, err = parseComposeContent(content)
 	}
 
-	// Regex to match service names and image definitions
-	serviceRegex := regexp.MustCompile(`^\s*([a-zA-Z0-9_-]+):\s*$`)
-	imageRegex := regexp.MustCompile(`^\s*image:\s*([^:\s]+):([^\s]+)\s*$`)
+	composeCacheKey = key
+	composeCacheSet = true
+	composeCacheFmt = parsed
+	composeCacheErr = err
+	return parsed, err
+}
 
-	lines := strings.Split(string(content), "\n")
-	var currentService string
-	inService := false
-	indentLevel := 0
-
-	for i, line := range lines {
-		// Check for service name (e.g., "  cm-ant:")
-		if matches := serviceRegex.FindStringSubmatch(line); matches != nil {
-			serviceName := matches[1]
-
-			// Check if this is a top-level service (not inside depends_on or other sections)
-			trimmedLine := strings.TrimLeft(line, " \t")
-			if strings.HasPrefix(trimmedLine, serviceName+":") {
-				// Check if we're not inside depends_on section by looking at previous lines
-				isInDependsOn := false
-				for j := i - 1; j >= 0 && j >= i-10; j-- {
-					prevLine := strings.TrimSpace(lines[j])
-					if prevLine == "depends_on:" {
-						isInDependsOn = true
-						break
-					}
-					if prevLine != "" && !strings.HasPrefix(lines[j], " ") && !strings.HasPrefix(lines[j], "\t") {
-						break
-					}
-				}
-
-				if !isInDependsOn {
-					currentService = serviceName
-					inService = true
-					// Calculate the indentation level of the service
-					indentLevel = len(line) - len(strings.TrimLeft(line, " \t"))
-					continue
-				}
-			}
-		}
-
-		// If we're in the service section, look for image field
-		if inService {
-			currentIndent := len(line) - len(strings.TrimLeft(line, " \t"))
-
-			// Check if we've moved to another service or section (same or less indentation)
-			if strings.TrimSpace(line) != "" && currentIndent <= indentLevel && !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
-				// We've moved to another service or section
-				inService = false
-				currentService = ""
-				continue
-			}
-
-			// Check for image definition (e.g., "    image: cloudbaristaorg/cm-ant:0.4.0")
-			if matches := imageRegex.FindStringSubmatch(line); matches != nil && currentService != "" {
-				imageName := matches[1]
-				tag := matches[2]
-				fullImage := fmt.Sprintf("%s:%s", imageName, tag)
-
-				// Categorize services
-				category := categorizeService(currentService, imageName)
-
-				services[currentService] = ServiceInfo{
-					Name:     currentService,
-					Image:    fullImage,
-					Category: category,
-				}
-
-				// Reset for next service
-				inService = false
-				currentService = ""
-			}
-		}
+// parseComposeContent parses compose YAML into a ComposeFile.
+//
+// Only the top-level keys under `services:` count as services. The previous
+// line-oriented scanner keyed off "a bare `key:` line followed by an `image:`
+// line", which silently dropped any service that declared `build:` or
+// `healthcheck:` before `image:` — and a dropped service is reported to the
+// user as "not found in docker-compose.yaml".
+func parseComposeContent(content []byte) (*ComposeFile, error) {
+	var root struct {
+		Services yaml.Node `yaml:"services"`
+	}
+	if err := yaml.Unmarshal(content, &root); err != nil {
+		return nil, fmt.Errorf("failed to parse compose YAML: %v", err)
 	}
 
+	result := &ComposeFile{Services: make(map[string]ComposeService)}
+	if root.Services.Kind != yaml.MappingNode {
+		return result, nil
+	}
+
+	// A mapping node stores keys and values as alternating children.
+	for i := 0; i+1 < len(root.Services.Content); i += 2 {
+		name := root.Services.Content[i].Value
+		if name == "" {
+			continue
+		}
+
+		var body struct {
+			Image     string    `yaml:"image"`
+			DependsOn yaml.Node `yaml:"depends_on"`
+		}
+		if err := root.Services.Content[i+1].Decode(&body); err != nil {
+			// A service we cannot decode is still a service: record the name so
+			// it validates, rather than telling the user it does not exist.
+			result.Order = append(result.Order, name)
+			result.Services[name] = ComposeService{Name: name, Category: categorizeService(name, "")}
+			continue
+		}
+
+		repository, tag := splitImageRef(body.Image)
+		svc := ComposeService{
+			Name:       name,
+			Image:      body.Image,
+			Repository: repository,
+			Tag:        tag,
+			Category:   categorizeService(name, repository),
+			DependsOn:  decodeDependsOn(&body.DependsOn),
+		}
+
+		result.Order = append(result.Order, name)
+		result.Services[name] = svc
+	}
+
+	return result, nil
+}
+
+// splitImageRef splits an image reference into repository and tag.
+//
+// The split is on the last colon, but only when that colon belongs to a tag
+// rather than to a registry port: "localhost:5000/foo" has no tag, while
+// "localhost:5000/foo:1.2" does. Digest references ("repo@sha256:…") have no
+// tag either.
+func splitImageRef(image string) (string, string) {
+	image = strings.TrimSpace(image)
+	if image == "" {
+		return "", ""
+	}
+	if at := strings.Index(image, "@"); at >= 0 {
+		return image[:at], ""
+	}
+
+	colon := strings.LastIndex(image, ":")
+	if colon < 0 {
+		return image, ""
+	}
+	if strings.Contains(image[colon+1:], "/") {
+		// The colon was a registry port, not a tag separator.
+		return image, ""
+	}
+	return image[:colon], image[colon+1:]
+}
+
+// decodeDependsOn reads compose's two depends_on spellings: the short list form
+// ("- cb-spider") and the long map form ("cb-spider: {condition: …}").
+func decodeDependsOn(node *yaml.Node) []string {
+	if node == nil || node.Kind == 0 {
+		return nil
+	}
+
+	switch node.Kind {
+	case yaml.SequenceNode:
+		var names []string
+		for _, item := range node.Content {
+			if item.Value != "" {
+				names = append(names, item.Value)
+			}
+		}
+		return names
+	case yaml.MappingNode:
+		var names []string
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			if name := node.Content[i].Value; name != "" {
+				names = append(names, name)
+			}
+		}
+		return names
+	}
+	return nil
+}
+
+// parseDockerComposeImages parses docker-compose.yaml to extract all service information
+func parseDockerComposeImages() (map[string]ServiceInfo, error) {
+	parsed, err := loadComposeFile()
+	if err != nil {
+		return nil, err
+	}
+
+	services := make(map[string]ServiceInfo, len(parsed.Services))
+	for name, svc := range parsed.Services {
+		services[name] = ServiceInfo{
+			Name:     svc.Name,
+			Image:    svc.Image,
+			Category: svc.Category,
+		}
+	}
 	return services, nil
 }
 
-// categorizeService categorizes services based on name and image
+// splitServiceNames normalizes a raw -s value into a list of service names.
+//
+// Commas and whitespace are both accepted, and may be mixed freely
+// ("a, b c" → ["a" "b" "c"]). Empty fields are dropped and duplicates are
+// removed while preserving the order the user wrote them in.
+//
+// A raw value that holds nothing but separators (",", "  ") yields an empty
+// slice. Callers must NOT read that as "all services" — see resolveServices.
+func splitServiceNames(raw string) []string {
+	fields := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t' || r == '\n' || r == '\r'
+	})
+
+	seen := make(map[string]bool, len(fields))
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		name := strings.TrimSpace(f)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	return out
+}
+
+// resolveServices splits a -s value and validates each name against the compose
+// file. It is the single entry point every infra subcommand uses to work out
+// which services it was asked to act on.
+//
+// The return value distinguishes two cases that must never be confused:
+//
+//   - raw is empty (the -s flag was not given) → (nil, nil), meaning "all
+//     services". This is the only way to select the whole environment.
+//   - raw is non-empty → a non-empty, validated list, or an error.
+//
+// In particular a raw value that contains only separators (-s "," or -s " ")
+// is an error, not "all services". Treating it as the whole environment is how
+// a typo aimed at one service ends up tearing down everything — which is why
+// the empty check below is on raw itself rather than on a trimmed copy.
+func resolveServices(raw string) ([]string, error) {
+	if raw == "" {
+		return nil, nil
+	}
+
+	names := splitServiceNames(raw)
+	if len(names) == 0 {
+		return nil, fmt.Errorf("no service name found in -s %q\n"+
+			"The value holds only separators. Name the services you want, e.g. -s cb-spider or -s \"cb-spider cb-tumblebug\".\n"+
+			"Omit -s entirely to target every service", raw)
+	}
+
+	available, err := parseDockerComposeImages()
+	if err != nil {
+		return nil, err
+	}
+
+	return validateServiceNames(names, available)
+}
+
+// validateServiceNames checks each already-split name against the services
+// declared in the compose file. It is split out from resolveServices so the
+// validation can be exercised without touching the filesystem.
+func validateServiceNames(names []string, available map[string]ServiceInfo) ([]string, error) {
+	var unknown []string
+	for _, name := range names {
+		if _, exists := available[name]; !exists {
+			unknown = append(unknown, name)
+		}
+	}
+	if len(unknown) == 0 {
+		return names, nil
+	}
+
+	// Name the offending entries only. Reporting the whole -s string leaves the
+	// user to work out which of several names was wrong.
+	subject := fmt.Sprintf("Service '%s' was", unknown[0])
+	if len(unknown) > 1 {
+		subject = fmt.Sprintf("Services '%s' were", strings.Join(unknown, "', '"))
+	}
+
+	sorted := make([]string, 0, len(available))
+	for name := range available {
+		sorted = append(sorted, name)
+	}
+	sort.Strings(sorted)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s not found in %s\nAvailable services:\n", subject, DockerFilePath)
+	for _, name := range sorted {
+		fmt.Fprintf(&b, "  - %s\n", name)
+	}
+	return nil, errors.New(strings.TrimRight(b.String(), "\n"))
+}
+
+// composeArgs builds the argument vector for a `docker compose -f <file> …`
+// invocation, with the caller's arguments appended.
+func composeArgs(args ...string) []string {
+	return append([]string{"compose", "-f", DockerFilePath}, args...)
+}
+
+// composeEnv returns the environment additions every compose invocation needs.
+// COMPOSE_PROJECT_NAME is passed through the child environment rather than
+// prefixed onto a shell command string.
+func composeEnv() []string {
+	return []string{"COMPOSE_PROJECT_NAME=" + ProjectName}
+}
+
+// runCompose runs `docker compose -f <file> <args…>` without a shell and
+// returns the exit status.
+func runCompose(args ...string) error {
+	return common.RunCommand("docker", composeArgs(args...), composeEnv())
+}
+
+// composeOutput runs `docker compose -f <file> <args…>` without a shell and
+// returns its standard output.
+func composeOutput(args ...string) ([]byte, error) {
+	return common.RunCommandOutput("docker", composeArgs(args...), composeEnv())
+}
+
+// displayCommand renders an argument vector for display (dry-run output, error
+// messages). It is never handed to a shell.
+func displayCommand(name string, args []string) string {
+	return name + " " + strings.Join(args, " ")
+}
+
+// Service categories. A service belongs to the framework it is part of first,
+// and to its technical role second: cb-tumblebug-postgres is a data store of the
+// Core Infrastructure lineup, while cm-butterfly-db belongs with the console it
+// serves. Grouping on the image prefix alone cannot express that, because one
+// registry namespace publishes images for every framework.
+const (
+	CategoryCoreInfra     = "Core Infrastructure"
+	CategoryFrameworks    = "C-Mig Frameworks"
+	CategoryWebConsole    = "Web Console"
+	CategoryWorkflow      = "Workflow Engine"
+	CategorySecrets       = "Secrets"
+	CategoryDataStores    = "Data Stores"
+	CategoryObjectStorage = "Object Storage"
+	CategoryDependencies  = "Dependencies"
+)
+
+// serviceCategories maps every service the shipped compose file declares to its
+// category. This is the authority: the pattern rules below only cover services
+// that are not listed here.
+var serviceCategories = map[string]string{
+	"cb-spider":    CategoryCoreInfra,
+	"cb-tumblebug": CategoryCoreInfra,
+	"cb-mapui":     CategoryCoreInfra,
+	"mc-terrarium": CategoryCoreInfra,
+
+	"cm-beetle":      CategoryFrameworks,
+	"cm-honeybee":    CategoryFrameworks,
+	"cm-damselfly":   CategoryFrameworks,
+	"cm-grasshopper": CategoryFrameworks,
+	"cm-ant":         CategoryFrameworks,
+
+	"cm-butterfly-front": CategoryWebConsole,
+	"cm-butterfly-api":   CategoryWebConsole,
+	"cm-butterfly-db":    CategoryWebConsole,
+
+	"cm-cicada":      CategoryWorkflow,
+	"airflow-server": CategoryWorkflow,
+	"airflow-mysql":  CategoryWorkflow,
+	"airflow-redis":  CategoryWorkflow,
+
+	"openbao":        CategorySecrets,
+	"openbao-unseal": CategorySecrets,
+
+	"cb-tumblebug-etcd":     CategoryDataStores,
+	"cb-tumblebug-postgres": CategoryDataStores,
+	"ant-postgres":          CategoryDataStores,
+
+	"cm-grasshopper-rustfs": CategoryObjectStorage,
+}
+
+// CategoryDisplay pairs a category with the icon that heads it on screen.
+type CategoryDisplay struct {
+	Name string
+	Icon string
+}
+
+// categoryDisplayOrder is the order categories are shown in, and the icon each
+// one carries. Both `infra run` and `infra info --human` read it, so the two
+// screens cannot drift into different orders or different icons.
+var categoryDisplayOrder = []CategoryDisplay{
+	{CategoryCoreInfra, "🎯"},
+	{CategoryFrameworks, "🧩"},
+	{CategoryWebConsole, "🖥️"},
+	{CategoryWorkflow, "⚙️"},
+	{CategorySecrets, "🔐"},
+	{CategoryDataStores, "🗄️"},
+	{CategoryObjectStorage, "📦"},
+	{CategoryDependencies, "🔧"},
+}
+
+// unknownCategoryIcon heads a category that categoryDisplayOrder does not know
+// about, which can only happen if a new category is added without listing it.
+const unknownCategoryIcon = "🔧"
+
+// categoryIcon returns the icon a category is headed with.
+func categoryIcon(name string) string {
+	for _, entry := range categoryDisplayOrder {
+		if entry.Name == name {
+			return entry.Icon
+		}
+	}
+	return unknownCategoryIcon
+}
+
+// categorizeService returns the category a service is displayed under. Names
+// listed in serviceCategories always win; anything else falls through to the
+// pattern rules so a service added to the compose file still lands somewhere
+// sensible instead of disappearing.
 func categorizeService(serviceName, imageName string) string {
-	// Core Cloud Migrator services
-	if strings.HasPrefix(imageName, "cloudbaristaorg/") {
-		return "Core Services"
+	if category, ok := serviceCategories[serviceName]; ok {
+		return category
 	}
 
-	// Database services
-	if strings.Contains(serviceName, "postgres") || strings.Contains(serviceName, "mysql") ||
-		strings.Contains(serviceName, "db") {
-		return "Database"
+	switch {
+	case strings.HasPrefix(serviceName, "airflow-"):
+		return CategoryWorkflow
+	case strings.HasPrefix(serviceName, "openbao"):
+		return CategorySecrets
+	case strings.HasPrefix(serviceName, "cm-butterfly-"):
+		return CategoryWebConsole
+	case strings.HasSuffix(serviceName, "-postgres"), strings.HasSuffix(serviceName, "-mysql"),
+		strings.HasSuffix(serviceName, "-db"), strings.Contains(serviceName, "etcd"),
+		strings.Contains(serviceName, "redis"):
+		return CategoryDataStores
+	case strings.HasPrefix(serviceName, "cb-"), serviceName == "mc-terrarium":
+		return CategoryCoreInfra
+	case strings.HasPrefix(serviceName, "cm-"):
+		return CategoryFrameworks
 	}
 
-	// Cache/Message Queue services
-	if strings.Contains(serviceName, "redis") || strings.Contains(serviceName, "etcd") {
-		return "Cache/Storage"
-	}
-
-	// Airflow services
-	if strings.Contains(serviceName, "airflow") {
-		return "Workflow Engine"
-	}
-
-	// Default category
-	return "Dependencies"
+	return CategoryDependencies
 }

--- a/cmd/docker/compose_test.go
+++ b/cmd/docker/compose_test.go
@@ -1,0 +1,474 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// withComposeFile points DockerFilePath at a temporary compose file for the
+// duration of one test. Each call writes to a fresh directory so the parse
+// cache, which is keyed on path plus size plus mtime, cannot serve one test's
+// content to another.
+func withComposeFile(t *testing.T, content string) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "docker-compose.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write the test compose file: %v", err)
+	}
+
+	prev := DockerFilePath
+	DockerFilePath = path
+	t.Cleanup(func() { DockerFilePath = prev })
+}
+
+// A service that declares healthcheck or build before image must still be found.
+// The line-oriented scanner this replaced looked for a bare "key:" line followed
+// by an "image:" line, so it attributed the image to whichever bare key came
+// last — and any service whose image was not its first key vanished, which the
+// user then saw as "service not found in docker-compose.yaml".
+func TestParseComposeFindsServicesWithImageNotFirst(t *testing.T) {
+	withComposeFile(t, `
+services:
+  image-first:
+    image: cloudbaristaorg/image-first:1.0.0
+    container_name: image-first
+
+  health-first:
+    healthcheck:
+      test: ["CMD", "true"]
+    image: cloudbaristaorg/health-first:2.0.0
+
+  build-first:
+    build:
+      context: .
+    image: cloudbaristaorg/build-first:3.0.0
+
+  no-image-at-all:
+    build:
+      context: .
+`)
+
+	parsed, err := loadComposeFile()
+	if err != nil {
+		t.Fatalf("loadComposeFile: %v", err)
+	}
+
+	want := map[string]string{
+		"image-first":     "cloudbaristaorg/image-first:1.0.0",
+		"health-first":    "cloudbaristaorg/health-first:2.0.0",
+		"build-first":     "cloudbaristaorg/build-first:3.0.0",
+		"no-image-at-all": "",
+	}
+
+	if len(parsed.Services) != len(want) {
+		t.Fatalf("parsed %d services (%v), want %d", len(parsed.Services), parsed.Order, len(want))
+	}
+	for name, image := range want {
+		svc, exists := parsed.Services[name]
+		if !exists {
+			t.Errorf("service %q is missing from the parse", name)
+			continue
+		}
+		if svc.Image != image {
+			t.Errorf("service %q image = %q, want %q", name, svc.Image, image)
+		}
+	}
+}
+
+// A commented-out image line belongs to no service. The compose file toggles
+// between an edge tag and a pinned tag by commenting one of the two out, so
+// picking up the wrong one would report a version that is not in use.
+func TestParseComposeIgnoresCommentedImage(t *testing.T) {
+	withComposeFile(t, `
+services:
+  cm-ant:
+    # image: cloudbaristaorg/cm-ant:edge
+    image: cloudbaristaorg/cm-ant:0.5.4
+`)
+
+	parsed, err := loadComposeFile()
+	if err != nil {
+		t.Fatalf("loadComposeFile: %v", err)
+	}
+	if got := parsed.Services["cm-ant"].Tag; got != "0.5.4" {
+		t.Errorf("cm-ant tag = %q, want the uncommented 0.5.4", got)
+	}
+}
+
+// Services are listed in the order the compose file declares them.
+func TestParseComposePreservesOrder(t *testing.T) {
+	withComposeFile(t, `
+services:
+  zulu:
+    image: repo/zulu:1
+  alpha:
+    image: repo/alpha:1
+  mike:
+    image: repo/mike:1
+`)
+
+	got := getServicesFromCompose()
+	want := []string{"zulu", "alpha", "mike"}
+
+	if len(got) != len(want) {
+		t.Fatalf("getServicesFromCompose() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("getServicesFromCompose() = %v, want %v", got, want)
+		}
+	}
+}
+
+// Keys nested under depends_on are dependency references, not services of
+// their own, and must not appear in the service list.
+func TestParseComposeExcludesDependsOnEntries(t *testing.T) {
+	withComposeFile(t, `
+services:
+  cm-beetle:
+    image: repo/cm-beetle:1
+    depends_on:
+      cb-tumblebug:
+        condition: service_healthy
+  cb-tumblebug:
+    image: repo/cb-tumblebug:1
+`)
+
+	parsed, err := loadComposeFile()
+	if err != nil {
+		t.Fatalf("loadComposeFile: %v", err)
+	}
+	if len(parsed.Services) != 2 {
+		t.Fatalf("parsed %v, want exactly cm-beetle and cb-tumblebug", parsed.Order)
+	}
+	deps := parsed.Services["cm-beetle"].DependsOn
+	if len(deps) != 1 || deps[0] != "cb-tumblebug" {
+		t.Errorf("cm-beetle depends_on = %v, want [cb-tumblebug]", deps)
+	}
+}
+
+// depends_on has a short list form as well as the map form, and both must read.
+func TestParseComposeReadsListFormDependsOn(t *testing.T) {
+	withComposeFile(t, `
+services:
+  a:
+    image: repo/a:1
+    depends_on:
+      - b
+      - c
+  b:
+    image: repo/b:1
+  c:
+    image: repo/c:1
+`)
+
+	parsed, err := loadComposeFile()
+	if err != nil {
+		t.Fatalf("loadComposeFile: %v", err)
+	}
+	deps := parsed.Services["a"].DependsOn
+	if len(deps) != 2 || deps[0] != "b" || deps[1] != "c" {
+		t.Errorf("a depends_on = %v, want [b c]", deps)
+	}
+}
+
+func TestSplitImageRef(t *testing.T) {
+	cases := []struct {
+		image      string
+		repository string
+		tag        string
+	}{
+		{"cloudbaristaorg/cm-ant:0.5.4", "cloudbaristaorg/cm-ant", "0.5.4"},
+		{"postgres:16-alpine", "postgres", "16-alpine"},
+		{"rustfs/rustfs:latest", "rustfs/rustfs", "latest"},
+		{"postgres", "postgres", ""},
+		// A colon before a slash is a registry port, not a tag separator.
+		{"localhost:5000/cm-ant", "localhost:5000/cm-ant", ""},
+		{"localhost:5000/cm-ant:0.5.4", "localhost:5000/cm-ant", "0.5.4"},
+		// A digest reference pins the image without naming a tag.
+		{"repo/name@sha256:abc123", "repo/name", ""},
+		{"", "", ""},
+	}
+
+	for _, c := range cases {
+		repository, tag := splitImageRef(c.image)
+		if repository != c.repository || tag != c.tag {
+			t.Errorf("splitImageRef(%q) = (%q, %q), want (%q, %q)",
+				c.image, repository, tag, c.repository, c.tag)
+		}
+	}
+}
+
+// Dependencies are followed the whole way down. Reporting only the direct
+// depends_on meant `info --human -s cm-cicada` showed cm-beetle but not the
+// cb-tumblebug that cm-beetle cannot start without.
+func TestGetDependencyServicesIsTransitive(t *testing.T) {
+	withComposeFile(t, `
+services:
+  cm-cicada:
+    image: repo/cm-cicada:1
+    depends_on:
+      cm-beetle:
+        condition: service_healthy
+  cm-beetle:
+    image: repo/cm-beetle:1
+    depends_on:
+      cb-tumblebug:
+        condition: service_healthy
+  cb-tumblebug:
+    image: repo/cb-tumblebug:1
+    depends_on:
+      cb-spider:
+        condition: service_started
+  cb-spider:
+    image: repo/cb-spider:1
+  unrelated:
+    image: repo/unrelated:1
+`)
+
+	got := getDependencyServices([]string{"cm-cicada"})
+
+	want := map[string]bool{"cm-beetle": true, "cb-tumblebug": true, "cb-spider": true}
+	if len(got) != len(want) {
+		t.Fatalf("getDependencyServices = %v, want the three transitive dependencies", got)
+	}
+	for _, name := range got {
+		if !want[name] {
+			t.Errorf("getDependencyServices returned %q, which cm-cicada does not depend on", name)
+		}
+	}
+}
+
+// A cycle in depends_on must end the walk rather than recurse forever.
+func TestGetDependencyServicesHandlesCycle(t *testing.T) {
+	withComposeFile(t, `
+services:
+  a:
+    image: repo/a:1
+    depends_on:
+      - b
+  b:
+    image: repo/b:1
+    depends_on:
+      - c
+  c:
+    image: repo/c:1
+    depends_on:
+      - a
+`)
+
+	got := getDependencyServices([]string{"a"})
+
+	// a is the requested service, so it is not reported as its own dependency
+	// even though the cycle leads back to it.
+	if len(got) != 2 {
+		t.Fatalf("getDependencyServices = %v, want [b c]", got)
+	}
+	for _, name := range got {
+		if name == "a" {
+			t.Errorf("getDependencyServices returned the requested service %q as a dependency", name)
+		}
+	}
+}
+
+// The size column must describe the image the version column names. It used to
+// match any repository *containing* a keyword and fall back to the first hit,
+// so a row could read "16-alpine (Not Downloaded)" and "291MB" at once — the
+// 291MB belonging to an unrelated postgres:14-alpine.
+func TestGetImageInfoRequiresExactTagMatch(t *testing.T) {
+	withComposeFile(t, `
+services:
+  cb-tumblebug-postgres:
+    image: postgres:16-alpine
+  cm-butterfly-db:
+    image: postgres:14-alpine
+`)
+
+	// Stand in for the local docker image list.
+	localImageOnce.Do(func() {})
+	prev := localImageIndex
+	localImageIndex = map[string]string{"postgres:14-alpine": "291MB"}
+	defer func() { localImageIndex = prev }()
+
+	images := getImageInfo()
+
+	if _, exists := images["cb-tumblebug-postgres"]; exists {
+		t.Errorf("cb-tumblebug-postgres reported a size, but postgres:16-alpine is not present locally")
+	}
+	if got := images["cm-butterfly-db"].Size; got != "291MB" {
+		t.Errorf("cm-butterfly-db size = %q, want 291MB", got)
+	}
+}
+
+// The VERSION cell always names the compose tag and marks whether that tag is
+// what is running. It used to spell the state out instead ("0.12.9 (Not
+// Downloaded)"), which doubled the column width and still never said which
+// version was really up.
+func TestHumanVersionCells(t *testing.T) {
+	withComposeFile(t, `
+services:
+  present:
+    image: repo/present:1.0.0
+  absent:
+    image: repo/absent:2.0.0
+  imageless:
+    build:
+      context: .
+`)
+
+	localImageOnce.Do(func() {})
+	prev := localImageIndex
+	localImageIndex = map[string]string{"repo/present:1.0.0": "10MB"}
+	defer func() { localImageIndex = prev }()
+
+	cases := []struct {
+		name       string
+		service    string
+		container  ContainerInfo
+		exists     bool
+		wantVer    string
+		wantActual string
+	}{
+		{
+			name:      "running on the compose version",
+			service:   "present",
+			container: ContainerInfo{Status: "running", Version: "1.0.0"},
+			exists:    true,
+			wantVer:   "1.0.0 ✓",
+		},
+		{
+			name:       "running on some other version",
+			service:    "present",
+			container:  ContainerInfo{Status: "running", Version: "0.9.0"},
+			exists:     true,
+			wantVer:    "1.0.0 ✗",
+			wantActual: "0.9.0",
+		},
+		{
+			// A stopped container proves nothing about what would come up, so
+			// its tag is not reported as actually running.
+			name:      "stopped container is not a running version",
+			service:   "present",
+			container: ContainerInfo{Status: "Stopped", Version: "0.9.0"},
+			exists:    true,
+			wantVer:   "1.0.0 ✗",
+		},
+		{
+			name:    "no container at all",
+			service: "present",
+			wantVer: "1.0.0 ✗",
+		},
+		{
+			// Not downloaded is not spelled out; the mark already says the
+			// service is not up on that version.
+			name:    "image not present locally",
+			service: "absent",
+			wantVer: "2.0.0 ✗",
+		},
+		{
+			name:    "service without an image tag",
+			service: "imageless",
+			wantVer: "-",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotVer, gotActual := humanVersionCells(c.service, c.container, c.exists)
+			if gotVer != c.wantVer || gotActual != c.wantActual {
+				t.Errorf("humanVersionCells(%q) = (%q, %q), want (%q, %q)",
+					c.service, gotVer, gotActual, c.wantVer, c.wantActual)
+			}
+		})
+	}
+}
+
+// Column widths are measured in terminal columns. Every branch of this function
+// used to add 1, so the "Unicode" handling it advertised did nothing and a
+// double-width character pushed the table border out by one per character.
+func TestGetDisplayWidth(t *testing.T) {
+	cases := []struct {
+		s     string
+		width int
+	}{
+		{"", 0},
+		{"cb-tumblebug-postgres", 21},
+		{"16-alpine (Not Downloaded)", 26},
+		{"✓", 1},
+		{"✗", 1},
+		{"-", 1},
+		{"한글", 4},   // two Hangul syllables, two columns each
+		{"日本語", 6},  // three CJK ideographs
+		{"a한b", 4},  // mixed ASCII and wide
+		{"🎯", 2},    // emoji used in the section headings
+		{"ｆｕｌｌ", 8}, // fullwidth Latin
+	}
+
+	for _, c := range cases {
+		if got := getDisplayWidth(c.s); got != c.width {
+			t.Errorf("getDisplayWidth(%q) = %d, want %d", c.s, got, c.width)
+		}
+	}
+}
+
+// Official Docker Hub images live under library/, even though they are pulled
+// by a bare name. Without the prefix the API answers 404 for every one of them,
+// which is why postgres, redis, mysql and etcd never showed a Latest value.
+func TestDockerHubRepositoryPath(t *testing.T) {
+	cases := map[string]string{
+		"postgres":                  "library/postgres",
+		"redis":                     "library/redis",
+		"cloudbaristaorg/cm-ant":    "cloudbaristaorg/cm-ant",
+		"rustfs/rustfs":             "rustfs/rustfs",
+		"gcr.io/etcd-development/e": "gcr.io/etcd-development/e",
+	}
+
+	for image, want := range cases {
+		if got := dockerHubRepositoryPath(image); got != want {
+			t.Errorf("dockerHubRepositoryPath(%q) = %q, want %q", image, got, want)
+		}
+	}
+}
+
+// The OpenBao consistency verdict belongs in a report that covers OpenBao. It
+// used to print unconditionally, so `info -s cm-ant` ended with a verdict about
+// a component the user had not asked about.
+func TestOpenbaoRelevant(t *testing.T) {
+	if !openbaoRelevant(nil) {
+		t.Error("openbaoRelevant(nil) = false, want true: no filter means the whole environment")
+	}
+	if !openbaoRelevant([]string{"cm-ant", "openbao-unseal"}) {
+		t.Error("openbaoRelevant with openbao-unseal = false, want true")
+	}
+	if openbaoRelevant([]string{"cm-ant", "ant-postgres"}) {
+		t.Error("openbaoRelevant without any OpenBao service = true, want false")
+	}
+}
+
+// The real compose file must parse, and every service in it must be reachable
+// through both the display list and -s resolution.
+func TestRealComposeFileParses(t *testing.T) {
+	prev := DockerFilePath
+	DockerFilePath = filepath.Join("..", "..", "conf", "docker", "docker-compose.yaml")
+	defer func() { DockerFilePath = prev }()
+
+	parsed, err := loadComposeFile()
+	if err != nil {
+		t.Fatalf("failed to parse the real compose file: %v", err)
+	}
+	if len(parsed.Order) == 0 {
+		t.Fatal("the real compose file parsed to zero services")
+	}
+
+	for _, name := range parsed.Order {
+		svc := parsed.Services[name]
+		if svc.Image == "" {
+			t.Errorf("service %q has no image; check whether that is intended", name)
+		}
+		if svc.Tag == "" {
+			t.Errorf("service %q has an image with no tag: %q", name, svc.Image)
+		}
+	}
+}

--- a/cmd/docker/envfile.go
+++ b/cmd/docker/envfile.go
@@ -1,0 +1,75 @@
+package docker
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// envFileMode is the mode .env is kept at. It holds DB credentials and
+// VAULT_TOKEN, so nobody but the owner has any business reading it.
+const envFileMode os.FileMode = 0600
+
+// writeEnvFile replaces the contents of the .env at path atomically, and leaves
+// the file owner-readable only.
+//
+// Two things the previous os.WriteFile(path, data, 0600) did not do:
+//
+//   - Mode. os.WriteFile only applies the mode when it *creates* the file. An
+//     .env copied from .env.example under a typical 0022 umask is 0644, and
+//     every rewrite left it that way — the comment claimed owner-only while the
+//     secrets stayed world-readable. The mode is therefore set explicitly.
+//   - Atomicity. os.WriteFile truncates first and then writes. An interrupted or
+//     out-of-space write leaves a half-written .env and no way back: the DB
+//     credentials and VAULT_TOKEN that were in it are simply gone. Writing to a
+//     temporary file in the same directory and renaming over the target means
+//     the file a reader sees is always one of the two complete versions.
+//
+// The temporary file lives in the target's own directory so the rename stays
+// within one filesystem (os.Rename cannot cross devices) and never widens the
+// exposure to a shared directory such as /tmp.
+func writeEnvFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".env.tmp-*")
+	if err != nil {
+		return fmt.Errorf("failed to create a temporary file next to %s: %w", path, err)
+	}
+	tmpName := tmp.Name()
+	// Clean up the temporary file on every path that does not rename it away.
+	defer func() {
+		if _, err := os.Stat(tmpName); err == nil {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	// CreateTemp already makes the file 0600, but say so explicitly rather than
+	// depending on that.
+	if err := tmp.Chmod(envFileMode); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("failed to set permissions on the temporary file for %s: %w", path, err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("failed to write %s: %w", path, err)
+	}
+	// Flush to disk before the rename, so a crash right after it cannot leave
+	// the renamed file with unwritten contents.
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("failed to flush %s: %w", path, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("failed to close the temporary file for %s: %w", path, err)
+	}
+
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("failed to replace %s: %w", path, err)
+	}
+	// The rename carries the temporary file's 0600 across, so the mode is
+	// already correct here. Re-apply it anyway: it costs nothing and keeps the
+	// guarantee true even if the file is replaced some other way later.
+	if err := os.Chmod(path, envFileMode); err != nil {
+		return fmt.Errorf("failed to set permissions on %s: %w", path, err)
+	}
+	return nil
+}

--- a/cmd/docker/envfile_test.go
+++ b/cmd/docker/envfile_test.go
@@ -1,0 +1,133 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// .env holds DB credentials and VAULT_TOKEN. Every rewrite must leave it
+// readable by its owner only — including a rewrite of a file that was created
+// world-readable, which is what copying .env.example under the usual umask
+// produces. os.WriteFile does not do this: its mode argument only applies when
+// it creates the file, so the old code left a 0644 .env at 0644.
+func TestWriteEnvFileNarrowsMode(t *testing.T) {
+	p := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(p, []byte("A=1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeEnvFile(p, []byte("A=2\n")); err != nil {
+		t.Fatalf("writeEnvFile: %v", err)
+	}
+	fi, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fi.Mode().Perm(); got != 0600 {
+		t.Errorf("mode = %04o, want 0600", got)
+	}
+	got, _ := os.ReadFile(p)
+	if string(got) != "A=2\n" {
+		t.Errorf("content = %q, want %q", got, "A=2\n")
+	}
+}
+
+// The same guarantee has to hold for a file that does not exist yet.
+func TestWriteEnvFileCreatesOwnerOnly(t *testing.T) {
+	p := filepath.Join(t.TempDir(), ".env")
+	if err := writeEnvFile(p, []byte("A=1\n")); err != nil {
+		t.Fatalf("writeEnvFile: %v", err)
+	}
+	fi, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fi.Mode().Perm(); got != 0600 {
+		t.Errorf("mode = %04o, want 0600", got)
+	}
+}
+
+// A write that fails must leave the previous .env intact. The old code
+// truncated first, so an interrupted write destroyed the credentials with
+// nothing to fall back on; writing to a temporary file and renaming means a
+// failure before the rename cannot touch the original.
+//
+// The failure is provoked by making the directory unwritable, so the temporary
+// file cannot be created.
+func TestWriteEnvFilePreservesOriginalOnFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores directory write permissions")
+	}
+	dir := t.TempDir()
+	p := filepath.Join(dir, ".env")
+	const original = "TUMBLEBUG_DB_PASSWORD=keepme\n"
+	if err := os.WriteFile(p, []byte(original), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0700) })
+
+	if err := writeEnvFile(p, []byte("TUMBLEBUG_DB_PASSWORD=clobbered\n")); err == nil {
+		t.Fatal("writeEnvFile succeeded on an unwritable directory, want an error")
+	}
+	got, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != original {
+		t.Errorf("original .env was modified by a failed write.\n got: %q\nwant: %q", got, original)
+	}
+}
+
+// No temporary file may be left behind next to .env — docker compose reads
+// every file in that directory's vicinity and a stray .env.tmp-* holding
+// credentials is exactly what the atomic write is meant to avoid.
+func TestWriteEnvFileLeavesNoTempFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, ".env")
+	if err := writeEnvFile(p, []byte("A=1\n")); err != nil {
+		t.Fatalf("writeEnvFile: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != ".env" {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("directory contains %v, want only .env", names)
+	}
+}
+
+// setEnvKey and clearEnvKey both go through writeEnvFile, so the mode
+// guarantee has to survive the path an actual command takes.
+func TestEnvKeyWritersNarrowMode(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		write func(path string) error
+	}{
+		{"setEnvKey", func(p string) error { return setEnvKey(p, "AIRFLOW_JWT_SECRET", "s3cret") }},
+		{"clearEnvKey", func(p string) error { _, err := clearEnvKey(p, "VAULT_TOKEN"); return err }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := filepath.Join(t.TempDir(), ".env")
+			if err := os.WriteFile(p, []byte("VAULT_TOKEN=abc\nAIRFLOW_JWT_SECRET=\n"), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if err := tc.write(p); err != nil {
+				t.Fatalf("%s: %v", tc.name, err)
+			}
+			fi, err := os.Stat(p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := fi.Mode().Perm(); got != 0600 {
+				t.Errorf("mode after %s = %04o, want 0600", tc.name, got)
+			}
+		})
+	}
+}

--- a/cmd/docker/info.go
+++ b/cmd/docker/info.go
@@ -3,12 +3,10 @@ package docker
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
+	"sort"
 	"strings"
-
-	"regexp"
+	"sync"
+	"unicode"
 
 	"github.com/cm-mayfly/cm-mayfly/common"
 	"github.com/cm-mayfly/cm-mayfly/internal/openbao"
@@ -22,6 +20,25 @@ func printOpenbaoInfo() {
 	fmt.Println()
 	fmt.Println("[OpenBao consistency]")
 	fmt.Println(openbao.CompactStatus())
+}
+
+// openbaoRelevant reports whether the OpenBao consistency section is worth
+// printing for this invocation.
+//
+// With no -s the report covers the whole environment, so it always is. With a
+// -s filter it only is when OpenBao itself is among the services being shown —
+// otherwise `infra info -s cm-ant` ends with a verdict about a component the
+// user did not ask about.
+func openbaoRelevant(services []string) bool {
+	if len(services) == 0 {
+		return true
+	}
+	for _, name := range services {
+		if strings.HasPrefix(name, "openbao") {
+			return true
+		}
+	}
+	return false
 }
 
 // infoAllFlag represents the --all flag for showing all containers including stopped ones
@@ -50,13 +67,19 @@ var infoCmd = &cobra.Command{
 			fmt.Println("")
 
 			fmt.Println("[v]Status of Cloud-Migrator runtime images")
-			convertedServiceName := convertServiceNameForDockerCompose(ServiceName)
-			cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s images %s", ProjectName, DockerFilePath, convertedServiceName)
-			//fmt.Println(cmdStr)
-			common.SysCall(cmdStr)
+			services, err := resolveServices(ServiceName)
+			if err != nil {
+				fmt.Printf("❌ %v\n", err)
+				return
+			}
+			if err := runCompose(append([]string{"images"}, services...)...); err != nil {
+				fmt.Printf("❌ docker compose images failed: %v\n", err)
+			}
 
 			// OpenBao consistency summary (shared preflight, read-only).
-			printOpenbaoInfo()
+			if openbaoRelevant(services) {
+				printOpenbaoInfo()
+			}
 
 			// Add helpful hint about --human option
 			fmt.Println()
@@ -69,13 +92,38 @@ var infoCmd = &cobra.Command{
 func init() {
 	dockerCmd.AddCommand(infoCmd)
 
-	// Add --all flag to info command
-	infoCmd.Flags().BoolVarP(&infoAllFlag, "all", "a", false, "Show all containers including stopped ones")
+	// Add --all flag to info command. It only affects the default view: the
+	// --human and --test-versions tables list every service in the compose file
+	// by design, so they have nothing to widen.
+	infoCmd.Flags().BoolVarP(&infoAllFlag, "all", "a", false, "Show all containers including stopped ones (default view only; --human and --test-versions always list every service)")
 	// Add --human flag to info command
 	infoCmd.Flags().BoolVarP(&infoHumanFlag, "human", "u", false, "Show human-readable service status table")
 	// Add --test-versions flag to info command
 	infoCmd.Flags().BoolVarP(&infoTestVersionsFlag, "test-versions", "t", false, "Test version extraction from docker-compose.yaml and show service status")
+
+	// --human and --test-versions each render their own table; asking for both
+	// used to run --test-versions and drop the other request without a word.
+	infoCmd.MarkFlagsMutuallyExclusive("human", "test-versions")
 }
+
+// Glyphs the VERSION column of the --human table uses.
+//
+// The column always shows the tag docker-compose.yaml names for the service —
+// the version that is supposed to come up — followed by one mark telling
+// whether that is what is actually running. Spelling the state out in
+// parentheses ("(?)", "(Not Downloaded)") doubled the column width and still
+// left the reader unable to see which version was really up.
+const (
+	// versionRunning marks a compose version that is the one actually running.
+	versionRunning = "✓"
+	// versionNotRunning marks a compose version that is not running, whether
+	// because the service is down or because its image is not even local.
+	versionNotRunning = "✗"
+	// actualVersionPrefix introduces the follow-up row naming the version that
+	// is running instead. Without it two bare versions on consecutive rows read
+	// as two services.
+	actualVersionPrefix = "<- "
+)
 
 // HumanServiceInfo represents service information for human-readable display
 type HumanServiceInfo struct {
@@ -86,6 +134,13 @@ type HumanServiceInfo struct {
 	InternalPort string
 	ExternalPort string
 	ImageSize    string
+
+	// ActualVersion is set only when the service is running on a version other
+	// than the one compose names. It renders as an extra row under the service,
+	// and the block gets ruled off so the disagreement is hard to miss.
+	ActualVersion string
+	// ActualHealthy is the health of that actually-running version.
+	ActualHealthy string
 }
 
 // showHumanReadableInfo displays service information in a human-readable table format
@@ -97,39 +152,15 @@ func showHumanReadableInfo() {
 	allServices := getServicesFromCompose()
 
 	// Filter services if -s option is used
+	requested, err := resolveServices(ServiceName)
+	if err != nil {
+		fmt.Printf("❌ %v\n", err)
+		return
+	}
+
 	var services []string
-	if ServiceName != "" {
-		// Parse multiple services - support both comma and space separation
-		var requestedServices []string
-		if strings.Contains(ServiceName, ",") {
-			// Comma-separated services
-			requestedServices = strings.Split(ServiceName, ",")
-		} else {
-			// Space-separated services
-			requestedServices = strings.Fields(ServiceName)
-		}
-
-		for _, requestedService := range requestedServices {
-			requestedService = strings.TrimSpace(requestedService)
-
-			// Check if the specified service exists
-			found := false
-			for _, service := range allServices {
-				if service == requestedService {
-					services = append(services, service)
-					found = true
-					break
-				}
-			}
-			if !found {
-				fmt.Printf("❌ Service '%s' not found in docker-compose.yaml\n", requestedService)
-				fmt.Println("Available services:")
-				for _, service := range allServices {
-					fmt.Printf("  - %s\n", service)
-				}
-				return
-			}
-		}
+	if len(requested) > 0 {
+		services = append(services, requested...)
 
 		// Add dependency services
 		dependencyServices := getDependencyServices(services)
@@ -146,6 +177,7 @@ func showHumanReadableInfo() {
 
 	// Get image information
 	images := getImageInfo()
+	localSizes := getLocalImageSizes()
 
 	// Create service info table
 	var serviceInfos []HumanServiceInfo
@@ -155,41 +187,48 @@ func showHumanReadableInfo() {
 			Service: service,
 		}
 
+		container, running := containers[service]
+
 		// Get container info for this service
-		if container, exists := containers[service]; exists {
+		if running {
 			info.Status = container.Status
 			info.Healthy = container.Healthy
 			info.InternalPort = container.InternalPort
 			info.ExternalPort = container.ExternalPort
-			info.Version = container.Version
 		} else {
 			info.Status = "Not Found"
 			info.Healthy = "-"
 			info.InternalPort = "-"
 			info.ExternalPort = "-"
-			// For non-running services, get version from docker-compose.yaml with "(?)" suffix
-			version := getVersionFromComposeFile(service)
-			if version != "-" {
-				info.Version = version + " (?)"
-			} else {
-				info.Version = version
-			}
+		}
+
+		// The VERSION column is the compose tag either way; what changes is
+		// whether it is marked as the one actually running.
+		info.Version, info.ActualVersion = humanVersionCells(service, container, running)
+		if info.ActualVersion != "" {
+			info.ActualHealthy = container.Healthy
 		}
 
 		// Get image size - prioritize running container's image
-		if container, exists := containers[service]; exists && container.Status == "running" {
-			// For running containers, try to get the actual image size
-			if image, exists := images[service]; exists {
+		if running && container.Status == "running" {
+			// A running container may be on an image other than the one the
+			// compose file names, so size is looked up by the image it actually
+			// runs rather than by the expected tag.
+			if size, exists := localSizes[container.Image]; exists {
+				info.ImageSize = size
+			} else if image, exists := images[service]; exists {
 				info.ImageSize = image.Size
 			} else {
 				info.ImageSize = "Running"
 			}
 		} else {
-			// For non-running services, check if expected version image exists
+			// For non-running services, check if expected version image exists.
+			// A missing image needs no words here: the "✗" beside the version
+			// already says the service is not up on it.
 			if image, exists := images[service]; exists {
 				info.ImageSize = image.Size
 			} else {
-				info.ImageSize = "Not Downloaded"
+				info.ImageSize = "-"
 			}
 		}
 
@@ -197,10 +236,12 @@ func showHumanReadableInfo() {
 	}
 
 	// Display table with service categorization
-	displayServiceTableWithDependencies(serviceInfos, ServiceName)
+	displayServiceTableWithDependencies(serviceInfos, requested)
 
 	// OpenBao consistency summary (shared preflight, read-only).
-	printOpenbaoInfo()
+	if openbaoRelevant(services) {
+		printOpenbaoInfo()
+	}
 }
 
 // ContainerInfo represents container information
@@ -219,33 +260,19 @@ type ImageInfo struct {
 	Tag  string
 }
 
-// getServicesFromCompose extracts service names from docker-compose.yaml
+// getServicesFromCompose extracts service names from docker-compose.yaml, in
+// the order they are declared.
+//
+// This used to be a hardcoded literal, which meant the compose file and this
+// list were two independent sources for "what services exist". They drifted:
+// cm-grasshopper-rustfs was added to compose but not here, so `run -s` accepted
+// the name while `info --human` said it did not exist.
 func getServicesFromCompose() []string {
-	// For now, return hardcoded services from docker-compose.yaml
-	// In a real implementation, you would parse the YAML file
-	return []string{
-		"cb-spider",
-		"cb-tumblebug",
-		"cb-tumblebug-etcd",
-		"cb-tumblebug-postgres",
-		"cb-mapui",
-		"mc-terrarium",
-		"openbao",
-		"openbao-unseal",
-		"cm-beetle",
-		"cm-butterfly-api",
-		"cm-butterfly-front",
-		"cm-butterfly-db",
-		"cm-honeybee",
-		"cm-damselfly",
-		"cm-cicada",
-		"airflow-redis",
-		"airflow-mysql",
-		"airflow-server",
-		"cm-grasshopper",
-		"cm-ant",
-		"ant-postgres",
+	parsed, err := loadComposeFile()
+	if err != nil {
+		return nil
 	}
+	return append([]string(nil), parsed.Order...)
 }
 
 // getContainerInfo gets container information using docker compose ps
@@ -253,14 +280,13 @@ func getContainerInfo(showAll bool) map[string]ContainerInfo {
 	containers := make(map[string]ContainerInfo)
 
 	// Execute docker compose ps command
-	var cmdStr string
+	args := []string{"ps"}
 	if showAll {
-		cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s ps -a --format json", ProjectName, DockerFilePath)
-	} else {
-		cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s ps --format json", ProjectName, DockerFilePath)
+		args = append(args, "-a")
 	}
-	cmd := exec.Command("bash", "-c", cmdStr)
-	output, err := cmd.Output()
+	args = append(args, "--format", "json")
+
+	output, err := composeOutput(args...)
 	if err != nil {
 		return containers
 	}
@@ -373,187 +399,140 @@ func isHexString(s string) bool {
 	return true
 }
 
-// getImageInfo gets image information using docker images
+// localImageSizes caches `docker images` for the lifetime of the process. The
+// info tables ask about every service, and each lookup used to spawn its own
+// `docker images` — about twenty processes for one `info --human`.
+var (
+	localImageOnce  sync.Once
+	localImageIndex map[string]string
+)
+
+// getLocalImageSizes returns a "repository:tag" → size index of the images
+// present locally.
+func getLocalImageSizes() map[string]string {
+	localImageOnce.Do(func() {
+		localImageIndex = make(map[string]string)
+
+		output, err := common.RunCommandOutput("docker", []string{"images", "--format", "json"}, nil)
+		if err != nil {
+			return
+		}
+
+		for _, line := range strings.Split(string(output), "\n") {
+			if strings.TrimSpace(line) == "" {
+				continue
+			}
+
+			var image struct {
+				Repository string `json:"Repository"`
+				Tag        string `json:"Tag"`
+				Size       string `json:"Size"`
+			}
+			if err := json.Unmarshal([]byte(line), &image); err != nil {
+				continue
+			}
+			if image.Repository == "" || image.Repository == "<none>" || image.Tag == "<none>" {
+				continue
+			}
+
+			localImageIndex[image.Repository+":"+image.Tag] = image.Size
+		}
+	})
+
+	return localImageIndex
+}
+
+// getImageInfo reports, per service, the local image matching the reference the
+// compose file names for it.
+//
+// The match is on the exact "repository:tag" pair. Matching loosely — the old
+// code took any repository *containing* a keyword and fell back to the first
+// hit when the expected tag was absent — produced rows that contradicted
+// themselves: cb-tumblebug-postgres read "16-alpine (Not Downloaded)" and
+// "291MB" at once, the 291MB being the unrelated postgres:14-alpine that
+// cm-butterfly-db uses. A service whose exact image is not local now has no
+// entry, and the caller renders that as "Not Downloaded".
 func getImageInfo() map[string]ImageInfo {
 	images := make(map[string]ImageInfo)
 
-	// Execute docker images command to get all images
-	cmdStr := "docker images --format json"
-	cmd := exec.Command("bash", "-c", cmdStr)
-	output, err := cmd.Output()
+	parsed, err := loadComposeFile()
 	if err != nil {
 		return images
 	}
 
-	// Parse JSON output
-	lines := strings.Split(string(output), "\n")
-	allImages := make(map[string][]ImageInfo)
-
-	for _, line := range lines {
-		if strings.TrimSpace(line) == "" {
+	local := getLocalImageSizes()
+	for name, svc := range parsed.Services {
+		if svc.Repository == "" || svc.Tag == "" {
 			continue
 		}
-
-		var image struct {
-			Repository string `json:"Repository"`
-			Tag        string `json:"Tag"`
-			Size       string `json:"Size"`
-		}
-
-		if err := json.Unmarshal([]byte(line), &image); err != nil {
-			continue
-		}
-
-		// Match images to services based on repository name
-		for serviceName, expectedImage := range getServiceImageMapping() {
-			if strings.Contains(image.Repository, expectedImage) {
-				if allImages[serviceName] == nil {
-					allImages[serviceName] = []ImageInfo{}
-				}
-				allImages[serviceName] = append(allImages[serviceName], ImageInfo{
-					Size: image.Size,
-					Tag:  image.Tag,
-				})
-			}
-		}
-	}
-
-	// For each service, select the appropriate image
-	for serviceName, imageList := range allImages {
-		if len(imageList) > 0 {
-			// If multiple images exist, prefer the one matching docker-compose.yaml version
-			expectedVersion := getVersionFromComposeFile(serviceName)
-			selectedImage := imageList[0] // default to first
-
-			for _, img := range imageList {
-				if img.Tag == expectedVersion {
-					selectedImage = img
-					break
-				}
-			}
-
-			images[serviceName] = selectedImage
+		if size, exists := local[svc.Repository+":"+svc.Tag]; exists {
+			images[name] = ImageInfo{Size: size, Tag: svc.Tag}
 		}
 	}
 
 	return images
 }
 
-// getServiceImageMapping returns mapping of service names to their image repository names
-func getServiceImageMapping() map[string]string {
-	return map[string]string{
-		"cb-spider":             "cb-spider",
-		"cb-tumblebug":          "cb-tumblebug",
-		"cb-tumblebug-etcd":     "etcd",
-		"cb-tumblebug-postgres": "postgres",
-		"cb-mapui":              "cb-mapui",
-		"mc-terrarium":          "mc-terrarium",
-		"openbao":               "openbao",
-		"openbao-unseal":        "alpine",
-		"cm-beetle":             "cm-beetle",
-		"cm-butterfly-api":      "cm-butterfly-api",
-		"cm-butterfly-front":    "cm-butterfly-front",
-		"cm-butterfly-db":       "postgres",
-		"cm-honeybee":           "cm-honeybee",
-		"cm-damselfly":          "cm-damselfly",
-		"cm-cicada":             "cm-cicada",
-		"airflow-redis":         "redis",
-		"airflow-mysql":         "mysql",
-		"airflow-server":        "airflow-server",
-		"cm-grasshopper":        "cm-grasshopper",
-		"cm-ant":                "cm-ant",
-		"ant-postgres":          "timescaledb",
+// composeVersion returns the tag docker-compose.yaml names for a service and
+// whether that exact image is present locally.
+//
+// The two facts are kept apart so that callers append at most one qualifier to
+// the version string. When they were baked into one return value the human
+// table produced "0.12.9 (Not Downloaded) (?)" — two qualifiers stacked, one
+// from here and one from the caller, and a version column padded to fit both.
+func composeVersion(serviceName string) (version string, present bool) {
+	parsed, err := loadComposeFile()
+	if err != nil {
+		return "", false
 	}
+
+	svc, exists := parsed.Services[serviceName]
+	if !exists || svc.Tag == "" {
+		return "", false
+	}
+
+	_, present = getLocalImageSizes()[svc.Repository+":"+svc.Tag]
+	return svc.Tag, present
 }
 
 // getVersionFromComposeFile reads docker-compose.yaml and returns version for non-running services
 func getVersionFromComposeFile(serviceName string) string {
-	// Read docker-compose.yaml file
-	composeFile := fmt.Sprintf("%s/docker-compose.yaml", filepath.Dir(DockerFilePath))
-	content, err := os.ReadFile(composeFile)
-	if err != nil {
+	version, present := composeVersion(serviceName)
+	if version == "" {
 		return "-"
 	}
+	if !present {
+		return version + " (Not Downloaded)"
+	}
+	return version
+}
 
-	// Use regex to find the service and its image
-	// Pattern: serviceName: at the beginning of a line (with minimal indentation)
-	servicePattern := fmt.Sprintf(`^\s*%s:\s*$`, regexp.QuoteMeta(serviceName))
-	imagePattern := `^\s*image:\s*(.+)$`
-
-	serviceRegex, err := regexp.Compile(servicePattern)
-	if err != nil {
-		return "-"
+// humanVersionCells renders the VERSION cell of the --human table for a service,
+// plus the version of a differing image that is actually running, if any.
+//
+// The first return value is always the compose tag with one mark appended: "✓"
+// when that tag is what is up, "✗" otherwise. The second is empty unless the
+// service runs on some other tag, in which case the caller adds a follow-up row
+// naming it.
+//
+// Only a container in the "running" state can confirm a version. A stopped one
+// says nothing about what would come up, so its image tag is not reported as
+// actually running.
+func humanVersionCells(serviceName string, container ContainerInfo, exists bool) (version, actual string) {
+	composeTag, _ := composeVersion(serviceName)
+	if composeTag == "" {
+		return "-", ""
 	}
 
-	imageRegex, err := regexp.Compile(imagePattern)
-	if err != nil {
-		return "-"
+	if !exists || container.Status != "running" {
+		return composeTag + " " + versionNotRunning, ""
 	}
 
-	lines := strings.Split(string(content), "\n")
-	inService := false
-	indentLevel := 0
-
-	for i, line := range lines {
-		// Check if we're entering the service section
-		if serviceRegex.MatchString(line) {
-			// Check if this is a top-level service (not inside depends_on or other sections)
-			// by checking if the line starts with minimal indentation and is not inside depends_on
-			trimmedLine := strings.TrimLeft(line, " \t")
-			if strings.HasPrefix(trimmedLine, serviceName+":") {
-				// Check if we're not inside depends_on section by looking at previous lines
-				isInDependsOn := false
-				for j := i - 1; j >= 0 && j >= i-10; j-- {
-					prevLine := strings.TrimSpace(lines[j])
-					if prevLine == "depends_on:" {
-						isInDependsOn = true
-						break
-					}
-					if prevLine != "" && !strings.HasPrefix(lines[j], " ") && !strings.HasPrefix(lines[j], "\t") {
-						break
-					}
-				}
-
-				if !isInDependsOn {
-					inService = true
-					// Calculate the indentation level of the service
-					indentLevel = len(line) - len(strings.TrimLeft(line, " \t"))
-					continue
-				}
-			}
-		}
-
-		// If we're in the service section, look for image field
-		if inService {
-			currentIndent := len(line) - len(strings.TrimLeft(line, " \t"))
-
-			// Check if we've moved to another service or section (same or less indentation)
-			if strings.TrimSpace(line) != "" && currentIndent <= indentLevel && !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
-				// We've moved to another service or section
-				break
-			}
-
-			// Look for image field
-			if matches := imageRegex.FindStringSubmatch(line); matches != nil {
-				image := strings.TrimSpace(matches[1])
-
-				// Extract version from image
-				version := extractVersionFromImage(image)
-				if version == "" {
-					return "-"
-				}
-
-				// Check if image exists locally
-				if !checkImageExists(image) {
-					return version + " (Not Downloaded)"
-				}
-
-				return version
-			}
-		}
+	if container.Version == "" || container.Version == composeTag {
+		return composeTag + " " + versionRunning, ""
 	}
 
-	return "-"
+	return composeTag + " " + versionNotRunning, container.Version
 }
 
 // showVersionTestInfo displays version extraction test results and service status
@@ -561,8 +540,18 @@ func showVersionTestInfo() {
 	fmt.Println("\n=== Version Extraction Test & Service Status ===")
 	fmt.Println()
 
-	// Get services from docker-compose.yaml
-	allServices := getServicesFromCompose()
+	// Honour -s, like the --human table does. Without this the flag was read,
+	// validated, and then ignored: `info -t -s cm-ant` printed every service.
+	requested, err := resolveServices(ServiceName)
+	if err != nil {
+		fmt.Printf("❌ %v\n", err)
+		return
+	}
+
+	services := requested
+	if len(services) == 0 {
+		services = getServicesFromCompose()
+	}
 
 	// Get running containers
 	containers := getContainerInfo(false)
@@ -570,34 +559,62 @@ func showVersionTestInfo() {
 	// Get image information
 	images := getImageInfo()
 
-	fmt.Printf("%-20s %-15s %-12s %-15s %s\n", "SERVICE", "COMPOSE_VERSION", "STATUS", "ACTUAL_VERSION", "IMAGE_SIZE")
-	fmt.Println(strings.Repeat("-", 80))
+	type testRow struct {
+		service        string
+		composeVersion string
+		status         string
+		actualVersion  string
+		imageSize      string
+	}
 
-	for _, service := range allServices {
-		// Get version from docker-compose.yaml
-		composeVersion := getVersionFromComposeFile(service)
-
-		// Get actual running status and version
-		var status, actualVersion, imageSize string
+	rows := make([]testRow, 0, len(services))
+	for _, service := range services {
+		row := testRow{
+			service:        service,
+			composeVersion: getVersionFromComposeFile(service),
+			status:         "Not Running",
+			actualVersion:  "-",
+			imageSize:      "-",
+		}
 
 		if container, exists := containers[service]; exists {
-			status = container.Status
-			actualVersion = container.Version
+			row.status = container.Status
+			row.actualVersion = container.Version
 
 			// Get image size
 			if image, exists := images[service]; exists {
-				imageSize = image.Size
-			} else {
-				imageSize = "-"
+				row.imageSize = image.Size
 			}
-		} else {
-			status = "Not Running"
-			actualVersion = "-"
-			imageSize = "-"
 		}
 
-		fmt.Printf("%-20s %-15s %-12s %-15s %s\n",
-			service, composeVersion, status, actualVersion, imageSize)
+		rows = append(rows, row)
+	}
+
+	// Size the columns from the content. The widths used to be fixed at 20 and
+	// 15, which is narrower than real values such as "cb-tumblebug-postgres"
+	// (21) and "16-alpine (Not Downloaded)" (26), so every long row pushed the
+	// remaining columns out of alignment.
+	serviceWidth := getDisplayWidth("SERVICE")
+	composeWidth := getDisplayWidth("COMPOSE_VERSION")
+	statusWidth := getDisplayWidth("STATUS")
+	actualWidth := getDisplayWidth("ACTUAL_VERSION")
+	for _, row := range rows {
+		serviceWidth = maxInt(serviceWidth, getDisplayWidth(row.service))
+		composeWidth = maxInt(composeWidth, getDisplayWidth(row.composeVersion))
+		statusWidth = maxInt(statusWidth, getDisplayWidth(row.status))
+		actualWidth = maxInt(actualWidth, getDisplayWidth(row.actualVersion))
+	}
+
+	rowFormat := fmt.Sprintf("%%-%ds %%-%ds %%-%ds %%-%ds %%s\n",
+		serviceWidth, composeWidth, statusWidth, actualWidth)
+
+	fmt.Printf(rowFormat, "SERVICE", "COMPOSE_VERSION", "STATUS", "ACTUAL_VERSION", "IMAGE_SIZE")
+
+	rulerWidth := serviceWidth + composeWidth + statusWidth + actualWidth + 4 + getDisplayWidth("IMAGE_SIZE")
+	fmt.Println(strings.Repeat("-", rulerWidth))
+
+	for _, row := range rows {
+		fmt.Printf(rowFormat, row.service, row.composeVersion, row.status, row.actualVersion, row.imageSize)
 	}
 
 	fmt.Println()
@@ -609,22 +626,10 @@ func showVersionTestInfo() {
 	fmt.Println("===============================================")
 }
 
-// checkImageExists checks if the specified image exists locally
+// checkImageExists checks if the specified "repository:tag" image exists locally.
 func checkImageExists(imageName string) bool {
-	cmd := exec.Command("docker", "images", "--format", "{{.Repository}}:{{.Tag}}", imageName)
-	output, err := cmd.Output()
-	if err != nil {
-		return false
-	}
-
-	// Check if the image exists in the output
-	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
-	for _, line := range lines {
-		if strings.TrimSpace(line) == imageName {
-			return true
-		}
-	}
-	return false
+	_, exists := getLocalImageSizes()[strings.TrimSpace(imageName)]
+	return exists
 }
 
 // parsePorts parses port information from docker compose ps output
@@ -666,149 +671,365 @@ func parsePorts(ports string) (string, string) {
 	return "-", "-"
 }
 
-// displayServiceTable displays the service information in a formatted table
-func displayServiceTable(services []HumanServiceInfo) {
-	// Calculate column widths based on content
-	maxServiceLen := 20 // minimum width
-	maxVersionLen := 12
-	maxStatusLen := 12
-	maxHealthyLen := 8
-	maxInternalLen := 12
-	maxExternalLen := 12
-	maxImageSizeLen := 15
+// humanTableColumns is the number of columns in the --human table.
+const humanTableColumns = 7
 
-	// Find maximum lengths
+// tableRow is one printed line of the --human table: seven cells, a horizontal
+// rule drawn with the table's own border glyphs, or a category heading that
+// spans the whole width.
+type tableRow struct {
+	cells     [humanTableColumns]string
+	separator bool
+	heading   string
+}
+
+// humanTableMinWidths are the column widths the table never shrinks below, so a
+// short run of services still lines up with a longer one.
+var humanTableMinWidths = [humanTableColumns]int{20, 12, 12, 8, 12, 12, 15}
+
+// humanTableHeaders labels the columns.
+var humanTableHeaders = [humanTableColumns]string{
+	"SERVICE", "VERSION", "STATUS", "HEALTHY", "INTERNAL", "EXTERNAL", "IMAGE SIZE",
+}
+
+// buildTableRows lays the services out as printable rows.
+//
+// A service running a version other than the one compose names gets a second
+// row — service column blank, version column naming what is really up — and the
+// pair is fenced off with horizontal rules. Neighbouring mismatches share the
+// rule between them instead of drawing two, and the rule that would sit against
+// the header separator or the bottom border is dropped, since those already
+// close the table off.
+func buildTableRows(services []HumanServiceInfo) []tableRow {
+	var rows []tableRow
+
 	for _, service := range services {
-		if getDisplayWidth(service.Service) > maxServiceLen {
-			maxServiceLen = getDisplayWidth(service.Service)
+		mismatch := service.ActualVersion != ""
+
+		if mismatch && len(rows) > 0 && !rows[len(rows)-1].separator {
+			rows = append(rows, tableRow{separator: true})
 		}
-		if getDisplayWidth(service.Version) > maxVersionLen {
-			maxVersionLen = getDisplayWidth(service.Version)
+
+		rows = append(rows, tableRow{cells: [humanTableColumns]string{
+			service.Service,
+			service.Version,
+			service.Status,
+			service.Healthy,
+			service.InternalPort,
+			service.ExternalPort,
+			service.ImageSize,
+		}})
+
+		if mismatch {
+			// Ports and size belong to the service, not to this one version, so
+			// repeating them here would only add noise.
+			rows = append(rows, tableRow{cells: [humanTableColumns]string{
+				"",
+				actualVersionPrefix + service.ActualVersion + " " + versionRunning,
+				"",
+				service.ActualHealthy,
+				"",
+				"",
+				"",
+			}})
+			rows = append(rows, tableRow{separator: true})
 		}
-		if getDisplayWidth(service.Status) > maxStatusLen {
-			maxStatusLen = getDisplayWidth(service.Status)
+	}
+
+	if n := len(rows); n > 0 && rows[n-1].separator {
+		rows = rows[:n-1]
+	}
+
+	return rows
+}
+
+// groupedServices is one category's worth of rows for the --human table.
+type groupedServices struct {
+	category string
+	icon     string
+	services []HumanServiceInfo
+}
+
+// groupServicesByCategory buckets services into the display categories, in the
+// order categoryDisplayOrder fixes, dropping categories nothing landed in.
+//
+// Within a category the services are sorted by name. The caller reads them out
+// of a map in several places, and a map yields its keys in a different order on
+// every run, so without this the table shuffled itself between invocations.
+func groupServicesByCategory(services []HumanServiceInfo) []groupedServices {
+	buckets := make(map[string][]HumanServiceInfo)
+	for _, service := range services {
+		category := categorizeService(service.Service, "")
+		buckets[category] = append(buckets[category], service)
+	}
+
+	ordered := make([]groupedServices, 0, len(buckets))
+	appendGroup := func(name, icon string) {
+		group := buckets[name]
+		if len(group) == 0 {
+			return
 		}
-		if getDisplayWidth(service.Healthy) > maxHealthyLen {
-			maxHealthyLen = getDisplayWidth(service.Healthy)
+		sort.Slice(group, func(i, j int) bool { return group[i].Service < group[j].Service })
+		ordered = append(ordered, groupedServices{category: name, icon: icon, services: group})
+		delete(buckets, name)
+	}
+
+	for _, entry := range categoryDisplayOrder {
+		appendGroup(entry.Name, entry.Icon)
+	}
+
+	// A category the ordered list does not know about still has to be shown;
+	// dropping it would drop services from the table.
+	leftovers := make([]string, 0, len(buckets))
+	for name := range buckets {
+		leftovers = append(leftovers, name)
+	}
+	sort.Strings(leftovers)
+	for _, name := range leftovers {
+		appendGroup(name, unknownCategoryIcon)
+	}
+
+	return ordered
+}
+
+// buildGroupedTableRows lays the services out grouped by category, each group
+// introduced by a heading row.
+//
+// The per-group rows come from buildTableRows, which neither opens nor closes
+// with a rule, so the rules drawn around a heading here cannot double up with
+// the ones a version mismatch draws.
+func buildGroupedTableRows(services []HumanServiceInfo) []tableRow {
+	var rows []tableRow
+
+	for _, group := range groupServicesByCategory(services) {
+		if len(rows) > 0 {
+			rows = append(rows, tableRow{separator: true})
 		}
-		if getDisplayWidth(service.InternalPort) > maxInternalLen {
-			maxInternalLen = getDisplayWidth(service.InternalPort)
+		rows = append(rows, tableRow{heading: group.icon + " " + group.category})
+		rows = append(rows, tableRow{separator: true})
+		rows = append(rows, buildTableRows(group.services)...)
+	}
+
+	return rows
+}
+
+// humanTableWidths measures each column, headers and every row included, so that
+// the follow-up rows and their rules are as wide as the rest of the table.
+//
+// Heading rows are not measured per column: they span the whole table, so a long
+// category name would otherwise stretch the SERVICE column and shift every row
+// under it. Instead the last column is widened, once, if a heading would not
+// fit — which leaves the columns where the content puts them.
+func humanTableWidths(rows []tableRow) [humanTableColumns]int {
+	widths := humanTableMinWidths
+
+	for i, header := range humanTableHeaders {
+		widths[i] = maxInt(widths[i], getDisplayWidth(header))
+	}
+	for _, row := range rows {
+		if row.separator || row.heading != "" {
+			continue
 		}
-		if getDisplayWidth(service.ExternalPort) > maxExternalLen {
-			maxExternalLen = getDisplayWidth(service.ExternalPort)
-		}
-		if getDisplayWidth(service.ImageSize) > maxImageSizeLen {
-			maxImageSizeLen = getDisplayWidth(service.ImageSize)
+		for i, cell := range row.cells {
+			widths[i] = maxInt(widths[i], getDisplayWidth(cell))
 		}
 	}
 
 	// Add some padding
-	maxServiceLen += 2
-	maxVersionLen += 2
-	maxStatusLen += 2
-	maxHealthyLen += 2
-	maxInternalLen += 2
-	maxExternalLen += 2
-	maxImageSizeLen += 2
-
-	// Top border
-	fmt.Printf("┌%s┬%s┬%s┬%s┬%s┬%s┬%s┐\n",
-		strings.Repeat("─", maxServiceLen),
-		strings.Repeat("─", maxVersionLen),
-		strings.Repeat("─", maxStatusLen),
-		strings.Repeat("─", maxHealthyLen),
-		strings.Repeat("─", maxInternalLen),
-		strings.Repeat("─", maxExternalLen),
-		strings.Repeat("─", maxImageSizeLen))
-
-	// Table header
-	fmt.Printf("│%-*s│%-*s│%-*s│%-*s│%-*s│%-*s│%-*s│\n",
-		maxServiceLen, "SERVICE",
-		maxVersionLen, "VERSION",
-		maxStatusLen, "STATUS",
-		maxHealthyLen, "HEALTHY",
-		maxInternalLen, "INTERNAL",
-		maxExternalLen, "EXTERNAL",
-		maxImageSizeLen, "IMAGE SIZE")
-
-	// Header separator
-	fmt.Printf("├%s┼%s┼%s┼%s┼%s┼%s┼%s┤\n",
-		strings.Repeat("─", maxServiceLen),
-		strings.Repeat("─", maxVersionLen),
-		strings.Repeat("─", maxStatusLen),
-		strings.Repeat("─", maxHealthyLen),
-		strings.Repeat("─", maxInternalLen),
-		strings.Repeat("─", maxExternalLen),
-		strings.Repeat("─", maxImageSizeLen))
-
-	// Table rows
-	for _, service := range services {
-		fmt.Printf("│%-*s│%-*s│%-*s│%-*s│%-*s│%-*s│%-*s│\n",
-			maxServiceLen, service.Service,
-			maxVersionLen, service.Version,
-			maxStatusLen, service.Status,
-			maxHealthyLen, service.Healthy,
-			maxInternalLen, service.InternalPort,
-			maxExternalLen, service.ExternalPort,
-			maxImageSizeLen, service.ImageSize)
+	for i := range widths {
+		widths[i] += 2
 	}
 
-	// Bottom border
-	fmt.Printf("└%s┴%s┴%s┴%s┴%s┴%s┴%s┘\n",
-		strings.Repeat("─", maxServiceLen),
-		strings.Repeat("─", maxVersionLen),
-		strings.Repeat("─", maxStatusLen),
-		strings.Repeat("─", maxHealthyLen),
-		strings.Repeat("─", maxInternalLen),
-		strings.Repeat("─", maxExternalLen),
-		strings.Repeat("─", maxImageSizeLen))
+	widest := 0
+	for _, row := range rows {
+		if row.heading != "" {
+			widest = maxInt(widest, getDisplayWidth(row.heading))
+		}
+	}
+	if inner := innerWidth(widths); widest > inner {
+		widths[humanTableColumns-1] += widest - inner
+	}
 
+	return widths
+}
+
+// innerWidth is the space a heading row has between the outer borders: every
+// column plus the interior separators it replaces.
+func innerWidth(widths [humanTableColumns]int) int {
+	total := humanTableColumns - 1
+	for _, width := range widths {
+		total += width
+	}
+	return total
+}
+
+// printTableBorder draws one horizontal line of the table with the given corner
+// and junction glyphs.
+func printTableBorder(left, mid, right string, widths [humanTableColumns]int) {
+	segments := make([]string, 0, humanTableColumns)
+	for _, width := range widths {
+		segments = append(segments, strings.Repeat("─", width))
+	}
+	fmt.Printf("%s%s%s\n", left, strings.Join(segments, mid), right)
+}
+
+// printTableCells draws one content line, padding each cell to its column width.
+//
+// The padding is computed here rather than left to "%-*s", whose width counts
+// runes. The column widths are measured in terminal columns, so a double-width
+// rune would be padded one column too far and push the border out.
+func printTableCells(cells [humanTableColumns]string, widths [humanTableColumns]int) {
+	var line strings.Builder
+	line.WriteString("│")
+	for i, cell := range cells {
+		line.WriteString(cell)
+		line.WriteString(strings.Repeat(" ", maxInt(0, widths[i]-getDisplayWidth(cell))))
+		line.WriteString("│")
+	}
+	fmt.Println(line.String())
+}
+
+// printTableHeading draws a category heading across the full width of the table.
+//
+// It spans the columns instead of sitting in the first one so that a category
+// name longer than the SERVICE column cannot widen it, and the line still ends
+// on the same terminal column as every other line.
+func printTableHeading(heading string, widths [humanTableColumns]int) {
+	padding := maxInt(0, innerWidth(widths)-getDisplayWidth(heading))
+	fmt.Printf("│%s%s│\n", heading, strings.Repeat(" ", padding))
+}
+
+// displayServiceTable displays the service information in a formatted table
+func displayServiceTable(services []HumanServiceInfo) {
+	rows := buildGroupedTableRows(services)
+	widths := humanTableWidths(rows)
+
+	printTableBorder("┌", "┬", "┐", widths)
+	printTableCells(humanTableHeaders, widths)
+	printTableBorder("├", "┼", "┤", widths)
+
+	for _, row := range rows {
+		switch {
+		case row.separator:
+			printTableBorder("├", "┼", "┤", widths)
+			continue
+		case row.heading != "":
+			printTableHeading(row.heading, widths)
+			continue
+		}
+		printTableCells(row.cells, widths)
+	}
+
+	printTableBorder("└", "┴", "┘", widths)
+
+	printVersionLegend()
 	fmt.Println()
 }
 
-// getDisplayWidth calculates the display width of a string, accounting for Unicode characters
+// printVersionLegend explains the marks the VERSION column uses.
+func printVersionLegend() {
+	fmt.Println("Legend:")
+	fmt.Println("✓ Running on this version")
+	fmt.Println("✗ Not running on this version (stopped, or image not installed locally)")
+	fmt.Println("<- Version actually running, where it differs from docker-compose.yaml")
+}
+
+// maxInt returns the larger of two ints.
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// getDisplayWidth calculates the display width of a string in terminal columns.
+//
+// Every branch of this function used to add 1, so it counted runes and the
+// "accounting for Unicode" it claimed never happened — a name in Hangul or an
+// emoji occupies two columns and pushed the table borders out by one each. The
+// characters actually used in these tables (✓ ✗ -) stay at one column, since
+// that is how terminals render them; only genuinely wide characters count two.
 func getDisplayWidth(s string) int {
 	width := 0
+	// Width the previous rune contributed, so that an emoji presentation
+	// selector can promote the character it follows.
+	last := 0
 	for _, r := range s {
-		// Handle specific Unicode characters that might have different display widths
-		switch r {
-		case '✓': // check mark
-			width += 1
-		case '✗': // cross mark
-			width += 1
-		case '-': // dash
-			width += 1
-		default:
-			if r < 0x80 {
-				width++ // ASCII
-			} else {
-				width += 1 // Most Unicode characters are 1 width
+		switch {
+		case r == 0xFE0F:
+			// U+FE0F asks for the emoji form of the preceding character, which
+			// terminals draw double-width. "⚙️" is one column as U+2699 alone
+			// and two once selected; without this the category headings that use
+			// such icons measure one column short and their border drifts.
+			if last == 1 {
+				width++
+				last = 2
 			}
+		case r == '✓' || r == '✗':
+			// East Asian "ambiguous" width; terminals render these as one column.
+			width++
+			last = 1
+		case r < 0x80:
+			width++ // ASCII
+			last = 1
+		case unicode.Is(unicode.Mn, r) || unicode.Is(unicode.Me, r) || r == 0x200B:
+			// Combining marks and the zero-width space occupy no column.
+			last = 0
+		case isWideRune(r):
+			width += 2
+			last = 2
+		default:
+			width++
+			last = 1
 		}
 	}
 	return width
 }
 
+// isWideRune reports whether a rune is rendered double-width (East Asian Wide
+// and Fullwidth, plus the emoji blocks used in this package's headings).
+func isWideRune(r rune) bool {
+	switch {
+	case r >= 0x1100 && r <= 0x115F: // Hangul Jamo
+		return true
+	case r >= 0x2E80 && r <= 0x303E: // CJK radicals, Kangxi, CJK symbols
+		return true
+	case r >= 0x3041 && r <= 0x33FF: // Hiragana, Katakana, Hangul Compat Jamo, CJK compat
+		return true
+	case r >= 0x3400 && r <= 0x4DBF: // CJK Unified Ideographs Extension A
+		return true
+	case r >= 0x4E00 && r <= 0x9FFF: // CJK Unified Ideographs
+		return true
+	case r >= 0xA000 && r <= 0xA4CF: // Yi
+		return true
+	case r >= 0xAC00 && r <= 0xD7A3: // Hangul syllables
+		return true
+	case r >= 0xF900 && r <= 0xFAFF: // CJK compatibility ideographs
+		return true
+	case r >= 0xFE30 && r <= 0xFE6F: // CJK compatibility forms
+		return true
+	case r >= 0xFF00 && r <= 0xFF60: // Fullwidth forms
+		return true
+	case r >= 0xFFE0 && r <= 0xFFE6: // Fullwidth signs
+		return true
+	case r >= 0x1F300 && r <= 0x1F64F: // Misc symbols and pictographs, emoticons
+		return true
+	case r >= 0x1F900 && r <= 0x1F9FF: // Supplemental symbols and pictographs
+		return true
+	case r >= 0x20000 && r <= 0x3FFFD: // CJK Unified Ideographs Extension B and later
+		return true
+	}
+	return false
+}
+
 // displayServiceTableWithDependencies displays the service information with dependency categorization
-func displayServiceTableWithDependencies(services []HumanServiceInfo, requestedServices string) {
-	if requestedServices == "" {
+// requestedList holds the already-resolved service names (see resolveServices);
+// an empty list means no -s filter was given.
+func displayServiceTableWithDependencies(services []HumanServiceInfo, requestedList []string) {
+	if len(requestedList) == 0 {
 		// No specific service requested, show all services in one table
 		displayServiceTable(services)
 		return
-	}
-
-	// Parse requested services - support both comma and space separation
-	var requestedList []string
-	if strings.Contains(requestedServices, ",") {
-		// Comma-separated services
-		requestedList = strings.Split(requestedServices, ",")
-	} else {
-		// Space-separated services
-		requestedList = strings.Fields(requestedServices)
-	}
-
-	for i, service := range requestedList {
-		requestedList[i] = strings.TrimSpace(service)
 	}
 
 	// Get dependency services (for reference, not used in categorization logic)
@@ -847,28 +1068,54 @@ func displayServiceTableWithDependencies(services []HumanServiceInfo, requestedS
 	}
 }
 
-// getDependencyServices returns dependency services for the given services
+// getDependencyServices returns every service the given ones depend on,
+// transitively, read from the compose file's depends_on.
+//
+// Two things changed here. The graph was a hardcoded literal that had to be
+// edited by hand whenever compose changed, and it was walked only one level
+// deep — `info --human -s cm-cicada` listed cm-beetle but not the cb-tumblebug
+// that cm-beetle cannot start without. The walk below follows the whole chain
+// and keeps a visited set, so a cycle in depends_on ends the traversal instead
+// of looping forever.
+//
+// The services named in the argument are not returned as their own
+// dependencies, even if the graph leads back to them; the caller lists those
+// separately as the requested services.
 func getDependencyServices(services []string) []string {
-	var dependencies []string
-
-	// Define service dependencies based on docker-compose.yaml
-	serviceDependencies := map[string][]string{
-		"cb-tumblebug":       {"cb-tumblebug-etcd", "cb-spider", "cb-tumblebug-postgres", "mc-terrarium"},
-		"mc-terrarium":       {"openbao-unseal"},
-		"openbao-unseal":     {"openbao"},
-		"cm-beetle":          {"cb-tumblebug"},
-		"cm-butterfly-api":   {"cm-butterfly-db"},
-		"cm-butterfly-front": {"cm-butterfly-api"},
-		"cm-cicada":          {"cm-damselfly", "cm-beetle", "cm-grasshopper", "airflow-server"},
-		"cm-grasshopper":     {"cm-honeybee"},
-		"cm-ant":             {"cb-tumblebug", "ant-postgres"},
-		"airflow-server":     {"airflow-mysql", "airflow-redis"},
+	parsed, err := loadComposeFile()
+	if err != nil {
+		return nil
 	}
 
-	for _, service := range services {
-		if deps, exists := serviceDependencies[service]; exists {
-			dependencies = append(dependencies, deps...)
+	requested := make(map[string]bool, len(services))
+	for _, name := range services {
+		requested[name] = true
+	}
+
+	visited := make(map[string]bool, len(parsed.Services))
+	var dependencies []string
+
+	var walk func(name string)
+	walk = func(name string) {
+		svc, exists := parsed.Services[name]
+		if !exists {
+			return
 		}
+		for _, dep := range svc.DependsOn {
+			if visited[dep] {
+				continue
+			}
+			visited[dep] = true
+
+			if !requested[dep] {
+				dependencies = append(dependencies, dep)
+			}
+			walk(dep)
+		}
+	}
+
+	for _, name := range services {
+		walk(name)
 	}
 
 	return dependencies

--- a/cmd/docker/info_table_test.go
+++ b/cmd/docker/info_table_test.go
@@ -1,0 +1,517 @@
+package docker
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureStdout runs fn and returns everything it printed.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to open a pipe: %v", err)
+	}
+
+	prev := os.Stdout
+	os.Stdout = write
+	defer func() { os.Stdout = prev }()
+
+	fn()
+
+	if err := write.Close(); err != nil {
+		t.Fatalf("failed to close the pipe: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, read); err != nil {
+		t.Fatalf("failed to read the captured output: %v", err)
+	}
+	return buf.String()
+}
+
+// matching builds a service row whose running version is the compose one.
+func matching(name string) HumanServiceInfo {
+	return HumanServiceInfo{
+		Service: name, Version: "1.0.0 ✓", Status: "running", Healthy: "✓",
+		InternalPort: "8080", ExternalPort: "8080", ImageSize: "10MB",
+	}
+}
+
+// mismatched builds a service row running a version other than the compose one.
+func mismatched(name, actual string) HumanServiceInfo {
+	return HumanServiceInfo{
+		Service: name, Version: "1.0.0 ✗", Status: "running", Healthy: "✓",
+		InternalPort: "8080", ExternalPort: "8080", ImageSize: "10MB",
+		ActualVersion: actual, ActualHealthy: "✓",
+	}
+}
+
+// A service running the version compose names is one plain row, with no rules
+// around it and nothing added underneath.
+func TestBuildTableRowsMatchingVersionIsOneRow(t *testing.T) {
+	rows := buildTableRows([]HumanServiceInfo{matching("cb-spider")})
+
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1: %+v", len(rows), rows)
+	}
+	if rows[0].separator {
+		t.Error("the row is a separator, want cells")
+	}
+	if rows[0].cells[1] != "1.0.0 ✓" {
+		t.Errorf("version cell = %q, want %q", rows[0].cells[1], "1.0.0 ✓")
+	}
+}
+
+// A mismatch adds a follow-up row naming what is really running, and fences the
+// pair off. The follow-up carries only the version and the health; ports and
+// size belong to the service, not to that one version.
+func TestBuildTableRowsMismatchAddsFencedFollowUp(t *testing.T) {
+	rows := buildTableRows([]HumanServiceInfo{
+		matching("cb-spider"),
+		mismatched("cb-tumblebug", "0.12.02"),
+		matching("cm-ant"),
+	})
+
+	want := []string{
+		"cb-spider",
+		"---",
+		"cb-tumblebug",
+		"", // the follow-up row
+		"---",
+		"cm-ant",
+	}
+	if len(rows) != len(want) {
+		t.Fatalf("got %d rows, want %d: %+v", len(rows), len(want), rows)
+	}
+	for i, w := range want {
+		if w == "---" {
+			if !rows[i].separator {
+				t.Errorf("row %d is not a separator, want one", i)
+			}
+			continue
+		}
+		if rows[i].separator {
+			t.Fatalf("row %d is a separator, want the %q row", i, w)
+		}
+		if rows[i].cells[0] != w {
+			t.Errorf("row %d service = %q, want %q", i, rows[i].cells[0], w)
+		}
+	}
+
+	followUp := rows[3].cells
+	if followUp[1] != "<- 0.12.02 ✓" {
+		t.Errorf("follow-up version = %q, want %q", followUp[1], "<- 0.12.02 ✓")
+	}
+	if followUp[3] != "✓" {
+		t.Errorf("follow-up healthy = %q, want %q", followUp[3], "✓")
+	}
+	for _, i := range []int{0, 2, 4, 5, 6} {
+		if followUp[i] != "" {
+			t.Errorf("follow-up cell %d = %q, want it blank", i, followUp[i])
+		}
+	}
+}
+
+// Back-to-back mismatches share the rule between them rather than drawing two,
+// and no rule is left against the bottom border, which already closes the table.
+func TestBuildTableRowsCollapsesAdjacentSeparators(t *testing.T) {
+	rows := buildTableRows([]HumanServiceInfo{
+		matching("cb-spider"),
+		mismatched("a", "0.1"),
+		mismatched("b", "0.2"),
+		mismatched("c", "0.3"),
+	})
+
+	for i := 1; i < len(rows); i++ {
+		if rows[i].separator && rows[i-1].separator {
+			t.Errorf("rows %d and %d are both separators", i-1, i)
+		}
+	}
+	if last := rows[len(rows)-1]; last.separator {
+		t.Error("the table ends with a separator, want the bottom border to close it")
+	}
+	// cb-spider, rule, then three (row, follow-up) pairs separated by two rules.
+	if len(rows) != 1+1+3*2+2 {
+		t.Fatalf("got %d rows, want 10: %+v", len(rows), rows)
+	}
+}
+
+// A mismatch on the very first service needs no leading rule: the header
+// separator right above it already rules the block off.
+func TestBuildTableRowsNoLeadingSeparator(t *testing.T) {
+	rows := buildTableRows([]HumanServiceInfo{mismatched("cb-tumblebug", "0.12.02")})
+
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2: %+v", len(rows), rows)
+	}
+	if rows[0].separator {
+		t.Error("the table opens with a separator, want the header separator to serve")
+	}
+}
+
+// The follow-up row is measured like any other, so a version long enough to be
+// the widest cell in the table still fits between the borders.
+func TestHumanTableWidthsCountFollowUpRows(t *testing.T) {
+	long := "0.12.02-with-a-very-long-suffix"
+	rows := buildTableRows([]HumanServiceInfo{mismatched("cb-tumblebug", long)})
+
+	widths := humanTableWidths(rows)
+	want := getDisplayWidth(actualVersionPrefix+long+" ✓") + 2
+	if widths[1] != want {
+		t.Errorf("version column width = %d, want %d", widths[1], want)
+	}
+}
+
+// Every printed line is the same width in terminal columns, follow-up rows and
+// rules included. Cells are padded by display width rather than by the rune
+// count a "%-*s" verb would use, so a double-width glyph cannot push a border
+// out by one.
+func TestDisplayServiceTableLinesAlign(t *testing.T) {
+	out := captureStdout(t, func() {
+		displayServiceTable([]HumanServiceInfo{
+			matching("cb-spider"),
+			mismatched("cb-tumblebug", "0.12.02"),
+			{Service: "cm-ant", Version: "0.5.4 ✗", Status: "Not Found",
+				Healthy: "-", InternalPort: "-", ExternalPort: "-", ImageSize: "-"},
+		})
+	})
+
+	var width int
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.HasPrefix(line, "│") && !strings.HasPrefix(line, "┌") &&
+			!strings.HasPrefix(line, "├") && !strings.HasPrefix(line, "└") {
+			continue
+		}
+		got := getDisplayWidth(line)
+		if width == 0 {
+			width = got
+			continue
+		}
+		if got != width {
+			t.Errorf("line %q is %d columns wide, want %d", line, got, width)
+		}
+	}
+	if width == 0 {
+		t.Fatal("no table lines were printed")
+	}
+}
+
+// The legend explains the marks the version column now carries.
+func TestDisplayServiceTablePrintsLegend(t *testing.T) {
+	out := captureStdout(t, func() {
+		displayServiceTable([]HumanServiceInfo{matching("cb-spider")})
+	})
+
+	for _, want := range []string{"Legend:", "✓ Running on this version", "<- Version actually running"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the output is missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// The old table spelled "Not Downloaded" into the size column, repeating what
+// the version mark already says. Blank columns all read "-" now.
+func TestDisplayServiceTableUsesDashForEmptySize(t *testing.T) {
+	out := captureStdout(t, func() {
+		displayServiceTable([]HumanServiceInfo{
+			{Service: "cm-ant", Version: "0.5.4 ✗", Status: "Not Found",
+				Healthy: "-", InternalPort: "-", ExternalPort: "-", ImageSize: "-"},
+		})
+	})
+
+	if strings.Contains(out, "Not Downloaded") {
+		t.Errorf("the table still says \"Not Downloaded\":\n%s", out)
+	}
+}
+
+// tableLines keeps only the lines that make up the table itself.
+func tableLines(out string) []string {
+	var lines []string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "│") || strings.HasPrefix(line, "┌") ||
+			strings.HasPrefix(line, "├") || strings.HasPrefix(line, "└") {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+// headingsOf lists the category headings the rows introduce, in order.
+func headingsOf(rows []tableRow) []string {
+	var headings []string
+	for _, row := range rows {
+		if row.heading != "" {
+			headings = append(headings, row.heading)
+		}
+	}
+	return headings
+}
+
+// servicesOf lists the service names the rows carry, in order, skipping rules
+// and the blank service column of a follow-up row.
+func servicesOf(rows []tableRow) []string {
+	var names []string
+	for _, row := range rows {
+		if row.separator || row.heading != "" || row.cells[0] == "" {
+			continue
+		}
+		names = append(names, row.cells[0])
+	}
+	return names
+}
+
+// Services are grouped under a heading per category, and the categories come out
+// in the fixed display order rather than the order the services were passed in.
+func TestBuildGroupedTableRowsOrdersCategories(t *testing.T) {
+	rows := buildGroupedTableRows([]HumanServiceInfo{
+		matching("ant-postgres"),
+		matching("cm-butterfly-api"),
+		matching("cb-spider"),
+		matching("openbao"),
+		matching("cm-ant"),
+	})
+
+	want := []string{
+		"🎯 " + CategoryCoreInfra,
+		"🧩 " + CategoryFrameworks,
+		"🖥️ " + CategoryWebConsole,
+		"🔐 " + CategorySecrets,
+		"🗄️ " + CategoryDataStores,
+	}
+	got := headingsOf(rows)
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("headings = %q, want %q", got, want)
+	}
+}
+
+// A category nothing landed in prints no heading; the table shows the groups it
+// actually has and nothing else.
+func TestBuildGroupedTableRowsSkipsEmptyCategories(t *testing.T) {
+	rows := buildGroupedTableRows([]HumanServiceInfo{matching("cb-spider")})
+
+	want := []string{"🎯 " + CategoryCoreInfra}
+	if got := headingsOf(rows); strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("headings = %q, want %q", got, want)
+	}
+	for _, unwanted := range []string{CategoryObjectStorage, CategoryDependencies, CategorySecrets} {
+		for _, heading := range headingsOf(rows) {
+			if strings.Contains(heading, unwanted) {
+				t.Errorf("the table heads an empty category %q", unwanted)
+			}
+		}
+	}
+}
+
+// Services arrive from a map, so the order they are handed over in is not
+// stable. Inside a category they are sorted by name, which makes the listing the
+// same on every run.
+func TestBuildGroupedTableRowsSortsWithinCategory(t *testing.T) {
+	rows := buildGroupedTableRows([]HumanServiceInfo{
+		matching("mc-terrarium"),
+		matching("cb-tumblebug"),
+		matching("cb-mapui"),
+		matching("cb-spider"),
+	})
+
+	want := []string{"cb-mapui", "cb-spider", "cb-tumblebug", "mc-terrarium"}
+	if got := servicesOf(rows); strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("services = %q, want %q", got, want)
+	}
+}
+
+// The same input renders identically however it is ordered on the way in, which
+// is what "the table does not shuffle between runs" means in practice.
+func TestDisplayServiceTableIsDeterministic(t *testing.T) {
+	forward := []HumanServiceInfo{
+		matching("cb-spider"), matching("cm-ant"), matching("openbao"),
+		mismatched("cb-tumblebug", "0.12.02"), matching("ant-postgres"),
+	}
+	reversed := make([]HumanServiceInfo, 0, len(forward))
+	for i := len(forward) - 1; i >= 0; i-- {
+		reversed = append(reversed, forward[i])
+	}
+
+	first := captureStdout(t, func() { displayServiceTable(forward) })
+	second := captureStdout(t, func() { displayServiceTable(forward) })
+	third := captureStdout(t, func() { displayServiceTable(reversed) })
+
+	if first != second {
+		t.Errorf("two renders of the same input differ:\n%s\n---\n%s", first, second)
+	}
+	if first != third {
+		t.Errorf("the render depends on the input order:\n%s\n---\n%s", first, third)
+	}
+}
+
+// A heading is fenced above and below, and never leaves two rules touching —
+// including where a version mismatch draws its own rule right beside one.
+func TestBuildGroupedTableRowsRulesDoNotDouble(t *testing.T) {
+	rows := buildGroupedTableRows([]HumanServiceInfo{
+		mismatched("cb-spider", "0.9.9"),
+		mismatched("cm-ant", "0.5.3"),
+		matching("openbao"),
+	})
+
+	for i := 1; i < len(rows); i++ {
+		if rows[i].separator && rows[i-1].separator {
+			t.Errorf("rows %d and %d are both rules", i-1, i)
+		}
+	}
+	if rows[0].heading == "" {
+		t.Error("the table does not open with a heading")
+	}
+	if last := rows[len(rows)-1]; last.separator {
+		t.Error("the table ends with a rule, want the bottom border to close it")
+	}
+	// Every heading is followed by a rule that separates it from its services.
+	for i, row := range rows {
+		if row.heading == "" {
+			continue
+		}
+		if i+1 >= len(rows) || !rows[i+1].separator {
+			t.Errorf("the heading %q is not ruled off from its services", row.heading)
+		}
+	}
+}
+
+// Headings span the table instead of sitting in the SERVICE column, so adding
+// them leaves every column exactly where it was.
+func TestHumanTableWidthsUnchangedByHeadings(t *testing.T) {
+	services := []HumanServiceInfo{
+		matching("cb-spider"), matching("cm-ant"), matching("cm-grasshopper-rustfs"),
+		mismatched("cb-tumblebug", "0.12.02"),
+	}
+
+	plain := humanTableWidths(buildTableRows(services))
+	grouped := humanTableWidths(buildGroupedTableRows(services))
+
+	if plain != grouped {
+		t.Errorf("column widths changed with headings: %v, want %v", grouped, plain)
+	}
+}
+
+// A category name wider than the table is not dropped and does not push the
+// columns around: the last column absorbs the difference, so the line still ends
+// where the others do.
+func TestHumanTableWidthsFitAnOversizedHeading(t *testing.T) {
+	rows := []tableRow{
+		{heading: strings.Repeat("x", 400)},
+		{cells: [humanTableColumns]string{"cb-spider", "1.0.0 ✓", "running", "✓", "8080", "8080", "10MB"}},
+	}
+
+	widths := humanTableWidths(rows)
+	if innerWidth(widths) < 400 {
+		t.Errorf("inner width = %d, want at least 400", innerWidth(widths))
+	}
+}
+
+// Every printed line stays the same width in terminal columns once headings are
+// in the table, rules and follow-up rows included.
+func TestDisplayServiceTableGroupedLinesAlign(t *testing.T) {
+	out := captureStdout(t, func() {
+		displayServiceTable([]HumanServiceInfo{
+			matching("cb-spider"),
+			mismatched("cb-tumblebug", "0.12.02"),
+			matching("cm-ant"),
+			matching("cm-butterfly-api"),
+			matching("cm-cicada"),
+			matching("openbao"),
+			matching("ant-postgres"),
+			matching("cm-grasshopper-rustfs"),
+		})
+	})
+
+	lines := tableLines(out)
+	if len(lines) == 0 {
+		t.Fatal("no table lines were printed")
+	}
+	width := getDisplayWidth(lines[0])
+	for _, line := range lines {
+		if got := getDisplayWidth(line); got != width {
+			t.Errorf("line %q is %d columns wide, want %d", line, got, width)
+		}
+	}
+
+	// All eight categories are headed, each exactly once.
+	for _, category := range []string{
+		CategoryCoreInfra, CategoryFrameworks, CategoryWebConsole, CategoryWorkflow,
+		CategorySecrets, CategoryDataStores, CategoryObjectStorage,
+	} {
+		if n := strings.Count(out, category); n != 1 {
+			t.Errorf("category %q appears %d times, want 1", category, n)
+		}
+	}
+}
+
+// With -s the table only holds the services asked for, so only their categories
+// are headed — a lone request does not print the whole category list.
+func TestDisplayServiceTableWithDependenciesHeadsOnlyItsGroups(t *testing.T) {
+	out := captureStdout(t, func() {
+		displayServiceTableWithDependencies([]HumanServiceInfo{
+			matching("cm-ant"),
+			matching("ant-postgres"),
+		}, []string{"cm-ant"})
+	})
+
+	for _, want := range []string{"🎯 Requested Services:", CategoryFrameworks, CategoryDataStores} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the output is missing %q:\n%s", want, out)
+		}
+	}
+	for _, unwanted := range []string{CategoryCoreInfra, CategoryWebConsole, CategorySecrets, CategoryObjectStorage} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("the output heads %q, which nothing was requested from:\n%s", unwanted, out)
+		}
+	}
+
+	// The two tables are sized independently, but each one lines up with itself.
+	lines := tableLines(out)
+	if len(lines) == 0 {
+		t.Fatal("no table lines were printed")
+	}
+	width := 0
+	for _, line := range lines {
+		if strings.HasPrefix(line, "┌") {
+			width = getDisplayWidth(line)
+		}
+		if got := getDisplayWidth(line); got != width {
+			t.Errorf("line %q is %d columns wide, want %d", line, got, width)
+		}
+	}
+}
+
+// U+FE0F asks for the emoji form of the character before it, which terminals
+// draw double-width. Counting the selector as nothing left "⚙️" measuring one
+// column and the heading it opens one short of the border.
+func TestGetDisplayWidthCountsEmojiPresentation(t *testing.T) {
+	cases := map[string]int{
+		"⚙️":  2, // U+2699 + U+FE0F: narrow base, promoted
+		"🖥️":  2, // U+1F5A5 + U+FE0F: already wide, unchanged
+		"🎯":   2,
+		"✓":   1,
+		"abc": 3,
+	}
+	for input, want := range cases {
+		if got := getDisplayWidth(input); got != want {
+			t.Errorf("getDisplayWidth(%q) = %d, want %d", input, got, want)
+		}
+	}
+}
+
+// Every icon the headings use is measured as two columns, so no category can
+// knock the heading row out of line with the rest of the table.
+func TestCategoryIconsMeasureTwoColumns(t *testing.T) {
+	for _, entry := range categoryDisplayOrder {
+		if got := getDisplayWidth(entry.Icon); got != 2 {
+			t.Errorf("icon %q of %q measures %d columns, want 2", entry.Icon, entry.Name, got)
+		}
+	}
+	if got := getDisplayWidth(unknownCategoryIcon); got != 2 {
+		t.Errorf("the fallback icon measures %d columns, want 2", got)
+	}
+}

--- a/cmd/docker/install.go
+++ b/cmd/docker/install.go
@@ -3,7 +3,6 @@ package docker
 import (
 	"fmt"
 
-	"github.com/cm-mayfly/cm-mayfly/common"
 	"github.com/spf13/cobra"
 )
 
@@ -16,10 +15,15 @@ var pullCmd = &cobra.Command{
 		fmt.Println("\n[Install the Docker images of the subsystems that make up the Cloud-Migrator system.]")
 		fmt.Println()
 
-		convertedServiceName := convertServiceNameForDockerCompose(ServiceName)
-		cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s pull %s", ProjectName, DockerFilePath, convertedServiceName)
-		//fmt.Println(cmdStr)
-		common.SysCall(cmdStr)
+		services, err := resolveServices(ServiceName)
+		if err != nil {
+			fmt.Printf("❌ %v\n", err)
+			return
+		}
+
+		if err := runCompose(append([]string{"pull"}, services...)...); err != nil {
+			fmt.Printf("❌ docker compose pull failed: %v\n", err)
+		}
 	},
 }
 

--- a/cmd/docker/log.go
+++ b/cmd/docker/log.go
@@ -3,7 +3,6 @@ package docker
 import (
 	"fmt"
 
-	"github.com/cm-mayfly/cm-mayfly/common"
 	"github.com/spf13/cobra"
 )
 
@@ -38,34 +37,39 @@ Note:
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("\n[View output from Cloud-Migrator system containers.]")
 
-		// Build docker compose logs command
-		cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s logs", ProjectName, DockerFilePath)
+		services, err := resolveServices(ServiceName)
+		if err != nil {
+			fmt.Printf("❌ %v\n", err)
+			return
+		}
+
+		// Build the docker compose logs argument vector. Flag values reach docker
+		// as single arguments, so a value carrying shell metacharacters is passed
+		// through literally rather than interpreted.
+		logArgs := []string{"logs"}
 
 		// Add --follow option (default: true, can be disabled with --no-follow)
 		if followLogs && !noFollow {
-			cmdStr += " --follow"
+			logArgs = append(logArgs, "--follow")
 		}
 
-		// Add --tail option
+		// Add --tail option (default: last 10 lines)
 		if tailLines != "" {
-			cmdStr += fmt.Sprintf(" --tail %s", tailLines)
+			logArgs = append(logArgs, "--tail", tailLines)
 		} else {
-			// Default: show last 10 lines
-			cmdStr += " --tail 10"
+			logArgs = append(logArgs, "--tail", "10")
 		}
 
-		// Add --since option if specified (quote the value to handle special characters)
+		// Add --since option if specified
 		if sinceTime != "" {
-			cmdStr += fmt.Sprintf(" --since '%s'", sinceTime)
+			logArgs = append(logArgs, "--since", sinceTime)
 		}
 
-		// Add service name if specified
-		if ServiceName != "" {
-			cmdStr += " " + ServiceName
-		}
+		logArgs = append(logArgs, services...)
 
-		//fmt.Println(cmdStr)
-		common.SysCall(cmdStr)
+		if err := runCompose(logArgs...); err != nil {
+			fmt.Printf("❌ docker compose logs failed: %v\n", err)
+		}
 	},
 }
 

--- a/cmd/docker/remove.go
+++ b/cmd/docker/remove.go
@@ -38,6 +38,20 @@ Removes containers, images, named volumes, networks, and DB host data.
 OpenBao credentials are preserved. Use --clean-all to remove OpenBao as well.
 Details: ` + removeDocsLink
 
+	// A service-scoped --clean-db is a genuinely narrower operation than the
+	// whole-system one, and it used to be announced with the paragraph above.
+	// That paragraph promises images, named volumes and networks, but
+	// buildComposeCommands only issues `stop` + `rm -s -v -f` for the named
+	// services: shared networks stay, and the images are never touched. Saying
+	// so plainly is the difference between a user who knows a follow-up is
+	// needed and one who believes the environment is already clean.
+	msgRemoveCleanDBService = `[mayfly infra remove -s <service> --clean-db]
+Stops and removes the targeted container(s) together with their attached volumes
+and their host data under conf/docker/data/<service>.
+Images and shared networks are left in place — use 'mayfly infra remove --clean-db'
+without -s to remove those.
+Details: ` + removeDocsLink
+
 	msgRemoveCleanAll = `[mayfly infra remove --clean-all]
 Removes containers, images, named volumes, networks, DB host data, and OpenBao credentials.
 You must run the OpenBao initialization again when rebuilding.
@@ -67,7 +81,15 @@ data are preserved (equivalent to 'docker compose down').
   -y, --yes    Skip the confirmation prompt (for automation).
   --dry-run    Print the commands that would run, without executing them.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		services := splitServices(ServiceName)
+		// resolveServices is what keeps the scope honest: an empty -s means "the
+		// whole environment", and anything else must name services that actually
+		// exist. A value that splits to nothing (-s "," or -s " ") is rejected
+		// rather than silently widened to everything.
+		services, err := resolveServices(ServiceName)
+		if err != nil {
+			fmt.Printf("\n❌ %v\n", err)
+			return
+		}
 
 		// -s cannot be combined with --clean-all: the intent is ambiguous.
 		if len(services) > 0 && cleanAllFlag {
@@ -79,10 +101,14 @@ data are preserved (equivalent to 'docker compose down').
 			return
 		}
 
-		// Print the single command-definition paragraph.
+		// Print the single command-definition paragraph. A service-scoped
+		// --clean-db gets its own paragraph because it does markedly less than
+		// the whole-system one.
 		switch {
 		case cleanAllFlag:
 			fmt.Printf("\n%s\n", msgRemoveCleanAll)
+		case cleanDBFlag && len(services) > 0:
+			fmt.Printf("\n%s\n", msgRemoveCleanDBService)
 		case cleanDBFlag:
 			fmt.Printf("\n%s\n", msgRemoveCleanDB)
 		default:
@@ -103,15 +129,7 @@ data are preserved (equivalent to 'docker compose down').
 
 		// --dry-run: show everything that would run and stop.
 		if dryRunFlag {
-			fmt.Println("[dry-run] The following commands would be executed:")
-			for _, c := range composeCmds {
-				fmt.Printf("  %s\n", c)
-			}
-			for _, t := range hostTargets {
-				abs, _ := filepath.Abs(t)
-				fmt.Printf("  sudo rm -rf %s\n", abs)
-			}
-			fmt.Println("\n[dry-run] No changes were made.")
+			fmt.Print(dryRunPlan(composeCmds, hostTargets))
 			printDependencyHint(services)
 			return
 		}
@@ -133,13 +151,31 @@ data are preserved (equivalent to 'docker compose down').
 			}
 		}
 
+		// A failing step means the environment is only partly torn down, so the
+		// sequence stops instead of carrying on and reporting success.
+		if len(hostTargets) > 0 {
+			if err := ensureSudoAvailable(); err != nil {
+				fmt.Printf("\n❌ %v\n", err)
+				fmt.Println("\nNothing was removed.")
+				return
+			}
+		}
+
 		// Execute compose command(s) first, then wipe host data.
 		for _, c := range composeCmds {
-			common.SysCall(c)
+			if err := runCompose(c...); err != nil {
+				fmt.Printf("\n❌ %s failed: %v\n", displayCommand("docker", composeArgs(c...)), err)
+				fmt.Println("Stopping here — the host data was NOT removed.")
+				return
+			}
 		}
 		for _, t := range hostTargets {
 			abs, _ := filepath.Abs(t)
-			common.SysCall(fmt.Sprintf("sudo rm -rf %s", abs))
+			if err := common.RunCommand("sudo", []string{"rm", "-rf", abs}, nil); err != nil {
+				fmt.Printf("\n❌ failed to remove %s: %v\n", abs, err)
+				fmt.Println("Stopping here — the removal is incomplete.")
+				return
+			}
 		}
 
 		// --clean-all also removed the OpenBao host data + volume, so the
@@ -147,11 +183,17 @@ data are preserved (equivalent to 'docker compose down').
 		// Clear just that key (every other user setting is preserved) so the
 		// next `setup openbao init` runs cleanly without needing --force.
 		if cleanAllFlag {
-			envFile := filepath.Join("conf", "docker", ".env")
-			if err := clearEnvKey(envFile, "VAULT_TOKEN"); err != nil {
+			envFile := envFilePath()
+			switch found, err := clearEnvKey(envFile, "VAULT_TOKEN"); {
+			case err != nil:
 				fmt.Printf("warn: failed to clear VAULT_TOKEN from %s: %v\n", envFile, err)
-			} else {
+			case found:
 				fmt.Println("Cleared VAULT_TOKEN from .env (OpenBao credentials were removed).")
+			default:
+				// Nothing was cleared, so saying otherwise would be a plain
+				// falsehood — and a misleading one, because a user who reads it
+				// concludes .env is consistent with the wipe that just happened.
+				fmt.Printf("No VAULT_TOKEN entry found in %s — nothing to clear.\n", envFile)
 			}
 		}
 
@@ -161,16 +203,52 @@ data are preserved (equivalent to 'docker compose down').
 	},
 }
 
+// dryRunPlan renders everything the command would do, in the order it would do
+// it. Building it as a string rather than printing inline keeps it checkable:
+// the point of --dry-run is that this list and the real run agree, and a list
+// nothing can compare against is exactly how the .env edit went unannounced.
+func dryRunPlan(composeCmds [][]string, hostTargets []string) string {
+	var b strings.Builder
+	b.WriteString("[dry-run] The following commands would be executed:\n")
+	for _, c := range composeCmds {
+		fmt.Fprintf(&b, "  %s\n", displayCommand("docker", composeArgs(c...)))
+	}
+	for _, t := range hostTargets {
+		abs, _ := filepath.Abs(t)
+		fmt.Fprintf(&b, "  sudo rm -rf %s\n", abs)
+	}
+	// --clean-all edits .env as its last step. A dry-run that lists the removals
+	// but not that edit understates what the real run does, and .env is the one
+	// thing here a user may have customised by hand.
+	if cleanAllFlag {
+		abs, _ := filepath.Abs(envFilePath())
+		fmt.Fprintf(&b, "  clear VAULT_TOKEN in %s\n", abs)
+	}
+	b.WriteString("\n[dry-run] No changes were made.\n")
+	return b.String()
+}
+
+// envFilePath is the .env the remove command may edit — the same file every
+// other infra subcommand reads.
+func envFilePath() string {
+	return filepath.Join("conf", "docker", ".env")
+}
+
 // clearEnvKey rewrites the .env at path, setting key to an empty value while
 // preserving every other line. If the key is absent the file is left unchanged.
-func clearEnvKey(path, key string) error {
-	// path is a fixed internal .env location (conf/docker/.env), not user input.
-	data, err := os.ReadFile(path) // #nosec G304
+//
+// found reports whether the key was actually there. It is separate from err
+// because "the file was fine and the key was not in it" is a success as far as
+// the file is concerned, but it is not the same outcome as clearing the key —
+// and the caller prints a different sentence for each. Folding the two into a
+// single nil error is what made the command announce "Cleared VAULT_TOKEN from
+// .env" for an .env that never had the line.
+func clearEnvKey(path, key string) (found bool, err error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- path is the internal .env next to the compose file, not user input
 	if err != nil {
-		return err
+		return false, err
 	}
 	lines := strings.Split(string(data), "\n")
-	found := false
 	for i, line := range lines {
 		if strings.HasPrefix(strings.TrimSpace(line), key+"=") {
 			lines[i] = key + "="
@@ -178,11 +256,14 @@ func clearEnvKey(path, key string) error {
 		}
 	}
 	if !found {
-		return nil
+		return false, nil
 	}
-	// .env holds secrets (VAULT_TOKEN); keep it owner-only. The file already
-	// exists here, so this preserves its current mode rather than widening it.
-	return os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0600)
+	// .env holds secrets (VAULT_TOKEN); writeEnvFile replaces it atomically and
+	// keeps it owner-only.
+	if err := writeEnvFile(path, []byte(strings.Join(lines, "\n"))); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // printDependencyHint reminds the user that, with the flat data layout, a
@@ -201,23 +282,6 @@ func printDependencyHint(services []string) {
 	fmt.Println("  mayfly infra remove -s \"<service> <dependency-service>\" --clean-db")
 }
 
-// splitServices normalizes the -s value (comma- or space-separated) into a slice.
-func splitServices(serviceName string) []string {
-	if strings.TrimSpace(serviceName) == "" {
-		return nil
-	}
-	fields := strings.FieldsFunc(serviceName, func(r rune) bool {
-		return r == ',' || r == ' '
-	})
-	var out []string
-	for _, f := range fields {
-		if t := strings.TrimSpace(f); t != "" {
-			out = append(out, t)
-		}
-	}
-	return out
-}
-
 // confirm reads a yes/no answer from stdin.
 func confirm(prompt string) bool {
 	fmt.Print(prompt)
@@ -230,25 +294,30 @@ func confirm(prompt string) bool {
 // buildComposeCommands returns the docker compose command(s) to run for the
 // requested scope. Whole-system removal uses `down`; a service-scoped removal
 // stops and removes only the named services.
-func buildComposeCommands(services []string) []string {
+// Each entry is an argument vector for `docker compose -f <file> …`, executed
+// directly rather than through a shell.
+func buildComposeCommands(services []string) [][]string {
 	wipeImagesVolumes := cleanDBFlag || cleanAllFlag
 
 	if len(services) == 0 {
-		opts := "--remove-orphans"
+		down := []string{"down"}
 		if wipeImagesVolumes {
-			opts = "--volumes --rmi all --remove-orphans"
+			down = append(down, "--volumes", "--rmi", "all")
 		}
-		return []string{fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s down %s", ProjectName, DockerFilePath, opts)}
+		down = append(down, "--remove-orphans")
+		return [][]string{down}
 	}
 
-	svc := convertServiceNameForDockerCompose(ServiceName)
-	stop := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s stop %s", ProjectName, DockerFilePath, svc)
-	rmOpts := "-s -f"
+	stop := append([]string{"stop"}, services...)
+
+	rm := []string{"rm", "-s", "-f"}
 	if cleanDBFlag {
-		rmOpts = "-s -v -f" // also drop anonymous/named volumes attached to the service
+		// also drop anonymous/named volumes attached to the service
+		rm = []string{"rm", "-s", "-v", "-f"}
 	}
-	rm := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s rm %s %s", ProjectName, DockerFilePath, rmOpts, svc)
-	return []string{stop, rm}
+	rm = append(rm, services...)
+
+	return [][]string{stop, rm}
 }
 
 // hostDataTargets returns the host directories to wipe for the requested scope.
@@ -272,7 +341,11 @@ func hostDataTargets(services []string) ([]string, error) {
 		// be incompatible with --clean-all).
 		var targets []string
 		for _, s := range services {
-			targets = append(targets, filepath.Join(dataRoot, s))
+			target := filepath.Join(dataRoot, s)
+			if err := assertUnderDataRoot(dataRoot, target); err != nil {
+				return nil, err
+			}
+			targets = append(targets, target)
 		}
 		return targets, nil
 	}
@@ -292,9 +365,61 @@ func hostDataTargets(services []string) ([]string, error) {
 		if !cleanAllFlag && e.Name() == openbaoDirName {
 			continue // --clean-db preserves OpenBao credentials
 		}
-		targets = append(targets, filepath.Join(dataRoot, e.Name()))
+		target := filepath.Join(dataRoot, e.Name())
+		if err := assertUnderDataRoot(dataRoot, target); err != nil {
+			return nil, err
+		}
+		targets = append(targets, target)
 	}
 	return targets, nil
+}
+
+// assertUnderDataRoot refuses any wipe target that is not inside the host data
+// directory.
+//
+// resolveServices already guarantees a -s value names a service declared in the
+// compose file, so a traversal sequence such as -s "../../.." cannot reach this
+// point. This is the second line of defence: the cost of being wrong here is a
+// `sudo rm -rf` outside the data directory, so the path is checked on its own
+// terms rather than trusted because an earlier stage checked something else.
+func assertUnderDataRoot(dataRoot, target string) error {
+	absRoot, err := filepath.Abs(dataRoot)
+	if err != nil {
+		return fmt.Errorf("failed to resolve the data directory %s: %w", dataRoot, err)
+	}
+	absTarget, err := filepath.Abs(target)
+	if err != nil {
+		return fmt.Errorf("failed to resolve the removal target %s: %w", target, err)
+	}
+
+	rel, err := filepath.Rel(absRoot, absTarget)
+	if err != nil {
+		return fmt.Errorf("failed to compare %s against the data directory %s: %w", absTarget, absRoot, err)
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("refusing to remove %s: it lies outside the data directory %s", absTarget, absRoot)
+	}
+	return nil
+}
+
+// ensureSudoAvailable checks that sudo can run without prompting for a password
+// before the removal sequence starts.
+//
+// The wipe step shells out to `sudo rm -rf`. On an account without NOPASSWD that
+// call fails, and because nothing used to inspect the exit status the command
+// still printed its success message — leaving the operator believing a clean
+// rebuild happened while the data was still on disk. Checking up front means the
+// command either does what it says or says why it cannot.
+func ensureSudoAvailable() error {
+	if err := common.RunCommand("sudo", []string{"-n", "true"}, nil); err != nil {
+		return fmt.Errorf("sudo is required to remove the host data under %s, but it cannot run without a password.\n\n"+
+			"Either allow it without a prompt:\n"+
+			"  add a NOPASSWD entry for your account with `sudo visudo`\n"+
+			"or run this command as a user that already has it:\n"+
+			"  sudo ./mayfly infra remove …\n\n"+
+			"underlying error: %w", hostDataDirName, err)
+	}
+	return nil
 }
 
 func init() {
@@ -305,4 +430,11 @@ func init() {
 	pf.BoolVar(&cleanAllFlag, "clean-all", false, "Everything --clean-db removes, plus openbao host data (full reset)")
 	pf.BoolVarP(&yesFlag, "yes", "y", false, "Skip the confirmation prompt")
 	pf.BoolVar(&dryRunFlag, "dry-run", false, "Print the commands that would run, without executing them")
+
+	// --clean-db and --clean-all describe two different amounts of destruction,
+	// and passing both used to run --clean-all without a word. The difference
+	// between them is precisely whether the OpenBao credentials survive, so a
+	// user who wrote --clean-db meant to keep them and lost them anyway. Cobra
+	// rejects the combination up front rather than picking one.
+	removeCmd.MarkFlagsMutuallyExclusive("clean-db", "clean-all")
 }

--- a/cmd/docker/remove_dryrun_test.go
+++ b/cmd/docker/remove_dryrun_test.go
@@ -1,0 +1,79 @@
+package docker
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setCleanFlags sets the two clean flags for one test and restores them after.
+func setCleanFlags(t *testing.T, db, all bool) {
+	t.Helper()
+	prevDB, prevAll := cleanDBFlag, cleanAllFlag
+	t.Cleanup(func() { cleanDBFlag, cleanAllFlag = prevDB, prevAll })
+	cleanDBFlag, cleanAllFlag = db, all
+}
+
+// --dry-run must announce the .env edit that --clean-all performs.
+//
+// The real run clears VAULT_TOKEN as its final step, but the dry-run listed only
+// the compose commands and the rm targets. A user reading it to decide whether
+// the command was safe saw nothing about .env — the one file in the blast radius
+// they may have hand-edited.
+func TestDryRunPlanAnnouncesEnvTokenClear(t *testing.T) {
+	setCleanFlags(t, false, true)
+
+	plan := dryRunPlan([][]string{{"down", "--volumes", "--rmi", "all", "--remove-orphans"}}, []string{"conf/docker/data/openbao"})
+
+	absEnv, _ := filepath.Abs(envFilePath())
+	if !strings.Contains(plan, "clear VAULT_TOKEN in "+absEnv) {
+		t.Errorf("--clean-all dry-run does not announce the VAULT_TOKEN clear.\nplan:\n%s", plan)
+	}
+	// The rest of the plan is still there.
+	if !strings.Contains(plan, "down") || !strings.Contains(plan, "sudo rm -rf") {
+		t.Errorf("dry-run plan lost its compose/rm lines.\nplan:\n%s", plan)
+	}
+	if !strings.Contains(plan, "No changes were made.") {
+		t.Errorf("dry-run plan should end by stating nothing happened.\nplan:\n%s", plan)
+	}
+}
+
+// Without --clean-all there is no .env edit, so the line must not appear —
+// otherwise the dry-run overstates the damage instead of understating it.
+func TestDryRunPlanOmitsEnvTokenClearWhenNotCleanAll(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		db     bool
+		all    bool
+		expect bool
+	}{
+		{"default", false, false, false},
+		{"clean-db", true, false, false},
+		{"clean-all", false, true, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			setCleanFlags(t, tc.db, tc.all)
+			plan := dryRunPlan([][]string{{"down", "--remove-orphans"}}, nil)
+			got := strings.Contains(plan, "clear VAULT_TOKEN")
+			if got != tc.expect {
+				t.Errorf("VAULT_TOKEN line present = %v, want %v.\nplan:\n%s", got, tc.expect, plan)
+			}
+		})
+	}
+}
+
+// Every host target the command would wipe has to be listed, as an absolute
+// path — a relative one is ambiguous about what is actually about to be deleted.
+func TestDryRunPlanListsEveryHostTargetAbsolute(t *testing.T) {
+	setCleanFlags(t, true, false)
+
+	targets := []string{"conf/docker/data/cb-spider", "conf/docker/data/cb-tumblebug"}
+	plan := dryRunPlan(nil, targets)
+
+	for _, tgt := range targets {
+		abs, _ := filepath.Abs(tgt)
+		if !strings.Contains(plan, "sudo rm -rf "+abs) {
+			t.Errorf("target %q missing from the plan (expected absolute %q).\nplan:\n%s", tgt, abs, plan)
+		}
+	}
+}

--- a/cmd/docker/remove_flags_test.go
+++ b/cmd/docker/remove_flags_test.go
@@ -1,0 +1,86 @@
+package docker
+
+import (
+	"strings"
+	"testing"
+)
+
+// --clean-db and --clean-all must not be accepted together.
+//
+// They differ in exactly one thing — whether the OpenBao credentials survive —
+// and the combination used to run --clean-all in silence. A user who typed
+// --clean-db asked to keep those credentials and lost them with no message.
+func TestRemoveRejectsCleanDBWithCleanAll(t *testing.T) {
+	prevDB, prevAll := cleanDBFlag, cleanAllFlag
+	t.Cleanup(func() { cleanDBFlag, cleanAllFlag = prevDB, prevAll })
+
+	// ParseFlags + ValidateFlagGroups is the pair cobra itself runs before a
+	// command's Run. Calling Execute here would walk up to the root command and
+	// run the real thing, which would touch containers.
+	if err := removeCmd.ParseFlags([]string{"--clean-db", "--clean-all"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	err := removeCmd.ValidateFlagGroups()
+	if err == nil {
+		t.Fatal("--clean-db --clean-all was accepted; the two must be mutually exclusive")
+	}
+	// Cobra names both flags in the message, which is what tells the user which
+	// pair conflicted.
+	msg := err.Error()
+	if !strings.Contains(msg, "clean-db") || !strings.Contains(msg, "clean-all") {
+		t.Errorf("error should name both flags, got: %v", err)
+	}
+}
+
+// Each flag on its own still parses — the exclusion must not have made the
+// command unusable.
+func TestRemoveAcceptsEachCleanFlagAlone(t *testing.T) {
+	prevDB, prevAll, prevDry := cleanDBFlag, cleanAllFlag, dryRunFlag
+	t.Cleanup(func() {
+		cleanDBFlag, cleanAllFlag, dryRunFlag = prevDB, prevAll, prevDry
+		removeCmd.SetArgs(nil)
+	})
+
+	for _, flag := range []string{"--clean-db", "--clean-all"} {
+		t.Run(flag, func(t *testing.T) {
+			cleanDBFlag, cleanAllFlag = false, false
+			// Parse only: ParseFlags stops short of running the command, so no
+			// containers are touched.
+			if err := removeCmd.ParseFlags([]string{flag}); err != nil {
+				t.Fatalf("%s alone should parse, got: %v", flag, err)
+			}
+		})
+	}
+}
+
+// The service-scoped --clean-db paragraph must not promise the things a
+// service-scoped removal does not do. buildComposeCommands issues stop + rm for
+// the named services, so images and shared networks stay put.
+func TestServiceScopedCleanDBMessageMatchesBehaviour(t *testing.T) {
+	// What the command actually runs for a service-scoped --clean-db.
+	prevDB, prevAll := cleanDBFlag, cleanAllFlag
+	t.Cleanup(func() { cleanDBFlag, cleanAllFlag = prevDB, prevAll })
+	cleanDBFlag, cleanAllFlag = true, false
+
+	cmds := buildComposeCommands([]string{"cb-spider"})
+	var flat []string
+	for _, c := range cmds {
+		flat = append(flat, strings.Join(c, " "))
+	}
+	joined := strings.Join(flat, " | ")
+	if strings.Contains(joined, "--rmi") {
+		t.Fatalf("service-scoped removal unexpectedly removes images: %s", joined)
+	}
+
+	// So the message must not claim it removes images or networks.
+	lower := strings.ToLower(msgRemoveCleanDBService)
+	for _, promise := range []string{"removes containers, images", "networks, and db host data"} {
+		if strings.Contains(lower, promise) {
+			t.Errorf("service-scoped message still promises %q, which the command does not do", promise)
+		}
+	}
+	// And it should say so explicitly, so the user knows a follow-up is needed.
+	if !strings.Contains(lower, "images and shared networks are left in place") {
+		t.Errorf("service-scoped message should state that images and networks are kept, got:\n%s", msgRemoveCleanDBService)
+	}
+}

--- a/cmd/docker/remove_test.go
+++ b/cmd/docker/remove_test.go
@@ -16,8 +16,12 @@ func TestClearEnvKey(t *testing.T) {
 	if err := os.WriteFile(p, []byte(in), 0644); err != nil {
 		t.Fatal(err)
 	}
-	if err := clearEnvKey(p, "VAULT_TOKEN"); err != nil {
+	found, err := clearEnvKey(p, "VAULT_TOKEN")
+	if err != nil {
 		t.Fatalf("clearEnvKey: %v", err)
+	}
+	if !found {
+		t.Error("clearEnvKey reported the key as absent although it was present")
 	}
 	got, _ := os.ReadFile(p)
 	want := "# header\nVAULT_TOKEN=\nTUMBLEBUG_DB_PASSWORD=tumblebug\nBEETLE_API_PASSWORD=default\n"
@@ -26,17 +30,37 @@ func TestClearEnvKey(t *testing.T) {
 	}
 }
 
-// Absent key → file unchanged.
+// Absent key → file unchanged, and found is false so the caller can say so
+// instead of announcing a clear that never happened.
 func TestClearEnvKeyAbsent(t *testing.T) {
 	dir := t.TempDir()
 	p := filepath.Join(dir, ".env")
 	in := "ANT_DB_PASSWORD=cm-ant-secret\n"
-	os.WriteFile(p, []byte(in), 0644)
-	if err := clearEnvKey(p, "VAULT_TOKEN"); err != nil {
+	if err := os.WriteFile(p, []byte(in), 0644); err != nil {
+		t.Fatal(err)
+	}
+	found, err := clearEnvKey(p, "VAULT_TOKEN")
+	if err != nil {
 		t.Fatalf("clearEnvKey: %v", err)
+	}
+	if found {
+		t.Error("clearEnvKey reported the key as found although the file has no VAULT_TOKEN line")
 	}
 	got, _ := os.ReadFile(p)
 	if string(got) != in {
 		t.Fatalf("absent key should leave file unchanged. got: %q", got)
+	}
+}
+
+// A missing .env is an error, not a quiet "nothing to clear" — the two are
+// different situations and the caller prints different things for them.
+func TestClearEnvKeyMissingFile(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "does-not-exist.env")
+	found, err := clearEnvKey(p, "VAULT_TOKEN")
+	if err == nil {
+		t.Fatal("clearEnvKey on a missing file should return an error")
+	}
+	if found {
+		t.Error("found should be false when the file could not be read")
 	}
 }

--- a/cmd/docker/root.go
+++ b/cmd/docker/root.go
@@ -47,7 +47,7 @@ For example, you can install and run, stop, update and ... Cloud-Migrator runtim
 	Run: func(cmd *cobra.Command, args []string) {
 		//fmt.Println(cmd.UsageString())
 		//fmt.Println(cmd.Help())
-		cmd.Help()
+		_ = cmd.Help()
 	},
 	// Before any docker (infra) subcommand runs a `docker compose` command,
 	// make sure the shared environment file exists. The compose file relies on
@@ -214,6 +214,23 @@ var generatedEnvKeys = []string{
 // key invalidates tokens that were already issued, so tasks sitting in the celery
 // queue would fail on a key the scheduler no longer signs with. Keeping the value
 // stable is the whole point — the key needs to be unguessable, not new.
+//
+// Note on ordering: this writes to .env from PersistentPreRunE, which is before
+// `infra run` asks "Do you want to proceed? (y/N)". Answering N therefore leaves
+// a generated AIRFLOW_JWT_SECRET behind in .env. That is deliberate, and moving
+// the generation after the prompt was considered and rejected: validateDockerEnvFile
+// runs in the same hook and treats a blank AIRFLOW_JWT_SECRET as a hard error, so
+// generation has to precede validation, and validation has to precede the prompt
+// for the check to fail fast rather than after the user has committed. Deferring
+// generation past the prompt would make the first run fail validation before the
+// prompt was ever reached.
+//
+// Leaving the value behind is harmless in a way the removal steps are not: it is
+// a random local secret nothing outside this stack has to agree on, it is written
+// once and never rotated, and a cancelled run is left in exactly the state a
+// successful one would have started from. What was missing was not the ordering
+// but the disclosure — the message below now says the file was changed and that
+// the value stays, so a user who cancels is not surprised by an .env diff.
 func ensureGeneratedEnvValues() error {
 	dir := filepath.Dir(DockerFilePath)
 	envPath := filepath.Join(dir, ".env")
@@ -232,7 +249,8 @@ func ensureGeneratedEnvValues() error {
 		if err := setEnvKey(envPath, key, secret); err != nil {
 			return fmt.Errorf("failed to write %s to %s: %w", key, envPath, err)
 		}
-		fmt.Printf("Generated %s in %s (first run).\n", key, envPath)
+		fmt.Printf("Generated %s and saved it to %s (first run).\n", key, envPath)
+		fmt.Println("  This value is kept even if you cancel at the confirmation prompt; it is reused on every later run.")
 	}
 	return nil
 }
@@ -252,8 +270,7 @@ func randomSecret() (string, error) {
 // version simply has no line for a key added since). Every other line, including
 // comments, is preserved.
 func setEnvKey(path, key, value string) error {
-	// path is a fixed internal .env location (conf/docker/.env), not user input.
-	data, err := os.ReadFile(path) // #nosec G304
+	data, err := os.ReadFile(path) // #nosec G304 -- path is the internal .env next to the compose file, not user input
 	if err != nil {
 		return err
 	}
@@ -276,9 +293,9 @@ func setEnvKey(path, key, value string) error {
 			lines = append(lines, key+"="+value)
 		}
 	}
-	// .env holds secrets; keep it owner-only. The file already exists here, so
-	// this preserves its current mode rather than widening it.
-	return os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0600)
+	// .env holds secrets; writeEnvFile replaces it atomically and keeps it
+	// owner-only.
+	return writeEnvFile(path, []byte(strings.Join(lines, "\n")))
 }
 
 // validateDockerEnvFile parses conf/docker/.env and reports any required key
@@ -321,41 +338,27 @@ func parseDotEnv(path string) (map[string]string, error) {
 	return common.ParseDotEnv(path)
 }
 
-// convertServiceNameForDockerCompose converts comma-separated service names to space-separated
-// for Docker Compose command compatibility
-func convertServiceNameForDockerCompose(serviceName string) string {
-	if serviceName == "" {
-		return ""
-	}
-
-	// If contains comma, convert to space-separated
-	if strings.Contains(serviceName, ",") {
-		services := strings.Split(serviceName, ",")
-		var result []string
-		for _, service := range services {
-			trimmed := strings.TrimSpace(service)
-			if trimmed != "" {
-				result = append(result, trimmed)
-			}
-		}
-		return strings.Join(result, " ")
-	}
-
-	// If space-separated or single service, return as is
-	return serviceName
-}
-
-// SysCallDockerComposePsWithAll executes `docker-compose ps` command with optional --all flag
+// SysCallDockerComposePsWithAll executes `docker compose ps` with an optional
+// --all flag, scoped to the services named by -s (all services when -s is
+// omitted).
 func SysCallDockerComposePsWithAll(showAll bool) {
 	fmt.Println("\n[v]Status of Cloud-Migrator runtimes")
-	var cmdStr string
-	convertedServiceName := convertServiceNameForDockerCompose(ServiceName)
-	if showAll {
-		cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s ps -a %s", ProjectName, DockerFilePath, convertedServiceName)
-	} else {
-		cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s ps %s", ProjectName, DockerFilePath, convertedServiceName)
+
+	services, err := resolveServices(ServiceName)
+	if err != nil {
+		fmt.Printf("❌ %v\n", err)
+		return
 	}
-	common.SysCall(cmdStr)
+
+	args := []string{"ps"}
+	if showAll {
+		args = append(args, "-a")
+	}
+	args = append(args, services...)
+
+	if err := runCompose(args...); err != nil {
+		fmt.Printf("❌ docker compose ps failed: %v\n", err)
+	}
 }
 
 func init() {

--- a/cmd/docker/run.go
+++ b/cmd/docker/run.go
@@ -3,9 +3,9 @@ package docker
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
-	"github.com/cm-mayfly/cm-mayfly/common"
 	"github.com/cm-mayfly/cm-mayfly/internal/openbao"
 	"github.com/spf13/cobra"
 )
@@ -15,65 +15,79 @@ func showServiceInfo(services map[string]ServiceInfo) {
 	fmt.Println("🚀 Services to be started:")
 	fmt.Println()
 
-	// Group services by category
+	// Group services by category. Sorting each group by name keeps the listing
+	// stable: services arrive in a map, and a map hands out its keys in a
+	// different order on every run, so the lines shuffled between invocations.
 	categories := make(map[string][]ServiceInfo)
 	for _, service := range services {
 		categories[service.Category] = append(categories[service.Category], service)
 	}
-
-	// Define category order and icons
-	categoryOrder := []struct {
-		name string
-		icon string
-	}{
-		{"Core Services", "🎯"},
-		{"Database", "🗄️"},
-		{"Cache/Storage", "💾"},
-		{"Workflow Engine", "⚙️"},
-		{"Dependencies", "🔧"},
+	for name := range categories {
+		group := categories[name]
+		sort.Slice(group, func(i, j int) bool { return group[i].Name < group[j].Name })
 	}
 
 	totalServices := len(services)
 	fmt.Printf("📊 Total Services: %d\n\n", totalServices)
 
-	// Display services by category
-	for _, catInfo := range categoryOrder {
-		if services, exists := categories[catInfo.name]; exists {
-			fmt.Printf("%s %s (%d services)\n", catInfo.icon, catInfo.name, len(services))
-
-			// Find the longest service name and image strings for proper table width
-			maxServiceLen := 15 // minimum width
-			maxImageLen := 25   // minimum width for image columns
-
-			for _, service := range services {
-				if len(service.Name) > maxServiceLen {
-					maxServiceLen = len(service.Name)
-				}
-				if len(service.Image) > maxImageLen {
-					maxImageLen = len(service.Image)
-				}
-			}
-
-			// Create table header with dynamic width
-			headerFormat := fmt.Sprintf("┌─%%-%ds─┬─%%-%ds─┐\n", maxServiceLen, maxImageLen)
-			separatorFormat := fmt.Sprintf("├─%%-%ds─┼─%%-%ds─┤\n", maxServiceLen, maxImageLen)
-			footerFormat := fmt.Sprintf("└─%%-%ds─┴─%%-%ds─┘\n", maxServiceLen, maxImageLen)
-
-			// Print top border
-			fmt.Printf(headerFormat, strings.Repeat("─", maxServiceLen), strings.Repeat("─", maxImageLen))
-			// Print header row
-			fmt.Printf("│ %-*s │ %-*s │\n", maxServiceLen, "Service", maxImageLen, "Image")
-			// Print separator
-			fmt.Printf(separatorFormat, strings.Repeat("─", maxServiceLen), strings.Repeat("─", maxImageLen))
-
-			for _, service := range services {
-				fmt.Printf("│ %-*s │ %-*s │\n", maxServiceLen, service.Name, maxImageLen, service.Image)
-			}
-
-			fmt.Printf(footerFormat, strings.Repeat("─", maxServiceLen), strings.Repeat("─", maxImageLen))
-			fmt.Println()
+	// Display services by category. Empty categories are skipped, so a lineup
+	// without an object store prints no empty Object Storage heading.
+	for _, catInfo := range categoryDisplayOrder {
+		if grouped, exists := categories[catInfo.Name]; exists {
+			printServiceCategory(catInfo.Icon, catInfo.Name, grouped)
+			delete(categories, catInfo.Name)
 		}
 	}
+
+	// Anything left carries a category the ordered list does not know about.
+	// Print it rather than dropping the services from the summary: the user is
+	// about to start them either way.
+	remaining := make([]string, 0, len(categories))
+	for name := range categories {
+		remaining = append(remaining, name)
+	}
+	sort.Strings(remaining)
+	for _, name := range remaining {
+		printServiceCategory(unknownCategoryIcon, name, categories[name])
+	}
+}
+
+// printServiceCategory prints one category heading and its service table, sized
+// to the widest service name and image it holds.
+func printServiceCategory(icon, name string, services []ServiceInfo) {
+	fmt.Printf("%s %s (%d services)\n", icon, name, len(services))
+
+	// Find the longest service name and image strings for proper table width
+	maxServiceLen := 15 // minimum width
+	maxImageLen := 25   // minimum width for image columns
+
+	for _, service := range services {
+		if len(service.Name) > maxServiceLen {
+			maxServiceLen = len(service.Name)
+		}
+		if len(service.Image) > maxImageLen {
+			maxImageLen = len(service.Image)
+		}
+	}
+
+	// Create table header with dynamic width
+	headerFormat := fmt.Sprintf("┌─%%-%ds─┬─%%-%ds─┐\n", maxServiceLen, maxImageLen)
+	separatorFormat := fmt.Sprintf("├─%%-%ds─┼─%%-%ds─┤\n", maxServiceLen, maxImageLen)
+	footerFormat := fmt.Sprintf("└─%%-%ds─┴─%%-%ds─┘\n", maxServiceLen, maxImageLen)
+
+	// Print top border
+	fmt.Printf(headerFormat, strings.Repeat("─", maxServiceLen), strings.Repeat("─", maxImageLen))
+	// Print header row
+	fmt.Printf("│ %-*s │ %-*s │\n", maxServiceLen, "Service", maxImageLen, "Image")
+	// Print separator
+	fmt.Printf(separatorFormat, strings.Repeat("─", maxServiceLen), strings.Repeat("─", maxImageLen))
+
+	for _, service := range services {
+		fmt.Printf("│ %-*s │ %-*s │\n", maxServiceLen, service.Name, maxImageLen, service.Image)
+	}
+
+	fmt.Printf(footerFormat, strings.Repeat("─", maxServiceLen), strings.Repeat("─", maxImageLen))
+	fmt.Println()
 }
 
 // runCmd represents the run command
@@ -85,20 +99,28 @@ var runCmd = &cobra.Command{
 		fmt.Println("\n[Install and Run Cloud-Migrator System]")
 		fmt.Println()
 
+		// Resolve -s first so an unusable value stops the command before anything
+		// is started. An empty -s means "every service".
+		targets, err := resolveServices(ServiceName)
+		if err != nil {
+			fmt.Printf("⚠️ %v\n", err)
+			return
+		}
+
 		// Parse docker-compose.yaml to show service information
 		services, err := parseDockerComposeImages()
 		if err != nil {
 			fmt.Printf("⚠️ Failed to parse docker-compose.yaml: %v\n", err)
 			fmt.Printf("🔄 Proceeding with regular run...\n")
 		} else {
-			// If specific service is requested, only show that service
-			if ServiceName != "" {
-				if serviceInfo, exists := services[ServiceName]; exists {
-					services = map[string]ServiceInfo{ServiceName: serviceInfo}
-				} else {
-					fmt.Printf("⚠️ Service %s not found in docker-compose.yaml\n", ServiceName)
-					return
+			// If specific services are requested, only show those. resolveServices
+			// has already confirmed every name exists.
+			if len(targets) > 0 {
+				selected := make(map[string]ServiceInfo, len(targets))
+				for _, name := range targets {
+					selected[name] = services[name]
 				}
+				services = selected
 			}
 
 			// Show service information
@@ -108,7 +130,7 @@ var runCmd = &cobra.Command{
 		// Ask user for confirmation before proceeding with installation
 		fmt.Print("\nDo you want to proceed with the installation? (y/N): ")
 		var response string
-		fmt.Scanln(&response)
+		_, _ = fmt.Scanln(&response)
 
 		if strings.ToLower(response) != "y" && strings.ToLower(response) != "yes" {
 			fmt.Println("❌ Installation cancelled by user")
@@ -131,7 +153,7 @@ var runCmd = &cobra.Command{
 		// wiped storage, invalid token, …) → print the specific remediation and
 		// stop BEFORE starting the rest, so the stack never deadlocks in the
 		// half-up "Created" state a broken OpenBao would otherwise leave behind.
-		if ServiceName == "" {
+		if len(targets) == 0 {
 			pf := openbao.Preflight(true) // run may start openbao alone to diagnose
 			switch {
 			case pf.Case == openbao.CaseFresh:
@@ -163,27 +185,18 @@ var runCmd = &cobra.Command{
 
 		// Always use detached mode to avoid dependency issues
 		// If user wants to see logs, we'll show them after containers are started
-		convertedServiceName := convertServiceNameForDockerCompose(ServiceName)
-		cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s up -d %s", ProjectName, DockerFilePath, convertedServiceName)
-
-		// // If there are additional arguments, treat them as services or additional commands and add them to the existing command with an additional
-		// if len(args) > 0 {
-		// 	cmdStr += args[0]
-
-		// 	// Explicitly passing the service name as a filter (--service) option or argument would be fine.
-		// 	// serviceName := args[0]
-		// 	// cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s up %s", ProjectName, DockerFilePath, serviceName)
-		// }
-
-		//fmt.Println(cmdStr)
-		common.SysCall(cmdStr)
+		if err := runCompose(append([]string{"up", "-d"}, targets...)...); err != nil {
+			fmt.Printf("\n❌ docker compose up failed: %v\n", err)
+			return
+		}
 
 		// If user didn't explicitly request detached mode, show logs
 		if !DetachMode {
 			fmt.Println("\n[Showing container logs - Press Ctrl+C to stop viewing logs]")
 			fmt.Println()
-			logCmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s logs -f %s", ProjectName, DockerFilePath, convertedServiceName)
-			common.SysCall(logCmdStr)
+			if err := runCompose(append([]string{"logs", "-f"}, targets...)...); err != nil {
+				fmt.Printf("❌ docker compose logs failed: %v\n", err)
+			}
 		} else {
 			// Show log command guidance for detached mode
 			fmt.Println("\n📋 Log Commands:")

--- a/cmd/docker/run_display_test.go
+++ b/cmd/docker/run_display_test.go
@@ -1,0 +1,69 @@
+package docker
+
+import (
+	"strings"
+	"testing"
+)
+
+// showServiceInfo reads its services out of a map, whose iteration order differs
+// on every run. Sorting each category by name is what keeps two runs of the same
+// lineup from printing the services in two different orders.
+func TestShowServiceInfoIsDeterministic(t *testing.T) {
+	services := map[string]ServiceInfo{}
+	for _, name := range []string{
+		"cb-tumblebug", "cb-spider", "cb-mapui", "mc-terrarium",
+		"cm-ant", "cm-beetle", "cm-honeybee",
+		"openbao", "openbao-unseal", "ant-postgres", "cm-grasshopper-rustfs",
+	} {
+		services[name] = ServiceInfo{
+			Name:     name,
+			Image:    "example/" + name + ":1.0.0",
+			Category: categorizeService(name, ""),
+		}
+	}
+
+	first := captureStdout(t, func() { showServiceInfo(services) })
+	for i := 0; i < 5; i++ {
+		if again := captureStdout(t, func() { showServiceInfo(services) }); again != first {
+			t.Fatalf("run %d printed a different listing:\n%s\n---\n%s", i+2, first, again)
+		}
+	}
+
+	// Within a category the names are in ascending order.
+	var core []string
+	for _, line := range strings.Split(first, "\n") {
+		for _, name := range []string{"cb-mapui", "cb-spider", "cb-tumblebug", "mc-terrarium"} {
+			if strings.HasPrefix(line, "│ "+name+" ") {
+				core = append(core, name)
+			}
+		}
+	}
+	want := "cb-mapui|cb-spider|cb-tumblebug|mc-terrarium"
+	if got := strings.Join(core, "|"); got != want {
+		t.Errorf("Core Infrastructure order = %q, want %q", got, want)
+	}
+}
+
+// The two screens read one list, so they cannot drift into different orders or
+// different icons for the same category.
+func TestCategoryDisplayOrderCoversEveryCategory(t *testing.T) {
+	listed := make(map[string]bool, len(categoryDisplayOrder))
+	for _, entry := range categoryDisplayOrder {
+		if listed[entry.Name] {
+			t.Errorf("category %q is listed twice", entry.Name)
+		}
+		listed[entry.Name] = true
+	}
+
+	for _, category := range []string{
+		CategoryCoreInfra, CategoryFrameworks, CategoryWebConsole, CategoryWorkflow,
+		CategorySecrets, CategoryDataStores, CategoryObjectStorage, CategoryDependencies,
+	} {
+		if !listed[category] {
+			t.Errorf("category %q has no display order entry", category)
+		}
+		if categoryIcon(category) == "" {
+			t.Errorf("category %q has no icon", category)
+		}
+	}
+}

--- a/cmd/docker/services_test.go
+++ b/cmd/docker/services_test.go
@@ -1,0 +1,346 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeTestCompose creates a minimal compose file declaring the given services
+// and points DockerFilePath at it for the duration of the test.
+func writeTestCompose(t *testing.T, services ...string) string {
+	t.Helper()
+
+	var b strings.Builder
+	b.WriteString("services:\n")
+	for _, s := range services {
+		b.WriteString("  " + s + ":\n")
+		b.WriteString("    image: example/" + s + ":1.0.0\n")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "docker-compose.yaml")
+	if err := os.WriteFile(path, []byte(b.String()), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	prev := DockerFilePath
+	DockerFilePath = path
+	t.Cleanup(func() { DockerFilePath = prev })
+	return path
+}
+
+// Comma, space and mixed separators must all produce the same list, with blanks
+// dropped and duplicates collapsed in first-seen order. Each command used to
+// split -s its own way, so the same value meant different things depending on
+// which subcommand read it.
+func TestSplitServiceNames(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{"single", "cb-spider", []string{"cb-spider"}},
+		{"comma", "cb-spider,cb-tumblebug", []string{"cb-spider", "cb-tumblebug"}},
+		{"space", "cb-spider cb-tumblebug", []string{"cb-spider", "cb-tumblebug"}},
+		{"comma and space", "cb-spider, cb-tumblebug", []string{"cb-spider", "cb-tumblebug"}},
+		{"mixed separators", "cb-spider, cb-tumblebug openbao", []string{"cb-spider", "cb-tumblebug", "openbao"}},
+		{"surrounding whitespace", "  cb-spider ,cb-tumblebug  ", []string{"cb-spider", "cb-tumblebug"}},
+		{"empty fields dropped", "cb-spider,,,cb-tumblebug", []string{"cb-spider", "cb-tumblebug"}},
+		{"duplicates removed, order kept", "cb-tumblebug,cb-spider,cb-tumblebug", []string{"cb-tumblebug", "cb-spider"}},
+		{"separators only", ",", []string{}},
+		{"whitespace only", "   ", []string{}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := splitServiceNames(tc.raw)
+			if len(got) != len(tc.want) {
+				t.Fatalf("splitServiceNames(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("splitServiceNames(%q) = %v, want %v", tc.raw, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// The whole environment may be selected only by omitting -s. This is the
+// distinction every destructive command depends on.
+func TestResolveServicesEmptyMeansAll(t *testing.T) {
+	writeTestCompose(t, "cb-spider", "openbao")
+
+	got, err := resolveServices("")
+	if err != nil {
+		t.Fatalf("resolveServices(\"\") returned error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("resolveServices(\"\") = %v, want empty (all services)", got)
+	}
+}
+
+// A -s value that holds nothing but separators must be an error, never "all
+// services". `remove -s ","` used to fall through to the whole-environment
+// branch and wipe every service's host data.
+func TestResolveServicesSeparatorOnlyIsAnError(t *testing.T) {
+	writeTestCompose(t, "cb-spider", "cb-tumblebug", "openbao")
+
+	for _, raw := range []string{",", " ", "  ,  ", ",,,", "\t"} {
+		got, err := resolveServices(raw)
+		if err == nil {
+			t.Fatalf("resolveServices(%q) = %v, want an error — a separator-only value must never mean 'all services'", raw, got)
+		}
+		if got != nil {
+			t.Fatalf("resolveServices(%q) returned %v alongside an error; it must return no targets", raw, got)
+		}
+		if !strings.Contains(err.Error(), "no service name found") {
+			t.Fatalf("resolveServices(%q) error = %q, want it to explain that no service was named", raw, err)
+		}
+	}
+}
+
+// Backward compatibility: a single valid name keeps working unchanged.
+func TestResolveServicesSingleName(t *testing.T) {
+	writeTestCompose(t, "cb-spider", "cb-tumblebug")
+
+	got, err := resolveServices("cb-spider")
+	if err != nil {
+		t.Fatalf("resolveServices: %v", err)
+	}
+	if len(got) != 1 || got[0] != "cb-spider" {
+		t.Fatalf("resolveServices(\"cb-spider\") = %v, want [cb-spider]", got)
+	}
+}
+
+// Comma, space and mixed input must resolve identically once validated.
+func TestResolveServicesSeparatorsAreEquivalent(t *testing.T) {
+	writeTestCompose(t, "cb-spider", "cb-tumblebug", "openbao")
+
+	want := []string{"cb-spider", "cb-tumblebug"}
+	for _, raw := range []string{
+		"cb-spider,cb-tumblebug",
+		"cb-spider cb-tumblebug",
+		"cb-spider, cb-tumblebug",
+		" cb-spider ,  cb-tumblebug ",
+	} {
+		got, err := resolveServices(raw)
+		if err != nil {
+			t.Fatalf("resolveServices(%q): %v", raw, err)
+		}
+		if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+			t.Fatalf("resolveServices(%q) = %v, want %v", raw, got, want)
+		}
+	}
+}
+
+// An unknown name must be named on its own. Reporting the whole -s string left
+// the user to guess which of several entries was wrong.
+func TestResolveServicesNamesTheUnknownEntryOnly(t *testing.T) {
+	writeTestCompose(t, "cb-spider", "cb-tumblebug", "openbao")
+
+	_, err := resolveServices("cb-spider,cb-tumbelbug,openbao")
+	if err == nil {
+		t.Fatal("resolveServices accepted a misspelled service name")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "cb-tumbelbug") {
+		t.Fatalf("error must point at the offending name; got %q", msg)
+	}
+	if strings.Contains(msg, "'cb-spider'") || strings.Contains(msg, "'openbao'") {
+		t.Fatalf("error must not blame the valid names; got %q", msg)
+	}
+	if !strings.Contains(msg, "Available services:") {
+		t.Fatalf("error must list the available services; got %q", msg)
+	}
+	for _, svc := range []string{"cb-spider", "cb-tumblebug", "openbao"} {
+		if !strings.Contains(msg, "  - "+svc) {
+			t.Fatalf("available list is missing %q; got %q", svc, msg)
+		}
+	}
+}
+
+// Several unknown names are all reported at once, so the user fixes the value
+// in one pass rather than one name per run.
+func TestResolveServicesReportsEveryUnknownName(t *testing.T) {
+	writeTestCompose(t, "cb-spider", "openbao")
+
+	_, err := resolveServices("nope-one nope-two")
+	if err == nil {
+		t.Fatal("resolveServices accepted two unknown service names")
+	}
+	for _, name := range []string{"nope-one", "nope-two"} {
+		if !strings.Contains(err.Error(), name) {
+			t.Fatalf("error must mention %q; got %q", name, err)
+		}
+	}
+}
+
+// Shell metacharacters and path traversal cannot name a compose service, so
+// they are rejected before any command or removal path is built. This is what
+// makes `remove -s 'openbao;id'` and `remove -s '../../..'` structurally
+// impossible rather than merely quoted.
+func TestResolveServicesRejectsInjectionAndTraversal(t *testing.T) {
+	writeTestCompose(t, "openbao", "cb-spider")
+
+	for _, raw := range []string{
+		"openbao;id",
+		"openbao|id",
+		"openbao$(id)",
+		"openbao`id`",
+		"../../..",
+		"../../../etc",
+		"openbao && rm -rf /",
+	} {
+		got, err := resolveServices(raw)
+		if err == nil {
+			t.Fatalf("resolveServices(%q) = %v, want an error — the value does not name a compose service", raw, got)
+		}
+	}
+}
+
+// validateServiceNames is the pure half of the resolver; a fully valid list
+// passes through untouched.
+func TestValidateServiceNamesPassesValidInput(t *testing.T) {
+	available := map[string]ServiceInfo{
+		"cb-spider": {Name: "cb-spider"},
+		"openbao":   {Name: "openbao"},
+	}
+	got, err := validateServiceNames([]string{"openbao", "cb-spider"}, available)
+	if err != nil {
+		t.Fatalf("validateServiceNames: %v", err)
+	}
+	if len(got) != 2 || got[0] != "openbao" || got[1] != "cb-spider" {
+		t.Fatalf("validateServiceNames = %v, want the input order preserved", got)
+	}
+}
+
+// Every service the human-readable table knows about must be resolvable by -s.
+// The two lists are maintained separately today, so a name present in one and
+// missing from the other would make `-s <name>` reject a service that `info`
+// happily displays.
+func TestComposeFileCoversDisplayedServices(t *testing.T) {
+	prev := DockerFilePath
+	DockerFilePath = filepath.Join("..", "..", "conf", "docker", "docker-compose.yaml")
+	defer func() { DockerFilePath = prev }()
+
+	parsed, err := parseDockerComposeImages()
+	if err != nil {
+		t.Fatalf("failed to parse the real compose file: %v", err)
+	}
+
+	for _, svc := range getServicesFromCompose() {
+		if _, ok := parsed[svc]; !ok {
+			t.Errorf("service %q is displayed by `infra info` but cannot be resolved by -s", svc)
+		}
+	}
+}
+
+// The removal targets must stay inside conf/docker/data. resolveServices already
+// prevents a traversal value from reaching here, so this guards the path itself.
+func TestAssertUnderDataRoot(t *testing.T) {
+	root := filepath.Join("conf", "docker", "data")
+
+	ok := []string{
+		filepath.Join(root, "openbao"),
+		filepath.Join(root, "cb-spider"),
+		filepath.Join(root, "a", "b"),
+	}
+	for _, target := range ok {
+		if err := assertUnderDataRoot(root, target); err != nil {
+			t.Errorf("assertUnderDataRoot(%q) = %v, want it accepted", target, err)
+		}
+	}
+
+	bad := []string{
+		root,                                  // the data root itself
+		filepath.Join(root, ".."),             // conf/docker
+		filepath.Join(root, "..", ".."),       // conf
+		filepath.Join(root, "..", "..", ".."), // the repository
+		"/etc",
+		filepath.Join(root, "..", "..", "..", "..", "etc"),
+	}
+	for _, target := range bad {
+		if err := assertUnderDataRoot(root, target); err == nil {
+			t.Errorf("assertUnderDataRoot(%q) accepted a target outside the data directory", target)
+		}
+	}
+}
+
+// buildComposeCommands must emit argument vectors, with each service as its own
+// element. A name is never concatenated into a string that a shell would parse.
+func TestBuildComposeCommandsUsesArgumentVectors(t *testing.T) {
+	prevDB, prevAll := cleanDBFlag, cleanAllFlag
+	defer func() { cleanDBFlag, cleanAllFlag = prevDB, prevAll }()
+
+	// Whole environment, default flags → a single `down`.
+	cleanDBFlag, cleanAllFlag = false, false
+	cmds := buildComposeCommands(nil)
+	if len(cmds) != 1 {
+		t.Fatalf("whole-environment removal should be one command, got %d", len(cmds))
+	}
+	if cmds[0][0] != "down" {
+		t.Fatalf("whole-environment removal should use `down`, got %v", cmds[0])
+	}
+
+	// Service-scoped → stop + rm, each service its own argument.
+	cleanDBFlag, cleanAllFlag = true, false
+	cmds = buildComposeCommands([]string{"cb-spider", "openbao"})
+	if len(cmds) != 2 {
+		t.Fatalf("service-scoped removal should be stop + rm, got %d commands", len(cmds))
+	}
+	if cmds[0][0] != "stop" || cmds[1][0] != "rm" {
+		t.Fatalf("expected stop then rm, got %v and %v", cmds[0], cmds[1])
+	}
+	for _, c := range cmds {
+		var found int
+		for _, arg := range c {
+			if arg == "cb-spider" || arg == "openbao" {
+				found++
+			}
+			if strings.Contains(arg, " ") {
+				t.Errorf("argument %q contains a space; service names must be separate arguments", arg)
+			}
+		}
+		if found != 2 {
+			t.Errorf("command %v should carry both service names as separate arguments", c)
+		}
+	}
+}
+
+// A service-scoped --clean-db wipes only the named services' directories.
+func TestHostDataTargetsServiceScoped(t *testing.T) {
+	prevDB, prevAll := cleanDBFlag, cleanAllFlag
+	defer func() { cleanDBFlag, cleanAllFlag = prevDB, prevAll }()
+	cleanDBFlag, cleanAllFlag = true, false
+
+	writeTestCompose(t, "cb-spider", "openbao")
+
+	targets, err := hostDataTargets([]string{"cb-spider"})
+	if err != nil {
+		t.Fatalf("hostDataTargets: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("hostDataTargets = %v, want exactly one target", targets)
+	}
+	if filepath.Base(targets[0]) != "cb-spider" {
+		t.Fatalf("hostDataTargets = %v, want the cb-spider data directory", targets)
+	}
+}
+
+// Without --clean-db/--clean-all nothing on the host is touched.
+func TestHostDataTargetsDefaultWipesNothing(t *testing.T) {
+	prevDB, prevAll := cleanDBFlag, cleanAllFlag
+	defer func() { cleanDBFlag, cleanAllFlag = prevDB, prevAll }()
+	cleanDBFlag, cleanAllFlag = false, false
+
+	targets, err := hostDataTargets([]string{"cb-spider"})
+	if err != nil {
+		t.Fatalf("hostDataTargets: %v", err)
+	}
+	if len(targets) != 0 {
+		t.Fatalf("hostDataTargets = %v, want nothing wiped without --clean-db", targets)
+	}
+}

--- a/cmd/docker/stop.go
+++ b/cmd/docker/stop.go
@@ -3,7 +3,6 @@ package docker
 import (
 	"fmt"
 
-	"github.com/cm-mayfly/cm-mayfly/common"
 	"github.com/spf13/cobra"
 )
 
@@ -19,19 +18,16 @@ var stopCmd = &cobra.Command{
 		fmt.Println("\n[Stop Cloud-Migrator]")
 		fmt.Println()
 
-		convertedServiceName := convertServiceNameForDockerCompose(ServiceName)
-		cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s stop %s", ProjectName, DockerFilePath, convertedServiceName)
-		// // If there are additional arguments, treat them as services or additional commands and add them to the existing command with an additional
-		// if len(args) > 0 {
-		// 	cmdStr += args[0]
+		services, err := resolveServices(ServiceName)
+		if err != nil {
+			fmt.Printf("❌ %v\n", err)
+			return
+		}
 
-		// 	// Explicitly passing the service name as a filter (--service) option or argument would be fine.
-		// 	// serviceName := args[0]
-		// 	// cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s stop %s", ProjectName, DockerFilePath, serviceName)
-		// }
-
-		//fmt.Println(cmdStr)
-		common.SysCall(cmdStr)
+		if err := runCompose(append([]string{"stop"}, services...)...); err != nil {
+			fmt.Printf("❌ docker compose stop failed: %v\n", err)
+			return
+		}
 
 		SysCallDockerComposePsWithAll(stopAllFlag)
 	},

--- a/cmd/docker/update.go
+++ b/cmd/docker/update.go
@@ -3,9 +3,7 @@ package docker
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
-	"os/exec"
 	"strings"
 
 	"github.com/cm-mayfly/cm-mayfly/common"
@@ -34,27 +32,38 @@ type DockerHubTagDetailResponse struct {
 	LastUpdated string `json:"last_updated"`
 }
 
+// dockerHubRepositoryPath maps an image name to its path in the Docker Hub API.
+//
+// Official images are addressed as "library/<name>" there, even though they are
+// pulled as a bare name. Without the prefix the API answers 404 for every one
+// of them, which is why postgres, redis, mysql and etcd never showed a value in
+// the Latest column.
+func dockerHubRepositoryPath(imageName string) string {
+	if strings.Contains(imageName, "/") {
+		return imageName
+	}
+	return "library/" + imageName
+}
+
 // checkDockerHubTagUpdate checks if the specific tag on Docker Hub has been updated
 func checkDockerHubTagUpdate(imageName, tag string) (string, error) {
-	url := fmt.Sprintf("https://hub.docker.com/v2/repositories/%s/tags/%s/", imageName, tag)
+	url := fmt.Sprintf("https://hub.docker.com/v2/repositories/%s/tags/%s/",
+		dockerHubRepositoryPath(imageName), tag)
 
-	resp, err := http.Get(url)
+	// The shared client carries a request timeout. The bare http.Get this
+	// replaced used the default client, which has none, so a slow or
+	// unresponsive Docker Hub left `infra update` waiting with no way out.
+	resp, err := common.NewHTTPClient().R().Get(url)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch Docker Hub API: %v", err)
 	}
-	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("Docker Hub API returned status %d", resp.StatusCode)
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("failed to read response body: %v", err)
+	if resp.StatusCode() != http.StatusOK {
+		return "", fmt.Errorf("Docker Hub API returned status %d", resp.StatusCode())
 	}
 
 	var tagResponse DockerHubTagDetailResponse
-	if err := json.Unmarshal(body, &tagResponse); err != nil {
+	if err := json.Unmarshal(resp.Body(), &tagResponse); err != nil {
 		return "", fmt.Errorf("failed to parse JSON response: %v", err)
 	}
 
@@ -66,9 +75,7 @@ func checkDockerHubTagUpdate(imageName, tag string) (string, error) {
 func getCurrentLocalVersion(imageName, tag string, serviceName string) (string, error) {
 	// First, try to get the actual running container's image using docker compose ps
 	// This is more accurate than docker ps --filter because it uses the service name from docker-compose.yaml
-	cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s ps --format json", ProjectName, DockerFilePath)
-	cmd := exec.Command("bash", "-c", cmdStr)
-	output, err := cmd.Output()
+	output, err := composeOutput("ps", "--format", "json")
 	if err == nil {
 		// Parse JSON output to find the container for this service
 		lines := strings.Split(string(output), "\n")
@@ -102,18 +109,42 @@ func getCurrentLocalVersion(imageName, tag string, serviceName string) (string, 
 	}
 
 	// Fallback: Check if the specific image exists locally
-	cmdStr = fmt.Sprintf("docker images --format '{{.Tag}}' %s:%s 2>/dev/null || echo 'not_installed'", imageName, tag)
-	output2 := common.SysCallWithOutput(cmdStr)
+	output2, err := common.RunCommandOutput("docker",
+		[]string{"images", "--format", "{{.Tag}}", fmt.Sprintf("%s:%s", imageName, tag)}, nil)
+	if err != nil {
+		// A failing `docker images` is not the same as an absent image: the
+		// command exits 0 with empty output for that (handled just below).
+		// Reporting "not_installed" here turned an unreachable daemon into a
+		// table claiming every image was missing, which then read as "there is
+		// an update for everything". Hand the failure back instead.
+		return "", fmt.Errorf("could not list local images for %s:%s: %w", imageName, tag, err)
+	}
 
-	if strings.TrimSpace(output2) == "not_installed" {
+	localTag := strings.TrimSpace(string(output2))
+	if localTag == "" {
+		// `docker images` prints nothing (and still exits 0) when the image is
+		// absent, so an empty result means it is not installed.
 		return "not_installed", nil
 	}
 
 	// Return the tag if image exists locally
-	return strings.TrimSpace(output2), nil
+	return localTag, nil
 }
 
-// checkVersionUpdates checks for version updates and displays comparison
+// checkVersionUpdates checks for version updates and displays comparison.
+//
+// Individual lookups stay best-effort — a service whose Docker Hub tag cannot be
+// read still gets a row, with "-" in the Latest column, because the Local vs
+// Compose comparison is what actually decides whether an update is needed and
+// that comes from the local daemon. An error is returned only when the local
+// lookup failed for every service examined: at that point nothing in the table
+// is grounded in the real state of the host, so the returned hasUpdates says
+// nothing, and the caller must not put a confirmation prompt in front of the
+// user based on it.
+//
+// This function used to return a literal nil on every path, which made the
+// caller's `if err != nil` fallback dead code and meant a completely unusable
+// docker daemon still produced a confident-looking "All services are up to date!".
 func checkVersionUpdates(services map[string]ServiceInfo) (bool, error) {
 	fmt.Println("🔍 Checking version updates...")
 	fmt.Println()
@@ -121,19 +152,28 @@ func checkVersionUpdates(services map[string]ServiceInfo) (bool, error) {
 	hasUpdates := false
 	updateInfo := make(map[string]map[string]string)
 
+	examined := 0
+	localFailures := 0
+	var firstLocalErr error
+
 	for serviceName, serviceInfo := range services {
-		// Extract image name and tag
-		parts := strings.Split(serviceInfo.Image, ":")
-		if len(parts) != 2 {
+		// Extract image name and tag. splitImageRef handles the cases a plain
+		// Split(":") gets wrong, such as a registry host that carries a port.
+		imageName, composeTag := splitImageRef(serviceInfo.Image)
+		if imageName == "" || composeTag == "" {
 			continue
 		}
-		imageName := parts[0]
-		composeTag := parts[1]
+
+		examined++
 
 		// Get current local version (pass serviceName to get actual running container's image)
 		currentVersion, err := getCurrentLocalVersion(imageName, composeTag, serviceName)
 		if err != nil {
 			currentVersion = "unknown"
+			localFailures++
+			if firstLocalErr == nil {
+				firstLocalErr = fmt.Errorf("%s: %w", serviceName, err)
+			}
 		}
 
 		// Check if the specific tag on Docker Hub has been updated
@@ -165,6 +205,13 @@ func checkVersionUpdates(services map[string]ServiceInfo) (bool, error) {
 		if currentVersion == "not_installed" || currentVersion != composeTag {
 			hasUpdates = true
 		}
+	}
+
+	// Every local lookup failed, so "Local" is "unknown" on every row and the
+	// hasUpdates it produced is an artefact of that, not a finding. Report it
+	// instead of letting the caller act on it.
+	if examined > 0 && localFailures == examined {
+		return false, fmt.Errorf("could not read the locally installed image version for any of the %d service(s); is the docker daemon reachable? (first failure — %w)", examined, firstLocalErr)
 	}
 
 	// Find the longest service name and version strings for proper table width
@@ -236,6 +283,14 @@ var updateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("\n[Update the Docker images of the subsystems that make up the Cloud-Migrator system.]")
 
+		// Resolve -s first so an unusable value stops the command before anything
+		// is pulled or restarted. An empty -s means "every service".
+		targets, err := resolveServices(ServiceName)
+		if err != nil {
+			fmt.Printf("⚠️ %v\n", err)
+			return
+		}
+
 		// Parse docker-compose.yaml to get actual image information
 		services, err := parseDockerComposeImages()
 		if err != nil {
@@ -243,18 +298,19 @@ var updateCmd = &cobra.Command{
 			fmt.Printf("🔄 Falling back to regular pull...\n")
 
 			// Fallback to regular pull without version check
-			convertedServiceName := convertServiceNameForDockerCompose(ServiceName)
-			cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s pull --ignore-pull-failures %s", ProjectName, DockerFilePath, convertedServiceName)
-			common.SysCall(cmdStr)
+			if err := runCompose(append([]string{"pull", "--ignore-pull-failures"}, targets...)...); err != nil {
+				fmt.Printf("❌ docker compose pull failed: %v\n", err)
+				return
+			}
 		} else {
-			// If specific service is requested, only check that service
-			if ServiceName != "" {
-				if serviceInfo, exists := services[ServiceName]; exists {
-					services = map[string]ServiceInfo{ServiceName: serviceInfo}
-				} else {
-					fmt.Printf("⚠️ Service %s not found in docker-compose.yaml\n", ServiceName)
-					return
+			// If specific services are requested, only check those. resolveServices
+			// has already confirmed every name exists.
+			if len(targets) > 0 {
+				selected := make(map[string]ServiceInfo, len(targets))
+				for _, name := range targets {
+					selected[name] = services[name]
 				}
+				services = selected
 			}
 
 			// Check for version updates
@@ -266,7 +322,7 @@ var updateCmd = &cobra.Command{
 				fmt.Println("✅ All services are up to date!")
 				fmt.Print("Do you want to proceed with pull and restart anyway? (y/N): ")
 				var response string
-				fmt.Scanln(&response)
+				_, _ = fmt.Scanln(&response)
 
 				if strings.ToLower(response) != "y" && strings.ToLower(response) != "yes" {
 					fmt.Println("❌ Update cancelled by user")
@@ -276,7 +332,7 @@ var updateCmd = &cobra.Command{
 				// Ask user for confirmation
 				fmt.Print("Do you want to proceed with the update? (y/N): ")
 				var response string
-				fmt.Scanln(&response)
+				_, _ = fmt.Scanln(&response)
 
 				if strings.ToLower(response) != "y" && strings.ToLower(response) != "yes" {
 					fmt.Println("❌ Update cancelled by user")
@@ -290,9 +346,10 @@ var updateCmd = &cobra.Command{
 			fmt.Println("\n[Install the latest Docker images of the Cloud-Migrator subsystems.]")
 			fmt.Println()
 
-			convertedServiceName := convertServiceNameForDockerCompose(ServiceName)
-			cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s pull --ignore-pull-failures %s", ProjectName, DockerFilePath, convertedServiceName)
-			common.SysCall(cmdStr)
+			if err := runCompose(append([]string{"pull", "--ignore-pull-failures"}, targets...)...); err != nil {
+				fmt.Printf("❌ docker compose pull failed: %v\n", err)
+				return
+			}
 		}
 
 		//============================
@@ -301,18 +358,39 @@ var updateCmd = &cobra.Command{
 		fmt.Println("\n\n[Restart based on the installed latest Docker images.]")
 		fmt.Println()
 
-		detachModeOption := ""
-		if DetachMode {
-			detachModeOption = "-d"
+		// Always bring the stack up detached, mirroring `infra run`. Running
+		// attached ties the stack's lifetime to this terminal, so a Ctrl-C
+		// meant to stop watching output tears the containers back down.
+		if err := runCompose(append([]string{"up", "-d"}, targets...)...); err != nil {
+			fmt.Printf("❌ docker compose up failed: %v\n", err)
+			return
 		}
-		convertedServiceName := convertServiceNameForDockerCompose(ServiceName)
-		cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s up %s %s", ProjectName, DockerFilePath, detachModeOption, convertedServiceName)
 
-		common.SysCall(cmdStr)
-
+		// Follow the logs unless the caller asked to stay detached.
+		if !UpdateDetachMode {
+			fmt.Println("\n[Showing container logs - Press Ctrl+C to stop viewing logs]")
+			fmt.Println()
+			if err := runCompose(append([]string{"logs", "-f"}, targets...)...); err != nil {
+				fmt.Printf("❌ docker compose logs failed: %v\n", err)
+			}
+		} else {
+			fmt.Println("\n📋 Log Commands:")
+			fmt.Println("  ./mayfly infra logs                    # View all service logs")
+			fmt.Println("  ./mayfly infra logs -s <service-name>  # View specific service logs")
+			fmt.Println("  ./mayfly infra info                    # Check system status")
+			fmt.Println()
+		}
 	},
 }
 
+// UpdateDetachMode keeps `infra update` from following logs after the stack is
+// up. It is registered on updateCmd because `-d` used to be declared only on
+// runCmd: `infra update -d` was rejected as an unknown flag while this code
+// still read the run command's variable, which was therefore always false.
+var UpdateDetachMode bool
+
 func init() {
 	dockerCmd.AddCommand(updateCmd)
+
+	updateCmd.Flags().BoolVarP(&UpdateDetachMode, "detach", "d", false, "Detached mode: Run containers in the background without showing logs")
 }

--- a/cmd/docker/update_test.go
+++ b/cmd/docker/update_test.go
@@ -1,0 +1,95 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// withStubbedPath puts dir at the front of PATH for one test, so a stub `docker`
+// executable is found instead of the real one.
+func withStubbedPath(t *testing.T, dir string) {
+	t.Helper()
+	prev := os.Getenv("PATH")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+prev)
+}
+
+// writeStubDocker installs a fake `docker` that exits with the given status.
+func writeStubDocker(t *testing.T, exitCode int) string {
+	t.Helper()
+	dir := t.TempDir()
+	body := "#!/bin/sh\nexit " + strconv.Itoa(exitCode) + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "docker"), []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// A failing `docker images` must be reported, not reported as "not_installed".
+//
+// The two are different states and the command exits 0 with empty output for a
+// genuinely absent image. Collapsing a broken daemon into "not_installed" made
+// the version table claim every image was missing, which reads to a user as
+// "everything needs updating".
+func TestGetCurrentLocalVersionReportsDockerFailure(t *testing.T) {
+	withStubbedPath(t, writeStubDocker(t, 1))
+	withComposeFile(t, "services:\n  cb-spider:\n    image: cloudbaristaorg/cb-spider:1.0.0\n")
+
+	_, err := getCurrentLocalVersion("cloudbaristaorg/cb-spider", "1.0.0", "cb-spider")
+	if err == nil {
+		t.Fatal("a failing `docker images` should be returned as an error, not swallowed as not_installed")
+	}
+	if !strings.Contains(err.Error(), "cb-spider") {
+		t.Errorf("error should name the image it failed on, got: %v", err)
+	}
+}
+
+// checkVersionUpdates must return an error when it could not read the local
+// version of a single service — its hasUpdates would otherwise be an artefact of
+// the failures rather than a finding, and the caller puts a confirmation prompt
+// in front of the user based on it.
+//
+// This is the branch that used to be unreachable: the function returned a
+// literal nil on every path, so the caller's `if err != nil` was dead code.
+func TestCheckVersionUpdatesReportsTotalLocalFailure(t *testing.T) {
+	withStubbedPath(t, writeStubDocker(t, 1))
+	withComposeFile(t, "services:\n  cb-spider:\n    image: cloudbaristaorg/cb-spider:1.0.0\n")
+
+	services := map[string]ServiceInfo{
+		"cb-spider":    {Image: "cloudbaristaorg/cb-spider:1.0.0"},
+		"cb-tumblebug": {Image: "cloudbaristaorg/cb-tumblebug:0.12.9"},
+	}
+
+	hasUpdates, err := checkVersionUpdates(services)
+	if err == nil {
+		t.Fatal("checkVersionUpdates should report an error when no local version could be read")
+	}
+	if hasUpdates {
+		t.Error("hasUpdates must be false when the check failed; a caller may not act on it")
+	}
+	if !strings.Contains(err.Error(), "docker daemon") {
+		t.Errorf("error should point at the likely cause, got: %v", err)
+	}
+}
+
+// Services with no parseable image reference are skipped rather than counted as
+// failures — otherwise a compose file full of build-only services would look
+// like a broken daemon.
+func TestCheckVersionUpdatesIgnoresServicesWithoutAnImageTag(t *testing.T) {
+	withStubbedPath(t, writeStubDocker(t, 1))
+	withComposeFile(t, "services:\n  local-build:\n    build: .\n")
+
+	// No service carries an image:tag, so nothing is examined and there is no
+	// failure to report.
+	hasUpdates, err := checkVersionUpdates(map[string]ServiceInfo{
+		"local-build": {Image: ""},
+	})
+	if err != nil {
+		t.Fatalf("nothing to examine should not be an error, got: %v", err)
+	}
+	if hasUpdates {
+		t.Error("hasUpdates should be false when no service was examined")
+	}
+}

--- a/cmd/k8s/README.md
+++ b/cmd/k8s/README.md
@@ -1,0 +1,36 @@
+# `mayfly k8s` (not built)
+
+This package holds a Helm-based Kubernetes deployment path for Cloud-Migrator —
+`run`, `stop`, `info`, `update` and `remove` against a chart instead of Docker
+Compose. It worked when it was written, but that was several years ago.
+
+It is not part of the CLI today. `main.go` does not import it (the import line is
+commented out), so `mayfly k8s` is an unknown command, and every file here now
+carries a `//go:build k8s` tag so the package is excluded from a normal build as
+well.
+
+## Why it is kept
+
+Kubernetes support is still planned. When it comes back it will most likely be
+rebuilt around the Kubernetes API rather than shelling out to `helm`, but the
+command layout, the flag set and the chart values in `conf/k8s/` are a useful
+starting point, and throwing them away would mean rediscovering decisions that
+were already made once.
+
+## Why it is not simply re-enabled
+
+Kubernetes has moved a long way since this code was last exercised: API versions
+have been removed, the Helm interface has changed, and the assumptions the
+commands make about cluster access have not been checked against a current
+cluster. Turning it back on would need re-verification and a fair amount of
+rework — it is not a matter of uncommenting the import.
+
+## Building it
+
+```sh
+go build -tags k8s ./...
+```
+
+The tag exists so the intent is visible in the code itself, and so the package
+is not compiled, linted, or security-scanned as if it were shipping. Restoring
+the import in `main.go` alone will not enable it.

--- a/cmd/k8s/info.go
+++ b/cmd/k8s/info.go
@@ -1,3 +1,5 @@
+//go:build k8s
+
 package k8s
 
 import (

--- a/cmd/k8s/remove.go
+++ b/cmd/k8s/remove.go
@@ -1,3 +1,5 @@
+//go:build k8s
+
 package k8s
 
 import (

--- a/cmd/k8s/root.go
+++ b/cmd/k8s/root.go
@@ -1,3 +1,5 @@
+//go:build k8s
+
 /*
 Copyright © 2024 NAME HERE <EMAIL ADDRESS>
 */

--- a/cmd/k8s/run.go
+++ b/cmd/k8s/run.go
@@ -1,3 +1,5 @@
+//go:build k8s
+
 package k8s
 
 import (

--- a/cmd/k8s/stop.go
+++ b/cmd/k8s/stop.go
@@ -1,3 +1,5 @@
+//go:build k8s
+
 package k8s
 
 import (

--- a/cmd/k8s/update.go
+++ b/cmd/k8s/update.go
@@ -1,3 +1,5 @@
+//go:build k8s
+
 package k8s
 
 import (

--- a/cmd/k8s/utility-k8s.go
+++ b/cmd/k8s/utility-k8s.go
@@ -1,3 +1,5 @@
+//go:build k8s
+
 package k8s
 
 var (

--- a/cmd/rest/delete.go
+++ b/cmd/rest/delete.go
@@ -4,8 +4,6 @@ Copyright © 2024 NAME HERE <EMAIL ADDRESS>
 package rest
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -19,19 +17,12 @@ var restDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 { // 아규먼트가 없으면 도움말 출력
 			//fmt.Println(cmd.Help())
-			cmd.Help()
+			_ = cmd.Help()
 			return
 		}
 
 		url := args[0]
-		resp, err := req.Delete(url)
-		if err != nil {
-			fmt.Println("Error:", err)
-			return
-		}
-
-		// 응답 출력
-		ProcessResultInfo(resp)
+		runRequest(url, req.Delete)
 	},
 }
 

--- a/cmd/rest/get.go
+++ b/cmd/rest/get.go
@@ -1,9 +1,6 @@
 package rest
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/spf13/cobra"
 )
 
@@ -29,21 +26,12 @@ var restGetCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 { // 아규먼트가 없으면 도움말 출력
 			//fmt.Println(cmd.Help())
-			cmd.Help()
+			_ = cmd.Help()
 			return
 		}
 
 		url := args[0]
-		resp, err := req.Get(url)
-		if err != nil {
-			fmt.Println("Error:", err)
-			os.Exit(1)
-			//return
-		}
-
-		// 응답 출력
-		ProcessResultInfo(resp)
-		ProcessOsExitcode(resp) // for docker compose healthy check
+		runRequest(url, req.Get)
 	},
 }
 

--- a/cmd/rest/patch.go
+++ b/cmd/rest/patch.go
@@ -4,8 +4,6 @@ Copyright © 2024 NAME HERE <EMAIL ADDRESS>
 package rest
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -23,19 +21,12 @@ var restPatchCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 { // 아규먼트가 없으면 도움말 출력
 			//fmt.Println(cmd.Help())
-			cmd.Help()
+			_ = cmd.Help()
 			return
 		}
 
 		url := args[0]
-		resp, err := req.Patch(url)
-		if err != nil {
-			fmt.Println("Error:", err)
-			return
-		}
-
-		// 응답 출력
-		ProcessResultInfo(resp)
+		runRequest(url, req.Patch)
 	},
 }
 

--- a/cmd/rest/post.go
+++ b/cmd/rest/post.go
@@ -4,8 +4,6 @@ Copyright © 2024 NAME HERE <EMAIL ADDRESS>
 package rest
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -26,19 +24,12 @@ var restPostCmd = &cobra.Command{
 		//fmt.Println("rest post called")
 		if len(args) < 1 { // 아규먼트가 없으면 도움말 출력
 			//fmt.Println(cmd.Help())
-			cmd.Help()
+			_ = cmd.Help()
 			return
 		}
 
 		url := args[0]
-		resp, err := req.Post(url)
-		if err != nil {
-			fmt.Println("Error:", err)
-			return
-		}
-
-		// 응답 출력
-		ProcessResultInfo(resp)
+		runRequest(url, req.Post)
 	},
 }
 

--- a/cmd/rest/put.go
+++ b/cmd/rest/put.go
@@ -4,8 +4,6 @@ Copyright © 2024 NAME HERE <EMAIL ADDRESS>
 package rest
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -23,19 +21,12 @@ var restPutCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 { // 아규먼트가 없으면 도움말 출력
 			//fmt.Println(cmd.Help())
-			cmd.Help()
+			_ = cmd.Help()
 			return
 		}
 
 		url := args[0]
-		resp, err := req.Put(url)
-		if err != nil {
-			fmt.Println("Error:", err)
-			return
-		}
-
-		// 응답 출력
-		ProcessResultInfo(resp)
+		runRequest(url, req.Put)
 	},
 }
 

--- a/cmd/rest/root.go
+++ b/cmd/rest/root.go
@@ -72,7 +72,7 @@ var restCmd = &cobra.Command{
 		//fmt.Println(cmd.UsageString())
 		//fmt.Println("============ REST 메인 호출됨!!!!  ")
 		//fmt.Println(cmd.Help())
-		cmd.Help() // root.go에서는 도움말만 출력 함.
+		_ = cmd.Help() // root.go에서는 도움말만 출력 함.
 	},
 
 	// PersistentPostRun: func(cmd *cobra.Command, args []string) {
@@ -84,7 +84,10 @@ func SetBasicAuth() {
 	if username != "" && password != "" {
 		if isVerbose {
 			fmt.Println("username : " + username)
-			fmt.Println("password : " + password)
+			// -v output ends up in scrollback, CI logs and redirected files, so
+			// the credential is reduced to a prefix: still enough to tell which
+			// password was picked up, not enough to reuse.
+			fmt.Println("password : " + common.MaskSecret(password))
 		}
 		client.SetBasicAuth(username, password)
 	}
@@ -100,7 +103,7 @@ func SetAuthToken() {
 
 	if authToken != "" {
 		if isVerbose {
-			fmt.Printf("sets the auth token of the `Authorization` header : [%s]\n", authToken)
+			fmt.Printf("sets the auth token of the `Authorization` header : [%s]\n", common.MaskSecret(authToken))
 		}
 		client.SetAuthToken(authToken)
 	}
@@ -136,7 +139,9 @@ func SetReqData() error {
 		}
 
 		// 파일에서 데이터 읽기
-		data, err := ioutil.ReadFile(inputFileData)
+		// Reading the file the operator names with the request-data flag is
+		// the feature itself; there is no directory this path should be confined to.
+		data, err := ioutil.ReadFile(inputFileData) // #nosec G304 -- operator-supplied request body file is the documented purpose of this flag
 		if err != nil {
 			return err
 		}
@@ -170,15 +175,47 @@ func ProcessResultInfo(resp *resty.Response) {
 	}
 }
 
+// exitCodeFor maps an HTTP status code to a process exit code.
+// Every 2xx is a success (201 Created and 204 No Content included), so it
+// returns 0. Anything else returns the first digit of the status code, which is
+// what docker-compose healthchecks have been relying on (3, 4 or 5).
+func exitCodeFor(statusCode int) int {
+	if statusCode >= 200 && statusCode <= 299 {
+		return 0
+	}
+	return statusCode / 100
+}
+
 // Handles OS exit code for docker-compose's healthy checks.
 func ProcessOsExitcode(resp *resty.Response) {
 	// Checking response status codes
-	if resp.StatusCode() != 200 {
+	if exitCode := exitCodeFor(resp.StatusCode()); exitCode != 0 {
 		if isVerbose {
-			fmt.Fprintf(os.Stderr, "Received non-200 response: %d\n", resp.StatusCode())
+			fmt.Fprintf(os.Stderr, "Received non-2xx response: %d\n", resp.StatusCode())
 		}
-		exitCode := resp.StatusCode() / 100 // First digit (2xx, 3xx, 4xx, 5xx)
-		os.Exit(exitCode)                   // One of 0, 3, 4, or 5
+		os.Exit(exitCode) // One of 1, 3, 4, or 5
+	}
+}
+
+// doRequest sends the request, prints the response and returns the exit code
+// the process should end with. It never exits by itself so it stays testable.
+func doRequest(url string, send func(string) (*resty.Response, error)) int {
+	resp, err := send(url)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return 1
+	}
+
+	// 응답 출력
+	ProcessResultInfo(resp)
+	return exitCodeFor(resp.StatusCode()) // for docker compose healthy check
+}
+
+// runRequest is the shared entry point of every rest verb so that a transport
+// error or a failing status code ends the process with a non-zero exit code.
+func runRequest(url string, send func(string) (*resty.Response, error)) {
+	if exitCode := doRequest(url, send); exitCode != 0 {
+		os.Exit(exitCode)
 	}
 }
 

--- a/cmd/rest/root_test.go
+++ b/cmd/rest/root_test.go
@@ -1,0 +1,102 @@
+package rest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-resty/resty/v2"
+)
+
+// sendFunc is the shape of every resty verb method (Get, Post, Put, Patch, Delete).
+type sendFunc func(string) (*resty.Response, error)
+
+// verbs returns a fresh request per verb so no state leaks between calls.
+func verbs() map[string]sendFunc {
+	return map[string]sendFunc{
+		"GET":    client.R().Get,
+		"POST":   client.R().Post,
+		"PUT":    client.R().Put,
+		"PATCH":  client.R().Patch,
+		"DELETE": client.R().Delete,
+	}
+}
+
+// A 2xx response means the call succeeded, so the process must exit with 0.
+// Anything else keeps reporting the first digit of the status code, which is
+// what the docker-compose healthchecks read.
+func TestExitCodeFor(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		expected int
+	}{
+		{"200 OK", http.StatusOK, 0},
+		{"201 Created", http.StatusCreated, 0},
+		{"202 Accepted", http.StatusAccepted, 0},
+		{"204 No Content", http.StatusNoContent, 0},
+		{"299 upper bound", 299, 0},
+		{"301 Moved Permanently", http.StatusMovedPermanently, 3},
+		{"400 Bad Request", http.StatusBadRequest, 4},
+		{"404 Not Found", http.StatusNotFound, 4},
+		{"500 Internal Server Error", http.StatusInternalServerError, 5},
+		{"503 Service Unavailable", http.StatusServiceUnavailable, 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := exitCodeFor(tt.status); got != tt.expected {
+				t.Errorf("exitCodeFor(%d) = %d, want %d", tt.status, got, tt.expected)
+			}
+		})
+	}
+}
+
+// Every verb, not only GET, has to report a failing status code through the
+// exit code. Before the fix POST/PUT/PATCH/DELETE always ended with 0, so a
+// script could not tell a failed call from a successful one.
+func TestDoRequestExitCodePerVerb(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		expected int
+	}{
+		{"created", http.StatusCreated, 0},
+		{"no content", http.StatusNoContent, 0},
+		{"not found", http.StatusNotFound, 4},
+		{"server error", http.StatusInternalServerError, 5},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(tt.status)
+		}))
+
+		for verb, send := range verbs() {
+			t.Run(tt.name+"/"+verb, func(t *testing.T) {
+				if got := doRequest(server.URL, send); got != tt.expected {
+					t.Errorf("doRequest(%s) with status %d = %d, want %d", verb, tt.status, got, tt.expected)
+				}
+			})
+		}
+
+		server.Close()
+	}
+}
+
+// A transport error (nothing listening on the address) must end with exit code
+// 1 for every verb rather than being printed and then swallowed.
+func TestDoRequestTransportErrorExitsNonZero(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := server.URL
+	server.Close() // nothing is listening on deadURL any more
+
+	for verb, send := range verbs() {
+		t.Run(verb, func(t *testing.T) {
+			if got := doRequest(deadURL, send); got != 1 {
+				t.Errorf("doRequest(%s) against a closed server = %d, want 1", verb, got)
+			}
+		})
+	}
+}

--- a/cmd/rest/verbose_secret_test.go
+++ b/cmd/rest/verbose_secret_test.go
@@ -1,0 +1,118 @@
+package rest
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureStdout collects everything fn prints.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var sb strings.Builder
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := r.Read(buf)
+			if n > 0 {
+				sb.Write(buf[:n])
+			}
+			if readErr != nil {
+				break
+			}
+		}
+		done <- sb.String()
+	}()
+	fn()
+	w.Close()
+	os.Stdout = orig
+	out := <-done
+	r.Close()
+	return out
+}
+
+const (
+	testPassword = "sup3r-secret-password"
+	testToken    = "eyJhbGciOiJIUzI1NiJ9.payload.signature"
+)
+
+// -v must not write the password into the terminal.
+//
+// `mayfly rest -v` is run to see how a call was assembled, and its output ends
+// up in scrollback, CI job logs and redirected files — all of which outlive the
+// debugging session by a long way. The username stays visible because it is not
+// a secret and it is half of what the user is trying to confirm.
+func TestSetBasicAuthVerboseDoesNotPrintPassword(t *testing.T) {
+	prevUser, prevPass, prevVerbose := username, password, isVerbose
+	t.Cleanup(func() { username, password, isVerbose = prevUser, prevPass, prevVerbose })
+
+	username, password, isVerbose = "admin", testPassword, true
+
+	out := captureStdout(t, SetBasicAuth)
+
+	if strings.Contains(out, testPassword) {
+		t.Errorf("-v printed the password verbatim:\n%s", out)
+	}
+	if !strings.Contains(out, "admin") {
+		t.Errorf("-v should still show the username, got:\n%s", out)
+	}
+	// A masked value is still shown, so the user can tell a password was picked
+	// up at all — hiding it entirely would make -v useless for this.
+	if !strings.Contains(out, "password :") {
+		t.Errorf("-v should still report the password field, got:\n%s", out)
+	}
+	if !strings.Contains(out, "***") {
+		t.Errorf("-v should show a masked value, got:\n%s", out)
+	}
+}
+
+// The same applies to the bearer token, which is if anything more sensitive —
+// it is a ready-to-use credential rather than one factor of a login.
+func TestSetAuthTokenVerboseDoesNotPrintToken(t *testing.T) {
+	prevToken, prevScheme, prevVerbose := authToken, authScheme, isVerbose
+	t.Cleanup(func() { authToken, authScheme, isVerbose = prevToken, prevScheme, prevVerbose })
+
+	authToken, authScheme, isVerbose = testToken, "Bearer", true
+
+	out := captureStdout(t, SetAuthToken)
+
+	if strings.Contains(out, testToken) {
+		t.Errorf("-v printed the auth token verbatim:\n%s", out)
+	}
+	// The signature is the part that must never appear, even if a prefix does.
+	if strings.Contains(out, "signature") {
+		t.Errorf("-v leaked the token signature:\n%s", out)
+	}
+	if !strings.Contains(out, "***") {
+		t.Errorf("-v should show a masked token, got:\n%s", out)
+	}
+	// The scheme is not a secret and is worth seeing.
+	if !strings.Contains(out, "Bearer") {
+		t.Errorf("-v should still show the auth scheme, got:\n%s", out)
+	}
+}
+
+// Without -v nothing is printed at all.
+func TestQuietModePrintsNothing(t *testing.T) {
+	prevUser, prevPass, prevToken, prevVerbose := username, password, authToken, isVerbose
+	t.Cleanup(func() {
+		username, password, authToken, isVerbose = prevUser, prevPass, prevToken, prevVerbose
+	})
+
+	username, password, authToken, isVerbose = "admin", testPassword, testToken, false
+
+	out := captureStdout(t, func() {
+		SetBasicAuth()
+		SetAuthToken()
+	})
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("without -v nothing should be printed, got:\n%s", out)
+	}
+}

--- a/cmd/setup/credential.go
+++ b/cmd/setup/credential.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
 	"os"
 	"sort"
@@ -51,12 +50,12 @@ const (
 	AVAILABLE_CSP_LIST_URL      = "/provider"
 	GET_CSP_CREDENTIAL_META_URL = "/forward/cloudos/metainfo/"
 
-	GET_PUBLICKEY_URL   = "/credential/publicKey"
+	GET_PUBLICKEY_URL = "/credential/publicKey"
+	// #nosec G101 -- a REST path on the tumblebug API, not a credential value
 	POST_CREDENTIAL_URL = "/credential"
 )
 
-var client = resty.New()
-var req = client.R()
+var client = common.NewHTTPClient()
 
 var host string
 var port string
@@ -92,13 +91,38 @@ type Auth struct {
 
 var serviceInfo ServiceInfo
 
+// 사용자가 -H로 전달한 헤더를 요청에 반영
+func setHeaders(r *resty.Request) *resty.Request {
+	for _, h := range headers {
+		headerParts := strings.SplitN(h, ":", 2)
+		if len(headerParts) != 2 {
+			fmt.Println("Invalid header format:", h)
+			continue
+		}
+		r.Header.Set(strings.TrimSpace(headerParts[0]), strings.TrimSpace(headerParts[1]))
+		if isVerbose {
+			fmt.Printf("%s : %s\n", strings.TrimSpace(headerParts[0]), strings.TrimSpace(headerParts[1]))
+		}
+	}
+	return r
+}
+
+// newRequest는 호출마다 새 요청을 만든다.
+// 하나의 요청을 재사용하면 앞선 호출에서 설정한 body 같은 상태가 다음 호출에 그대로 남는다.
+func newRequest() *resty.Request {
+	return setHeaders(client.R())
+}
+
 func SetBasicAuth() {
 	// Set basic authentication
 	if serviceInfo.Auth.Username != "" && serviceInfo.Auth.Password != "" {
 		if isVerbose {
 			fmt.Println("setting basic auth")
 			fmt.Println("username : " + serviceInfo.Auth.Username)
-			fmt.Println("password : " + serviceInfo.Auth.Password)
+			// Masked: -v here is about confirming which credential was picked
+			// up, which a prefix answers without writing the password itself
+			// into the terminal history.
+			fmt.Println("password : " + common.MaskSecret(serviceInfo.Auth.Password))
 		}
 		client.SetBasicAuth(serviceInfo.Auth.Username, serviceInfo.Auth.Password)
 	}
@@ -161,8 +185,13 @@ func checkServiceInfo() error {
 	}
 
 	// 사용자 입력 host, port로 BaseURL 정보 업데이트
+	// The override only fails when the configured BaseURL cannot be parsed. That
+	// used to pass unnoticed and the request went to the unmodified address, so
+	// warn instead — the printed BaseURL below then explains where it really went.
 	if host != "" || port != "" {
-		updateBaseURL(&serviceInfo.BaseURL, host, port)
+		if err := updateBaseURL(&serviceInfo.BaseURL, host, port); err != nil {
+			fmt.Printf("Warning: could not apply the host/port override to %s: %v\n", serviceInfo.BaseURL, err)
+		}
 	}
 
 	SetAuth()
@@ -204,7 +233,7 @@ func getCspList() ([]string, error) {
 	}
 
 	//resp, err := client2.R().Get(url)
-	resp, err := req.Get(url)
+	resp, err := newRequest().Get(url)
 	if err != nil {
 		fmt.Println("Error:", err)
 		return nil, fmt.Errorf("Error: %v", err)
@@ -309,9 +338,7 @@ func getCredentialsMeta(csp string) ([]string, error) {
 		fmt.Println("Request Url : ", url)
 	}
 
-	req.SetBody("{}")
-
-	resp, err := req.Post(url)
+	resp, err := newRequest().SetBody("{}").Post(url)
 	if err != nil {
 		fmt.Println("Error:", err)
 		return nil, fmt.Errorf("Error: %v", err)
@@ -457,6 +484,8 @@ func inputCredentialsFromCli(credentialMeta []string) (map[string]string, error)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting terminal state: %v", err)
 	}
+	// 입력 도중 오류로 빠져나가더라도 터미널의 echo가 꺼진 채 남지 않도록 함
+	defer func() { _ = term.Restore(int(syscall.Stdin), oldState) }()
 
 	for {
 		// ================================
@@ -542,7 +571,7 @@ func getPublicKey() (*PublicKeyResponse, error) {
 		fmt.Println("Request Url : ", url)
 	}
 
-	resp, err := req.Get(url)
+	resp, err := newRequest().Get(url)
 	if err != nil {
 		fmt.Println("Error:", err)
 		return nil, fmt.Errorf("Error: %v", err)
@@ -563,9 +592,12 @@ func getPublicKey() (*PublicKeyResponse, error) {
 }
 
 // PKCS7 패딩 추가 함수
+// The only caller passes aes.BlockSize() (16), so padding lands in 1..16 and
+// always fits a byte — which PKCS#7 requires anyway, being undefined for block
+// sizes of 256 or more.
 func pkcs7Pad(data []byte, blockSize int) []byte {
 	padding := blockSize - len(data)%blockSize
-	padText := bytes.Repeat([]byte{byte(padding)}, padding)
+	padText := bytes.Repeat([]byte{byte(padding)}, padding) // #nosec G115 -- padding is 1..blockSize (16 here), always within byte range
 	return append(data, padText...)
 }
 
@@ -637,93 +669,51 @@ func encryptCredentialsWithPublicKey(publicKeyPem string, credentials map[string
 func sendCredentials(payload map[string]interface{}) (map[string]interface{}, error) {
 	fmt.Println("Sending encrypted credentials to server")
 
-	// POST_CREDENTIAL_URL = "/credential"
-
-	client := &http.Client{}
-	reqBody, _ := json.Marshal(payload)
-	req, err := http.NewRequest("POST", "http://localhost:1323/tumblebug/credential", bytes.NewBuffer(reqBody))
-	if err != nil {
-		panic(err)
+	// 다른 호출들과 마찬가지로 --host/--port/--user/--password로 해석된 정보를 사용한다.
+	// 그래야 한 대의 서버에서 여러 서버의 Tumblebug을 초기화할 수 있다.
+	// (기본값은 그대로 http://localhost:1323/tumblebug)
+	url := serviceInfo.BaseURL + POST_CREDENTIAL_URL
+	if isVerbose {
+		fmt.Println("Request Url : ", url)
 	}
 
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Basic ZGVmYXVsdDpkZWZhdWx0")
-
-	resp, err := client.Do(req)
+	// payload를 JSON으로 변환
+	reqBody, err := json.Marshal(payload)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("Error marshalling payload: %v", err)
 	}
-	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
-	fmt.Println(string(body))
+	resp, err := newRequest().
+		SetHeader("Content-Type", "application/json").
+		SetBody(reqBody).
+		Post(url)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return nil, fmt.Errorf("Error: %v", err)
+	}
 
-	return nil, nil
-	/*
-		if isVerbose {
-			fmt.Println("Request payload")
-			// Print the payload in a pretty-printed JSON format
-			payloadJSON, err := json.MarshalIndent(payload, "", "  ")
-			if err != nil {
-				panic(err)
-			}
+	// 응답 결과 확인
+	body := resp.Body() // []byte 타입
+	if isVerbose {
+		fmt.Println(string(body))
+	}
 
-			fmt.Println("Payload:")
-			fmt.Println(string(payloadJSON)) // 출력
-		}
+	// 2xx가 아니면 등록에 실패한 것이므로 응답 본문과 함께 오류를 반환
+	if resp.StatusCode() < 200 || resp.StatusCode() > 299 {
+		return nil, fmt.Errorf("credential registration failed with status %d: %s", resp.StatusCode(), strings.TrimSpace(string(body)))
+	}
 
-		url := serviceInfo.BaseURL + POST_CREDENTIAL_URL
-		if isVerbose {
-			fmt.Println("Request Url : ", url)
-		}
+	// 응답 결과를 처리하여 리턴 타입에 맞게 반환
+	var result map[string]interface{}
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing JSON: %v", err)
+	}
 
-		// payload를 JSON으로 변환
-		reqBody, err := json.Marshal(payload)
-		if err != nil {
-			return nil, fmt.Errorf("Error marshalling payload: %v", err)
-		}
+	// CSP Credential 정보 등록 완료 메시지 출력
+	fmt.Println("CSP Credential registration completed successfully")
 
-		// HTTP 요청 생성
-		req.SetHeader("Content-Type", "application/json")
-		resp, err := req.SetBody(reqBody).Post(url)
-		if err != nil {
-			fmt.Println("Error:", err)
-			return nil, fmt.Errorf("Error: %v", err)
-		}
-
-		// 응답 결과 확인
-		body := resp.Body() // []byte 타입
-		if isVerbose {
-			fmt.Println(string(body))
-		}
-
-		if isVerbose {
-			fmt.Println(string(body))
-		}
-
-		// 응답 결과를 처리하여 리턴 타입에 맞게 반환
-		var result map[string]interface{}
-		err = json.Unmarshal(body, &result)
-		if err != nil {
-			return nil, fmt.Errorf("Error parsing JSON: %v", err)
-		}
-
-		if isVerbose {
-			fmt.Println("Response:")
-			// Print the response in a pretty-printed JSON format
-			responseJSON, err := json.MarshalIndent(result, "", "  ")
-			if err != nil {
-				panic(err)
-			}
-
-			fmt.Println(string(responseJSON)) // 출력
-		}
-
-		// CSP Credential 정보 등록 완료 메시지 출력
-		fmt.Println("CSP Credential registration completed successfully")
-	*/
-
-	//return result, nil
+	return result, nil
 }
 
 var credentialCmd = &cobra.Command{
@@ -738,7 +728,7 @@ var credentialCmd = &cobra.Command{
 		// 서브 커맨드가 입력되었을 때에는 도움말을 출력하지 않음.
 		if len(args) == 0 && cmd.Flags().NFlag() == 0 && cmd.HasSubCommands() {
 			//fmt.Println(cmd.Help())
-			cmd.Help()
+			_ = cmd.Help()
 			return
 		}
 

--- a/cmd/setup/credential_test.go
+++ b/cmd/setup/credential_test.go
@@ -1,0 +1,199 @@
+package setup
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// samplePayload is the shape processCspCredentialEncrypt builds.
+func samplePayload() map[string]interface{} {
+	return map[string]interface{}{
+		"credentialHolder": "admin",
+		"providerName":     "aws",
+	}
+}
+
+// hostPortOf splits an httptest server URL into its host and port.
+func hostPortOf(t *testing.T, rawURL string) (string, string) {
+	t.Helper()
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parsing test server URL: %v", err)
+	}
+	return parsed.Hostname(), parsed.Port()
+}
+
+// --host/--port must move the credential registration call off the default
+// localhost:1323, so one machine can initialise the Tumblebug of another.
+func TestUpdateBaseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseURL  string
+		host     string
+		port     string
+		expected string
+	}{
+		{"host and port", "http://localhost:1323/tumblebug", "10.0.0.5", "8080", "http://10.0.0.5:8080/tumblebug"},
+		{"host only", "http://localhost:1323/tumblebug", "10.0.0.5", "", "http://10.0.0.5:1323/tumblebug"},
+		{"port only", "http://localhost:1323/tumblebug", "", "8080", "http://localhost:8080/tumblebug"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseURL := tt.baseURL
+			if err := updateBaseURL(&baseURL, tt.host, tt.port); err != nil {
+				t.Fatalf("updateBaseURL returned error: %v", err)
+			}
+			if baseURL != tt.expected {
+				t.Errorf("updateBaseURL = %q, want %q", baseURL, tt.expected)
+			}
+		})
+	}
+}
+
+// The registration POST used to be hardwired to http://localhost:1323 with a
+// hardcoded default:default header. It must now follow the resolved base URL
+// and credentials like every other call in this file.
+func TestSendCredentialsUsesConfiguredHostAndAuth(t *testing.T) {
+	var gotPath, gotMethod, gotAuth, gotContentType, gotCustomHeader string
+	var gotBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+		gotCustomHeader = r.Header.Get("X-Test-Header")
+
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"message":"registered"}`))
+	}))
+	defer server.Close()
+
+	testHost, testPort := hostPortOf(t, server.URL)
+
+	// start from the api.yaml default and apply --host/--port like the command does
+	serviceInfo = ServiceInfo{BaseURL: "http://localhost:1323/tumblebug"}
+	if err := updateBaseURL(&serviceInfo.BaseURL, testHost, testPort); err != nil {
+		t.Fatalf("updateBaseURL returned error: %v", err)
+	}
+
+	// --user/--password and -H are resolved the same way as for the other calls
+	serviceInfo.Auth = Auth{Type: "basic", Username: "tester", Password: "secret"}
+	SetAuth()
+	headers = []string{"X-Test-Header: from-flag"}
+	defer func() { headers = nil }()
+
+	result, err := sendCredentials(samplePayload())
+	if err != nil {
+		t.Fatalf("sendCredentials returned error: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %s, want POST", gotMethod)
+	}
+	if gotPath != "/tumblebug"+POST_CREDENTIAL_URL {
+		t.Errorf("path = %q, want %q", gotPath, "/tumblebug"+POST_CREDENTIAL_URL)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotContentType)
+	}
+	if gotCustomHeader != "from-flag" {
+		t.Errorf("X-Test-Header = %q, want the value passed with -H", gotCustomHeader)
+	}
+
+	// The registration call used to carry a fixed default:default header no
+	// matter what the caller configured. Encode it here rather than spelling
+	// the base64 out, so the check reads as "the built-in pair" instead of an
+	// opaque string.
+	builtInPair := base64.StdEncoding.EncodeToString([]byte("default:default"))
+	if strings.Contains(gotAuth, builtInPair) {
+		t.Errorf("Authorization = %q, want the credentials resolved from the flags", gotAuth)
+	}
+	if gotAuth == "" {
+		t.Error("Authorization header was not sent")
+	}
+
+	if gotBody["providerName"] != "aws" {
+		t.Errorf("payload providerName = %v, want aws", gotBody["providerName"])
+	}
+	if result["message"] != "registered" {
+		t.Errorf("result = %v, want the parsed response body", result)
+	}
+}
+
+// A non-2xx response used to look exactly like a success. It has to be reported
+// as a failure, with the response body kept for diagnosis.
+func TestSendCredentialsFailsOnNon2xx(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{"unauthorized", http.StatusUnauthorized, `{"message":"invalid credentials"}`},
+		{"server error", http.StatusInternalServerError, `{"message":"boom"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			serviceInfo = ServiceInfo{BaseURL: server.URL}
+
+			result, err := sendCredentials(samplePayload())
+			if err == nil {
+				t.Fatalf("sendCredentials returned no error for status %d", tt.status)
+			}
+			if result != nil {
+				t.Errorf("result = %v, want nil on failure", result)
+			}
+			if !strings.Contains(err.Error(), tt.body) {
+				t.Errorf("error = %q, want it to carry the response body %q", err, tt.body)
+			}
+		})
+	}
+}
+
+// A transport error must be returned, not raised as a panic with a Go stack
+// trace in the user's face.
+func TestSendCredentialsReturnsErrorInsteadOfPanic(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := server.URL
+	server.Close() // nothing is listening any more
+
+	serviceInfo = ServiceInfo{BaseURL: deadURL}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("sendCredentials panicked: %v", r)
+		}
+	}()
+
+	if _, err := sendCredentials(samplePayload()); err == nil {
+		t.Error("sendCredentials returned no error for an unreachable server")
+	}
+}
+
+// Each call builds its own request so a body set by one call cannot leak into
+// the next one.
+func TestNewRequestDoesNotShareState(t *testing.T) {
+	first := newRequest()
+	first.SetBody("{}")
+
+	if second := newRequest(); second.Body != nil {
+		t.Errorf("a freshly built request already carries a body: %v", second.Body)
+	}
+}

--- a/cmd/setup/root.go
+++ b/cmd/setup/root.go
@@ -18,7 +18,7 @@ var setupCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		//fmt.Println(cmd.UsageString())
 		//fmt.Println(cmd.Help())
-		cmd.Help()
+		_ = cmd.Help()
 	},
 }
 

--- a/cmd/setup/tumblebug_init.go
+++ b/cmd/setup/tumblebug_init.go
@@ -112,8 +112,12 @@ func runTumblebugInit() {
 	err = downloadAndInitTumblebug(version, originalDir)
 	if err != nil {
 		fmt.Printf("Error during Tumblebug initialization: %v\n", err)
-		// Return to original directory even on error
-		os.Chdir(originalDir)
+		// Return to original directory even on error. The initialization error
+		// above is the one worth reporting, so a failure to change back is
+		// noted but does not replace it.
+		if cderr := os.Chdir(originalDir); cderr != nil {
+			fmt.Printf("Warning: Could not return to original directory: %v\n", cderr)
+		}
 		return
 	}
 
@@ -128,12 +132,21 @@ func runTumblebugInit() {
 	fmt.Println("\nCB-Tumblebug initialization completed.")
 }
 
+// composePsJSON runs `docker compose ps --format json` for the cloud-migrator
+// project and returns its stdout. The project name used to be prefixed onto a
+// `/bin/sh -c` string; it is passed through the child environment instead, so
+// the compose file path never reaches a shell that could reinterpret it.
+func composePsJSON() ([]byte, error) {
+	return common.RunCommandOutput(
+		"docker",
+		[]string{"compose", "-f", common.DefaultDockerComposeConfig, "ps", "--format", "json"},
+		[]string{"COMPOSE_PROJECT_NAME=" + common.ComposeProjectName},
+	)
+}
+
 // isTumblebugRunning checks if CB-Tumblebug container is running
 func isTumblebugRunning() bool {
-	cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s ps --format json", common.ComposeProjectName, common.DefaultDockerComposeConfig)
-	cmd := exec.Command("/bin/sh", "-c", cmdStr)
-
-	output, err := cmd.Output()
+	output, err := composePsJSON()
 	if err != nil {
 		return false
 	}
@@ -151,10 +164,7 @@ func isTumblebugRunning() bool {
 
 // isTumblebugHealthy checks if CB-Tumblebug container is healthy
 func isTumblebugHealthy() bool {
-	cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s ps --format json", common.ComposeProjectName, common.DefaultDockerComposeConfig)
-	cmd := exec.Command("/bin/sh", "-c", cmdStr)
-
-	output, err := cmd.Output()
+	output, err := composePsJSON()
 	if err != nil {
 		return false
 	}
@@ -170,39 +180,22 @@ func isTumblebugHealthy() bool {
 	return false
 }
 
-// getExistingTumblebugVersion gets the version of existing cb-tumblebug directory
+// getExistingTumblebugVersion gets the version of existing cb-tumblebug directory.
+//
+// It reports the release tag HEAD sits on, or the bare commit hash when HEAD is
+// not on a tag — the caller shows either to the user and compares it against the
+// wanted tag. The detection itself lives in common.GitCheckoutVersion so that
+// this flow and the unattended OpenBao initialization path read a checkout the
+// same way (notably the --tags rule, which cb-tumblebug's lightweight release
+// tags depend on).
 func getExistingTumblebugVersion(cbTumblebugDir string) (string, error) {
-	// Check if it's a git repository
-	gitDir := filepath.Join(cbTumblebugDir, ".git")
-	if _, err := os.Stat(gitDir); os.IsNotExist(err) {
-		return "", fmt.Errorf("not a git repository")
-	}
-
-	// Get current HEAD commit hash
-	cmdStr := fmt.Sprintf("cd %s && git rev-parse HEAD", cbTumblebugDir)
-	cmd := exec.Command("/bin/sh", "-c", cmdStr)
-
-	output, err := cmd.Output()
+	tag, commit, err := common.GitCheckoutVersion(cbTumblebugDir)
 	if err != nil {
 		return "", err
 	}
-
-	currentCommit := strings.TrimSpace(string(output))
-	if currentCommit == "" {
-		return "", fmt.Errorf("unable to get current commit")
+	if tag == "" {
+		return commit, nil
 	}
-
-	// Get the tag that the current HEAD is pointing to (exact match)
-	cmdStr = fmt.Sprintf("cd %s && git describe --exact-match HEAD 2>/dev/null", cbTumblebugDir)
-	cmd = exec.Command("/bin/sh", "-c", cmdStr)
-
-	output, err = cmd.Output()
-	if err != nil {
-		// If no exact tag match, return the commit hash to indicate it's not on a tag
-		return currentCommit, nil
-	}
-
-	tag := strings.TrimSpace(string(output))
 	return tag, nil
 }
 
@@ -296,10 +289,7 @@ func getCurrentTumblebugVersion() (string, error) {
 
 // getVersionFromDockerCompose gets version from running docker compose ps
 func getVersionFromDockerCompose() (string, error) {
-	cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s ps --format json", common.ComposeProjectName, common.DefaultDockerComposeConfig)
-	cmd := exec.Command("/bin/sh", "-c", cmdStr)
-
-	output, err := cmd.Output()
+	output, err := composePsJSON()
 	if err != nil {
 		return "", err
 	}
@@ -349,20 +339,23 @@ func downloadAndInitTumblebug(version, originalDir string) error {
 	// Convert version to GitHub tag format (add 'v' prefix)
 	gitTag := "v" + version
 
-	// Create target directory
-	targetDir := filepath.Join(os.Getenv("HOME"), "go", "src", "github.com", "cloud-barista")
-	cbTumblebugDir := filepath.Join(targetDir, "cb-tumblebug")
+	// Create target directory. Both paths are built from $HOME plus fixed
+	// segments — no flag or argument contributes to them — and Clean resolves
+	// the result before it reaches any file operation.
+	targetDir := filepath.Clean(filepath.Join(os.Getenv("HOME"), "go", "src", "github.com", "cloud-barista"))
+	cbTumblebugDir := filepath.Clean(filepath.Join(targetDir, "cb-tumblebug"))
 
 	fmt.Printf("Downloading CB-Tumblebug %s version from GitHub...\n", gitTag)
 	fmt.Printf("Target directory: %s\n", cbTumblebugDir)
 
 	// Check if directory already exists
-	if _, err := os.Stat(cbTumblebugDir); err == nil {
+	if _, err := os.Stat(cbTumblebugDir); err == nil { // #nosec G703 -- $HOME plus fixed segments, cleaned above
 		return handleExistingDirectory(cbTumblebugDir, gitTag, targetDir, originalDir)
 	}
 
-	// Create directory structure
-	err := os.MkdirAll(targetDir, 0755)
+	// Create directory structure. 0750 rather than 0755: only the operator who
+	// runs mayfly reads this checkout.
+	err := os.MkdirAll(targetDir, 0750) // #nosec G703 -- $HOME plus fixed segments, cleaned above
 	if err != nil {
 		return fmt.Errorf("failed to create target directory: %v", err)
 	}
@@ -374,10 +367,10 @@ func downloadAndInitTumblebug(version, originalDir string) error {
 	}
 
 	// Clone the repository with specific tag
-	cloneCmd := fmt.Sprintf("git clone -b %s https://github.com/cloud-barista/cb-tumblebug.git", gitTag)
-	fmt.Printf("Executing command: %s\n", cloneCmd)
+	cloneArgs := []string{"clone", "-b", gitTag, "https://github.com/cloud-barista/cb-tumblebug.git"}
+	fmt.Printf("Executing command: git %s\n", strings.Join(cloneArgs, " "))
 
-	err = common.SysCallWithError(cloneCmd)
+	err = common.RunCommand("git", cloneArgs, nil)
 	if err != nil {
 		return fmt.Errorf("failed to clone repository: %v", err)
 	}
@@ -400,9 +393,15 @@ func handleExistingDirectory(cbTumblebugDir, gitTag, targetDir, originalDir stri
 
 	// Check if the existing version is exactly the same as the running version
 	if existingVersion == gitTag {
-		// Same version and on the correct tag
-		fmt.Printf("Same version of Tumblebug (%s) already exists and is correctly checked out in %s folder.\n", gitTag, cbTumblebugDir)
-		return showMenuAndHandleChoice(cbTumblebugDir, gitTag, targetDir, originalDir, existingVersion, false)
+		// Same version and on the correct tag: nothing to decide. The source is
+		// already what this run needs, so asking the user to choose between
+		// "download fresh" and "use existing" only adds a prompt to the normal
+		// path. `infra run` clones the same tag on demand during OpenBao
+		// initialization, so a matching checkout is the common case rather than
+		// the exception.
+		fmt.Printf("Same version of Tumblebug (%s) is already checked out in %s folder. Using it.\n", gitTag, cbTumblebugDir)
+		fmt.Printf("\nExecuting cb-tumblebug in %s folder...\n", cbTumblebugDir)
+		return initializeTumblebug(cbTumblebugDir, originalDir)
 	} else {
 		// Different version or not on the correct tag
 		fmt.Printf("Different version of Tumblebug found in %s folder.\n", cbTumblebugDir)
@@ -422,15 +421,7 @@ func handleExistingDirectory(cbTumblebugDir, gitTag, targetDir, originalDir stri
 
 // isTagExistsInRepo checks if a specific tag exists in the repository
 func isTagExistsInRepo(cbTumblebugDir, gitTag string) bool {
-	cmdStr := fmt.Sprintf("cd %s && git tag -l %s", cbTumblebugDir, gitTag)
-	cmd := exec.Command("/bin/sh", "-c", cmdStr)
-
-	output, err := cmd.Output()
-	if err != nil {
-		return false
-	}
-
-	return strings.TrimSpace(string(output)) == gitTag
+	return common.GitTagExists(cbTumblebugDir, gitTag)
 }
 
 // showMenuAndHandleChoice shows menu and handles user choice
@@ -505,10 +496,7 @@ func showMenuAndHandleChoice(cbTumblebugDir, gitTag, targetDir, originalDir, exi
 func switchToVersion(cbTumblebugDir, gitTag string) error {
 	fmt.Printf("Switching to version %s...\n", gitTag)
 
-	cmdStr := fmt.Sprintf("cd %s && git checkout %s", cbTumblebugDir, gitTag)
-	cmd := exec.Command("/bin/sh", "-c", cmdStr)
-
-	output, err := cmd.Output()
+	output, err := common.GitOutputInDir(cbTumblebugDir, "checkout", gitTag)
 	if err != nil {
 		return fmt.Errorf("failed to checkout version %s: %v", gitTag, err)
 	}
@@ -518,10 +506,36 @@ func switchToVersion(cbTumblebugDir, gitTag string) error {
 	return nil
 }
 
+// assertUnderCheckoutRoot reports whether target sits strictly inside root.
+// The recursive delete below is the one irreversible step in this file, so the
+// path it is handed is checked against the directory it is supposed to live in
+// rather than trusted because of how it was built.
+func assertUnderCheckoutRoot(root, target string) error {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return fmt.Errorf("failed to resolve the checkout directory %s: %w", root, err)
+	}
+	absTarget, err := filepath.Abs(target)
+	if err != nil {
+		return fmt.Errorf("failed to resolve the removal target %s: %w", target, err)
+	}
+	rel, err := filepath.Rel(absRoot, absTarget)
+	if err != nil {
+		return fmt.Errorf("failed to compare %s against %s: %w", absTarget, absRoot, err)
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("refusing to remove %s: it lies outside %s", absTarget, absRoot)
+	}
+	return nil
+}
+
 // removeAndDownloadFresh removes existing directory and downloads fresh copy
 func removeAndDownloadFresh(cbTumblebugDir, gitTag, targetDir, originalDir string) error {
 	// Remove existing directory
-	err := os.RemoveAll(cbTumblebugDir)
+	if err := assertUnderCheckoutRoot(targetDir, cbTumblebugDir); err != nil {
+		return err
+	}
+	err := os.RemoveAll(cbTumblebugDir) // #nosec G703 -- checked to be inside targetDir just above
 	if err != nil {
 		return fmt.Errorf("failed to remove existing directory: %v", err)
 	}
@@ -533,10 +547,10 @@ func removeAndDownloadFresh(cbTumblebugDir, gitTag, targetDir, originalDir strin
 	}
 
 	// Clone fresh copy
-	cloneCmd := fmt.Sprintf("git clone -b %s https://github.com/cloud-barista/cb-tumblebug.git", gitTag)
-	fmt.Printf("Executing command: %s\n", cloneCmd)
+	cloneArgs := []string{"clone", "-b", gitTag, "https://github.com/cloud-barista/cb-tumblebug.git"}
+	fmt.Printf("Executing command: git %s\n", strings.Join(cloneArgs, " "))
 
-	err = common.SysCallWithError(cloneCmd)
+	err = common.RunCommand("git", cloneArgs, nil)
 	if err != nil {
 		return fmt.Errorf("failed to clone repository: %v", err)
 	}
@@ -564,11 +578,14 @@ func initializeTumblebug(cbTumblebugDir, originalDir string) error {
 	// token from its own container env rather than from mayfly's .env. There
 	// is nothing here that consumes ENV_FILE anymore — openbao-init.sh still
 	// takes it, but internal/openbao.Init() passes it directly.
-	script := fmt.Sprintf(`#!/bin/bash
+	// The script carries no interpolated paths. It used to start with
+	// `cd "<cbTumblebugDir>"`, and that path is built from $HOME — a shell
+	// re-parses whatever it holds, and double quotes stop word splitting but not
+	// command substitution. The directory is now set on the child process
+	// instead (cmd.Dir below), so nothing outside this literal reaches the
+	// shell.
+	script := `#!/bin/bash
 set -e
-
-# Change to cb-tumblebug directory
-cd "%s"
 
 echo "Current location: $(pwd)"
 
@@ -619,21 +636,40 @@ else
 fi
 
 echo "CB-Tumblebug initialization completed."
-`, cbTumblebugDir)
+`
 
-	// Write script to temporary file
-	tmpScript := filepath.Join(os.TempDir(), "tumblebug_init.sh")
-	err := os.WriteFile(tmpScript, []byte(script), 0755)
+	// Write the script to a temporary file.
+	//
+	// The name used to be a fixed /tmp/tumblebug_init.sh. /tmp is world-writable,
+	// os.WriteFile follows a symlink it finds at that path, and the file is
+	// executed moments after being written — so any other local user could have
+	// pre-created the name or swapped the contents in between. os.CreateTemp
+	// picks a name nobody can predict and creates it exclusively; 0700 keeps the
+	// script readable and runnable by its owner only.
+	tmpFile, err := os.CreateTemp("", "tumblebug_init-*.sh")
 	if err != nil {
 		return fmt.Errorf("failed to create temporary script: %v", err)
 	}
+	tmpScript := tmpFile.Name()
 	defer os.Remove(tmpScript)
+	if _, err := tmpFile.Write([]byte(script)); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("failed to write temporary script: %v", err)
+	}
+	if err := tmpFile.Chmod(0700); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("failed to set permissions on temporary script: %v", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temporary script: %v", err)
+	}
 
 	// Execute the script in a new shell with proper stdin/stdout/stderr handling
 	fmt.Println("Executing Tumblebug initialization in separate shell...")
 	fmt.Println("Note: You will be prompted for user input during the initialization process.")
 
-	cmd := exec.Command("/bin/bash", tmpScript)
+	cmd := exec.Command("/bin/bash", tmpScript) // #nosec G204 -- tmpScript is a temporary file this function just created
+	cmd.Dir = cbTumblebugDir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin // This ensures stdin is properly connected

--- a/cmd/setup/tumblebug_init_test.go
+++ b/cmd/setup/tumblebug_init_test.go
@@ -1,0 +1,213 @@
+package setup
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// requireGit skips the test when git is unavailable so the suite stays green
+// on machines and CI images without a git binary.
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not available")
+	}
+}
+
+// runGit runs git inside dir with a fixed identity, since committing fails
+// when no user.name/user.email is configured in the environment.
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	full := append([]string{
+		"-c", "user.email=test@example.com",
+		"-c", "user.name=test",
+		"-c", "commit.gpgsign=false",
+	}, args...)
+	cmd := exec.Command("git", full...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// writeFile writes name inside dir, creating or overwriting it.
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+		t.Fatalf("writing %s: %v", name, err)
+	}
+}
+
+// testRepo builds a throwaway repository shaped like a checked-out
+// cb-tumblebug clone: two commits, a lightweight tag on the first and an
+// annotated tag on the second.
+//
+// cb-tumblebug publishes its release tags as lightweight tags, so the
+// lightweight case is the one that matters in production; the annotated tag
+// is kept alongside it to prove both kinds resolve.
+type testRepo struct {
+	dir            string
+	firstCommit    string
+	secondCommit   string
+	lightweightTag string
+	annotatedTag   string
+}
+
+func newTestRepo(t *testing.T) testRepo {
+	t.Helper()
+	requireGit(t)
+
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet", "--initial-branch=main")
+
+	writeFile(t, dir, "README.md", "first\n")
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "commit", "--quiet", "-m", "first commit")
+	first := runGit(t, dir, "rev-parse", "HEAD")
+	runGit(t, dir, "tag", "v1.2.3")
+
+	writeFile(t, dir, "README.md", "second\n")
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "commit", "--quiet", "-m", "second commit")
+	second := runGit(t, dir, "rev-parse", "HEAD")
+	runGit(t, dir, "tag", "-a", "v1.2.4", "-m", "release v1.2.4")
+
+	writeFile(t, dir, "README.md", "third\n")
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "commit", "--quiet", "-m", "third commit")
+
+	return testRepo{
+		dir:            dir,
+		firstCommit:    first,
+		secondCommit:   second,
+		lightweightTag: "v1.2.3",
+		annotatedTag:   "v1.2.4",
+	}
+}
+
+// TestGetExistingTumblebugVersionLightweightTag is the regression test for the
+// version detection bug: `git describe --exact-match` without --tags only
+// considers annotated tags, so a correctly checked-out cb-tumblebug release
+// reported its commit hash and the caller kept asking the user to switch
+// versions on every run.
+func TestGetExistingTumblebugVersionLightweightTag(t *testing.T) {
+	repo := newTestRepo(t)
+	runGit(t, repo.dir, "checkout", "--quiet", repo.lightweightTag)
+
+	got, err := getExistingTumblebugVersion(repo.dir)
+	if err != nil {
+		t.Fatalf("getExistingTumblebugVersion: %v", err)
+	}
+	if got != repo.lightweightTag {
+		t.Fatalf("expected the lightweight tag %q, got %q (a commit hash here means --tags was dropped)", repo.lightweightTag, got)
+	}
+}
+
+func TestGetExistingTumblebugVersionAnnotatedTag(t *testing.T) {
+	repo := newTestRepo(t)
+	runGit(t, repo.dir, "checkout", "--quiet", repo.annotatedTag)
+
+	got, err := getExistingTumblebugVersion(repo.dir)
+	if err != nil {
+		t.Fatalf("getExistingTumblebugVersion: %v", err)
+	}
+	if got != repo.annotatedTag {
+		t.Fatalf("expected the annotated tag %q, got %q", repo.annotatedTag, got)
+	}
+}
+
+// TestGetExistingTumblebugVersionUntaggedBranchHead checks that an untagged
+// branch tip still reports its commit hash, so the caller correctly treats it
+// as a different version.
+func TestGetExistingTumblebugVersionUntaggedBranchHead(t *testing.T) {
+	repo := newTestRepo(t)
+
+	got, err := getExistingTumblebugVersion(repo.dir)
+	if err != nil {
+		t.Fatalf("getExistingTumblebugVersion: %v", err)
+	}
+	head := runGit(t, repo.dir, "rev-parse", "HEAD")
+	if got != head {
+		t.Fatalf("expected the commit hash %q for an untagged branch head, got %q", head, got)
+	}
+	if strings.HasPrefix(got, "v") {
+		t.Fatalf("an untagged head must not resolve to a tag, got %q", got)
+	}
+}
+
+// TestGetExistingTumblebugVersionUntaggedIntermediateCommit checks that a
+// commit sitting between tags is not reported as the nearest tag: --exact-match
+// must keep describe from walking back through history.
+func TestGetExistingTumblebugVersionUntaggedIntermediateCommit(t *testing.T) {
+	repo := newTestRepo(t)
+
+	writeFile(t, repo.dir, "extra.txt", "untagged\n")
+	runGit(t, repo.dir, "add", "extra.txt")
+	runGit(t, repo.dir, "commit", "--quiet", "-m", "untagged commit")
+	untagged := runGit(t, repo.dir, "rev-parse", "HEAD")
+
+	got, err := getExistingTumblebugVersion(repo.dir)
+	if err != nil {
+		t.Fatalf("getExistingTumblebugVersion: %v", err)
+	}
+	if got != untagged {
+		t.Fatalf("expected the commit hash %q for an untagged commit, got %q", untagged, got)
+	}
+}
+
+// TestGetExistingTumblebugVersionDirtyWorktree checks that uncommitted changes
+// do not hide the tag: users edit files inside the clone, and the version must
+// still resolve from HEAD.
+func TestGetExistingTumblebugVersionDirtyWorktree(t *testing.T) {
+	repo := newTestRepo(t)
+	runGit(t, repo.dir, "checkout", "--quiet", repo.lightweightTag)
+	writeFile(t, repo.dir, "README.md", "locally modified\n")
+
+	got, err := getExistingTumblebugVersion(repo.dir)
+	if err != nil {
+		t.Fatalf("getExistingTumblebugVersion: %v", err)
+	}
+	if got != repo.lightweightTag {
+		t.Fatalf("expected the lightweight tag %q despite local changes, got %q", repo.lightweightTag, got)
+	}
+}
+
+// TestGetExistingTumblebugVersionNotAGitRepository checks the guard for a
+// directory that exists but was never cloned.
+func TestGetExistingTumblebugVersionNotAGitRepository(t *testing.T) {
+	if _, err := getExistingTumblebugVersion(t.TempDir()); err == nil {
+		t.Fatal("expected an error for a directory that is not a git repository")
+	}
+}
+
+// TestIsTagExistsInRepo checks the lookup that tells the user a release is
+// present but not checked out. It must find lightweight tags as well, and must
+// not match a tag name by prefix.
+func TestIsTagExistsInRepo(t *testing.T) {
+	repo := newTestRepo(t)
+
+	cases := []struct {
+		name string
+		tag  string
+		want bool
+	}{
+		{name: "lightweight tag", tag: repo.lightweightTag, want: true},
+		{name: "annotated tag", tag: repo.annotatedTag, want: true},
+		{name: "unknown tag", tag: "v9.9.9", want: false},
+		{name: "prefix of an existing tag", tag: "v1.2", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isTagExistsInRepo(repo.dir, tc.tag); got != tc.want {
+				t.Fatalf("isTagExistsInRepo(%q) = %v, want %v", tc.tag, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/setup/verbose_secret_test.go
+++ b/cmd/setup/verbose_secret_test.go
@@ -1,0 +1,64 @@
+package setup
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func captureStdoutSecret(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var sb strings.Builder
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := r.Read(buf)
+			if n > 0 {
+				sb.Write(buf[:n])
+			}
+			if readErr != nil {
+				break
+			}
+		}
+		done <- sb.String()
+	}()
+	fn()
+	w.Close()
+	os.Stdout = orig
+	out := <-done
+	r.Close()
+	return out
+}
+
+// `mayfly setup credential -v` is the command someone runs while registering CSP
+// credentials, so its output is the last place a cb-tumblebug API password
+// should be written in the clear.
+func TestSetupSetBasicAuthVerboseDoesNotPrintPassword(t *testing.T) {
+	const secret = "tumblebug-api-password"
+
+	prevInfo, prevVerbose := serviceInfo, isVerbose
+	t.Cleanup(func() { serviceInfo, isVerbose = prevInfo, prevVerbose })
+
+	serviceInfo.Auth.Username = "default"
+	serviceInfo.Auth.Password = secret
+	isVerbose = true
+
+	out := captureStdoutSecret(t, SetBasicAuth)
+
+	if strings.Contains(out, secret) {
+		t.Errorf("-v printed the password verbatim:\n%s", out)
+	}
+	if !strings.Contains(out, "default") {
+		t.Errorf("-v should still show the username, got:\n%s", out)
+	}
+	if !strings.Contains(out, "***") {
+		t.Errorf("-v should show a masked password, got:\n%s", out)
+	}
+}

--- a/cmd/tool/mysqlping.go
+++ b/cmd/tool/mysqlping.go
@@ -3,6 +3,7 @@ package tool
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -50,19 +51,19 @@ Flags:
 		// 아규먼트나 플래그가 입력 되지 않은 경우에만 도움말 출력 후 종료
 		if len(args) == 0 && cmd.Flags().NFlag() == 0 {
 			// 환경 변수가 모두 설정되었으면 도움말 출력 없이 종료
-			if checkConfig() {
+			if checkConfig(cmd) {
 				return
 			}
-			cmd.Help()
+			_ = cmd.Help()
 			os.Exit(1) // Docker Compose의 Health Check 사용을 감안해서 에러로 리턴 함.
 		} else {
 			// verbose 플래그만 설정된 경우에는 도움말 출력
 			if len(args) == 0 && cmd.Flags().NFlag() == 1 && isVerbose {
-				cmd.Help()
+				_ = cmd.Help()
 				fmt.Print("\n\n")
 			}
 
-			if !checkConfig() {
+			if !checkConfig(cmd) {
 				log.Println("Please set the MySQL connection information using flags or environment variables.")
 				os.Exit(1) // 비정상 종료
 			}
@@ -90,7 +91,7 @@ func dbPing() bool {
 	}
 
 	if isVerbose {
-		log.Println("DSN:", dsn)
+		log.Println("DSN:", maskDSN(dsn))
 	}
 
 	// MySQL 연결 테스트
@@ -111,42 +112,87 @@ func dbPing() bool {
 	return true
 }
 
+// maskDSN replaces the password in a MySQL DSN with ***, so a DSN can be logged
+// without printing the credential.
+//
+// This matters more here than it looks: mysqlping runs as a docker compose
+// healthcheck, so it is executed every few seconds for the lifetime of the
+// stack. With -v enabled, the DSN was written to the container log on every one
+// of those runs — a plaintext DB password accumulating in a log anyone with
+// access to the daemon can read.
+//
+// The DSN format is user:password@tcp(host:port)[/database]. The password is
+// whatever sits between the first ':' and the last '@' before the address, so
+// the split is on the last '@' — a password may legitimately contain '@'.
+func maskDSN(dsn string) string {
+	at := strings.LastIndex(dsn, "@")
+	if at < 0 {
+		return dsn
+	}
+	credentials, rest := dsn[:at], dsn[at:]
+	colon := strings.Index(credentials, ":")
+	if colon < 0 {
+		return dsn
+	}
+	return credentials[:colon] + ":***" + rest
+}
+
+// maskSecret reports a secret's presence without revealing it.
+//
+// Deliberately stricter than common.MaskSecret, which keeps a two-character
+// prefix so a user can tell one credential from another. That trade-off is
+// right for an interactive `-v` run and wrong here: mysqlping is a docker
+// compose healthcheck, so with -v enabled it re-prints this line every few
+// seconds for the lifetime of the stack. A prefix repeated thousands of times
+// into a container log is worth more to someone reading the log than it is to
+// the operator, who ran the command once and knows what they typed.
+func maskSecret(s string) string {
+	if s == "" {
+		return "(empty)"
+	}
+	return "***"
+}
+
 // DB 접속을 위한 환경 변수 값을 체크 함.
-func checkConfig() bool {
+//
+// Precedence: a flag the user actually typed always wins over the matching
+// environment variable, which is what the command's help text promises.
+//
+// The previous version could not honour that for --host and --port, because it
+// decided "the user did not pass a flag" by comparing the value against the
+// default. `--host localhost` is indistinguishable from an absent --host under
+// that test, so MYSQL_HOST won and the connection went somewhere the user did
+// not ask for — the opposite of the documented behaviour, and silent.
+// cmd.Flags().Changed answers the question directly.
+func checkConfig(cmd *cobra.Command) bool {
 	if isVerbose {
 		log.Println("Checking MySQL connection information...")
 	}
 
-	// 전달 받은 값이 없을 경우 환경 변수로부터 값을 읽어오기
-	if user == "" {
+	// 플래그로 명시하지 않은 값만 환경 변수로부터 읽어오기
+	if !cmd.Flags().Changed("user") && os.Getenv("MYSQL_USER") != "" {
 		user = os.Getenv("MYSQL_USER")
 	}
 
-	if password == "" {
+	if !cmd.Flags().Changed("password") && os.Getenv("MYSQL_PASSWORD") != "" {
 		password = os.Getenv("MYSQL_PASSWORD")
 	}
 
-	// 기본값 변경
-	if host == "localhost" {
-		if os.Getenv("MYSQL_HOST") != "" && os.Getenv("MYSQL_HOST") != "localhost" {
-			host = os.Getenv("MYSQL_HOST")
-		}
+	if !cmd.Flags().Changed("host") && os.Getenv("MYSQL_HOST") != "" {
+		host = os.Getenv("MYSQL_HOST")
 	}
 
-	// 기본값 변경
-	if port == "3306" {
-		if os.Getenv("MYSQL_PORT") != "" && os.Getenv("MYSQL_PORT") != "3306" {
-			port = os.Getenv("MYSQL_PORT")
-		}
+	if !cmd.Flags().Changed("port") && os.Getenv("MYSQL_PORT") != "" {
+		port = os.Getenv("MYSQL_PORT")
 	}
 
-	if database == "" {
+	if !cmd.Flags().Changed("database") && os.Getenv("MYSQL_DATABASE") != "" {
 		database = os.Getenv("MYSQL_DATABASE")
 	}
 
 	if isVerbose {
 		log.Println("user:", user)
-		log.Println("password:", password)
+		log.Println("password:", maskSecret(password))
 		log.Println("host:", host)
 		log.Println("port:", port)
 		log.Println("database:", database)

--- a/cmd/tool/mysqlping_test.go
+++ b/cmd/tool/mysqlping_test.go
@@ -1,0 +1,175 @@
+package tool
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// mysqlping runs as a compose healthcheck, so anything it logs is written
+// repeatedly for the lifetime of the stack. The DSN must never carry the
+// password into that log.
+func TestMaskDSN(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "no database",
+			in:   "root:p4ssw0rd@tcp(db:3306)",
+			want: "root:***@tcp(db:3306)",
+		},
+		{
+			name: "with database",
+			in:   "root:p4ssw0rd@tcp(db:3306)/airflow",
+			want: "root:***@tcp(db:3306)/airflow",
+		},
+		{
+			// A password containing '@' is why the split is on the last '@'
+			// and not the first.
+			name: "password contains at sign",
+			in:   "root:p@ss@w0rd@tcp(db:3306)/airflow",
+			want: "root:***@tcp(db:3306)/airflow",
+		},
+		{
+			name: "empty password",
+			in:   "root:@tcp(db:3306)",
+			want: "root:***@tcp(db:3306)",
+		},
+		{
+			name: "not a dsn is returned unchanged",
+			in:   "garbage",
+			want: "garbage",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := maskDSN(tc.in)
+			if got != tc.want {
+				t.Errorf("maskDSN(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			if strings.Contains(got, "p4ssw0rd") || strings.Contains(got, "p@ss@w0rd") {
+				t.Errorf("maskDSN leaked the password: %q", got)
+			}
+		})
+	}
+}
+
+func TestMaskSecret(t *testing.T) {
+	if got := maskSecret(""); got != "(empty)" {
+		t.Errorf("maskSecret(\"\") = %q, want %q", got, "(empty)")
+	}
+	if got := maskSecret("p4ssw0rd"); got != "***" {
+		t.Errorf("maskSecret(secret) = %q, want %q", got, "***")
+	}
+}
+
+// newTestCmd builds a command carrying the same flag set as mysqlpingCmd,
+// bound to the same package-level variables, so checkConfig can be exercised
+// without running the real command.
+func newTestCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+	// Reset the shared state each time — these are package-level variables.
+	user, password, database = "", "", ""
+	host, port = "localhost", "3306"
+	isVerbose = false
+
+	c := &cobra.Command{Use: "mysqlping"}
+	c.Flags().StringVarP(&user, "user", "u", "", "")
+	c.Flags().StringVarP(&password, "password", "p", "", "")
+	c.Flags().StringVarP(&host, "host", "", "localhost", "")
+	c.Flags().StringVarP(&port, "port", "", "3306", "")
+	c.Flags().StringVarP(&database, "database", "d", "", "")
+	c.Flags().BoolVarP(&isVerbose, "verbose", "v", false, "")
+	return c
+}
+
+// The help text promises that flags take precedence over the environment.
+// The old checkConfig detected "flag was passed" by comparing against the
+// default, so an explicit --host localhost looked identical to no flag at all
+// and MYSQL_HOST silently won.
+func TestFlagsBeatEnvironment(t *testing.T) {
+	t.Setenv("MYSQL_USER", "envuser")
+	t.Setenv("MYSQL_PASSWORD", "envpass")
+	t.Setenv("MYSQL_HOST", "envhost")
+	t.Setenv("MYSQL_PORT", "3307")
+	t.Setenv("MYSQL_DATABASE", "envdb")
+
+	c := newTestCmd(t)
+	if err := c.ParseFlags([]string{
+		"--user", "flaguser",
+		"--password", "flagpass",
+		"--host", "localhost", // deliberately equal to the default
+		"--port", "3306", // deliberately equal to the default
+		"--database", "flagdb",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if !checkConfig(c) {
+		t.Fatal("checkConfig returned false with a complete configuration")
+	}
+	for _, tc := range []struct{ name, got, want string }{
+		{"user", user, "flaguser"},
+		{"password", password, "flagpass"},
+		{"host", host, "localhost"},
+		{"port", port, "3306"},
+		{"database", database, "flagdb"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s = %q, want %q (the flag must win over the environment)", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+// With no flags given, the environment still supplies every value — this is how
+// the compose healthcheck is configured, so it must keep working.
+func TestEnvironmentUsedWhenNoFlags(t *testing.T) {
+	t.Setenv("MYSQL_USER", "envuser")
+	t.Setenv("MYSQL_PASSWORD", "envpass")
+	t.Setenv("MYSQL_HOST", "envhost")
+	t.Setenv("MYSQL_PORT", "3307")
+	t.Setenv("MYSQL_DATABASE", "envdb")
+
+	c := newTestCmd(t)
+	if err := c.ParseFlags(nil); err != nil {
+		t.Fatal(err)
+	}
+	if !checkConfig(c) {
+		t.Fatal("checkConfig returned false with a complete environment")
+	}
+	for _, tc := range []struct{ name, got, want string }{
+		{"user", user, "envuser"},
+		{"password", password, "envpass"},
+		{"host", host, "envhost"},
+		{"port", port, "3307"},
+		{"database", database, "envdb"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s = %q, want %q", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+// Nothing configured anywhere: the defaults stay put and checkConfig reports
+// the missing credentials rather than attempting a connection.
+func TestMissingCredentialsRejected(t *testing.T) {
+	t.Setenv("MYSQL_USER", "")
+	t.Setenv("MYSQL_PASSWORD", "")
+	t.Setenv("MYSQL_HOST", "")
+	t.Setenv("MYSQL_PORT", "")
+	t.Setenv("MYSQL_DATABASE", "")
+
+	c := newTestCmd(t)
+	if err := c.ParseFlags(nil); err != nil {
+		t.Fatal(err)
+	}
+	if checkConfig(c) {
+		t.Error("checkConfig returned true without a user or password")
+	}
+	if host != "localhost" || port != "3306" {
+		t.Errorf("defaults were disturbed: host=%q port=%q", host, port)
+	}
+}

--- a/cmd/tool/root.go
+++ b/cmd/tool/root.go
@@ -16,7 +16,7 @@ var toolCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		//fmt.Println(cmd.UsageString())
 		//fmt.Println(cmd.Help())
-		cmd.Help()
+		_ = cmd.Help()
 	},
 }
 

--- a/common/dotenv.go
+++ b/common/dotenv.go
@@ -16,11 +16,13 @@ import (
 // syntax, this routine only needs to surface values. Shared by `mayfly infra`
 // (.env validation) and `mayfly api`/`rest` (auth env resolution).
 func ParseDotEnv(path string) (map[string]string, error) {
-	f, err := os.Open(path)
+	// The caller names the .env file to read (a compose env file path); reading
+	// an operator-chosen file is the purpose of this routine, not a traversal.
+	f, err := os.Open(path) // #nosec G304 -- path is the .env file the operator asked to parse
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }() // read-only handle: nothing to flush
 	values := map[string]string{}
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {

--- a/common/gitcheckout.go
+++ b/common/gitcheckout.go
@@ -1,0 +1,84 @@
+package common
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// GitOutputInDir runs git with the given arguments inside dir and returns its
+// standard output.
+//
+// The directory is handed to the process as its working directory rather than
+// interpolated into a `cd <dir> && git …` shell command. Callers build the path
+// from $HOME, and a shell would re-parse whatever that contains — a space alone
+// breaks the unquoted form, and a $(…) sequence in it would be executed.
+// Dropping the shell removes the question entirely.
+func GitOutputInDir(dir string, args ...string) ([]byte, error) {
+	cmd := exec.Command("git", args...) // #nosec G204 -- arguments are passed as a vector, never re-parsed by a shell
+	cmd.Dir = dir
+	return cmd.Output()
+}
+
+// GitCheckoutVersion reports which release a git checkout is sitting on.
+//
+// It returns the tag HEAD points at exactly, and the HEAD commit hash. When
+// HEAD is not on a tag the tag is empty and only the commit is filled in, so a
+// caller can tell "on release X" from "on some arbitrary commit" without
+// parsing anything. A directory that is not a git repository is an error.
+//
+// This is the single place the `--tags` rule is written down. cb-tumblebug
+// publishes its release tags as *lightweight* tags, and `git describe
+// --exact-match` on its own considers annotated tags only. Without --tags the
+// tag is never found, so a correctly checked-out release still reports its
+// commit hash — and every caller that compares that against a wanted version
+// concludes the checkout is wrong. Both the interactive `setup tumblebug-init`
+// flow and the unattended OpenBao initialization path call in here rather than
+// spelling the git invocation out twice, because getting it wrong twice is
+// exactly what happened before.
+func GitCheckoutVersion(dir string) (tag string, commit string, err error) {
+	gitDir := filepath.Join(dir, ".git")
+	if _, statErr := os.Stat(gitDir); statErr != nil {
+		return "", "", fmt.Errorf("%s is not a git repository", dir)
+	}
+
+	out, err := GitOutputInDir(dir, "rev-parse", "HEAD")
+	if err != nil {
+		return "", "", fmt.Errorf("could not read HEAD of %s: %w", dir, err)
+	}
+	commit = strings.TrimSpace(string(out))
+	if commit == "" {
+		return "", "", fmt.Errorf("could not read HEAD of %s: empty output", dir)
+	}
+
+	// --tags: see the note above. Removing it silently breaks every caller.
+	out, err = GitOutputInDir(dir, "describe", "--exact-match", "--tags", "HEAD")
+	if err != nil {
+		// HEAD is not on a tag. That is a normal state, not a failure — the
+		// caller decides what to do with a checkout that is off-release.
+		return "", commit, nil
+	}
+	return strings.TrimSpace(string(out)), commit, nil
+}
+
+// GitWorkTreeClean reports whether a checkout has no uncommitted changes and no
+// untracked files. Switching tags underneath local edits would either fail or
+// carry them onto another release, so callers check this before checking out.
+func GitWorkTreeClean(dir string) (bool, error) {
+	out, err := GitOutputInDir(dir, "status", "--porcelain")
+	if err != nil {
+		return false, fmt.Errorf("could not read the status of %s: %w", dir, err)
+	}
+	return strings.TrimSpace(string(out)) == "", nil
+}
+
+// GitTagExists reports whether tag is present in the local checkout.
+func GitTagExists(dir, tag string) bool {
+	out, err := GitOutputInDir(dir, "tag", "-l", tag)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == tag
+}

--- a/common/gitcheckout_test.go
+++ b/common/gitcheckout_test.go
@@ -1,0 +1,182 @@
+package common
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// requireGit skips the test when git is unavailable so the suite stays green
+// on machines and CI images without a git binary.
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not available")
+	}
+}
+
+// runGit runs git inside dir with a fixed identity, since committing fails
+// when no user.name/user.email is configured in the environment.
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	full := append([]string{
+		"-c", "user.email=test@example.com",
+		"-c", "user.name=test",
+		"-c", "commit.gpgsign=false",
+	}, args...)
+	cmd := exec.Command("git", full...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// gitRepoWithTags builds a throwaway repository with two commits: a
+// lightweight tag on the first and an annotated tag on the second.
+//
+// cb-tumblebug publishes its release tags as lightweight tags, so that is the
+// case that matters in production; the annotated tag sits alongside it to show
+// both kinds resolve.
+func gitRepoWithTags(t *testing.T) (dir, firstCommit, secondCommit string) {
+	t.Helper()
+	requireGit(t)
+	dir = t.TempDir()
+	runGit(t, dir, "init", "-q", "-b", "main")
+
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("one"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-q", "-m", "first")
+	firstCommit = runGit(t, dir, "rev-parse", "HEAD")
+	// Lightweight tag: no -a/-m, so no tag object is created.
+	runGit(t, dir, "tag", "v0.12.22")
+
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("two"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-q", "-m", "second")
+	secondCommit = runGit(t, dir, "rev-parse", "HEAD")
+	runGit(t, dir, "tag", "-a", "v0.12.25", "-m", "annotated")
+
+	return dir, firstCommit, secondCommit
+}
+
+// TestGitCheckoutVersionFindsLightweightTag is the regression this helper
+// exists for. cb-tumblebug's release tags are lightweight, and `git describe
+// --exact-match` without --tags only ever sees annotated tags — so dropping
+// --tags makes a correctly checked-out release look like a bare commit.
+func TestGitCheckoutVersionFindsLightweightTag(t *testing.T) {
+	dir, firstCommit, _ := gitRepoWithTags(t)
+	runGit(t, dir, "checkout", "-q", "v0.12.22")
+
+	tag, commit, err := GitCheckoutVersion(dir)
+	if err != nil {
+		t.Fatalf("GitCheckoutVersion: %v", err)
+	}
+	if tag != "v0.12.22" {
+		t.Errorf("lightweight tag not resolved: got tag %q, want %q", tag, "v0.12.22")
+	}
+	if commit != firstCommit {
+		t.Errorf("commit = %q, want %q", commit, firstCommit)
+	}
+}
+
+func TestGitCheckoutVersionFindsAnnotatedTag(t *testing.T) {
+	dir, _, secondCommit := gitRepoWithTags(t)
+	runGit(t, dir, "checkout", "-q", "v0.12.25")
+
+	tag, commit, err := GitCheckoutVersion(dir)
+	if err != nil {
+		t.Fatalf("GitCheckoutVersion: %v", err)
+	}
+	if tag != "v0.12.25" {
+		t.Errorf("tag = %q, want %q", tag, "v0.12.25")
+	}
+	if commit != secondCommit {
+		t.Errorf("commit = %q, want %q", commit, secondCommit)
+	}
+}
+
+// TestGitCheckoutVersionOffTag covers a checkout parked on a commit that
+// carries no tag: that is reported as "no tag, this commit" rather than as an
+// error, because the caller decides what to make of it.
+func TestGitCheckoutVersionOffTag(t *testing.T) {
+	dir, _, _ := gitRepoWithTags(t)
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("three"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-q", "-m", "third")
+	head := runGit(t, dir, "rev-parse", "HEAD")
+
+	tag, commit, err := GitCheckoutVersion(dir)
+	if err != nil {
+		t.Fatalf("GitCheckoutVersion: %v", err)
+	}
+	if tag != "" {
+		t.Errorf("tag = %q, want empty for an untagged commit", tag)
+	}
+	if commit != head {
+		t.Errorf("commit = %q, want %q", commit, head)
+	}
+}
+
+func TestGitCheckoutVersionRejectsNonRepo(t *testing.T) {
+	requireGit(t)
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := GitCheckoutVersion(dir); err == nil {
+		t.Fatal("a plain directory was accepted as a git repository")
+	}
+}
+
+func TestGitWorkTreeClean(t *testing.T) {
+	dir, _, _ := gitRepoWithTags(t)
+
+	clean, err := GitWorkTreeClean(dir)
+	if err != nil {
+		t.Fatalf("GitWorkTreeClean: %v", err)
+	}
+	if !clean {
+		t.Error("a freshly committed checkout was reported dirty")
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("edited"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	clean, err = GitWorkTreeClean(dir)
+	if err != nil {
+		t.Fatalf("GitWorkTreeClean: %v", err)
+	}
+	if clean {
+		t.Error("a checkout with a modified tracked file was reported clean")
+	}
+}
+
+func TestGitTagExists(t *testing.T) {
+	dir, _, _ := gitRepoWithTags(t)
+
+	if !GitTagExists(dir, "v0.12.22") {
+		t.Error("existing lightweight tag not found")
+	}
+	if !GitTagExists(dir, "v0.12.25") {
+		t.Error("existing annotated tag not found")
+	}
+	if GitTagExists(dir, "v9.9.9") {
+		t.Error("absent tag reported as present")
+	}
+	// `git tag -l v0.12.2` must not match v0.12.22 — a prefix is not a tag.
+	if GitTagExists(dir, "v0.12.2") {
+		t.Error("a tag prefix was accepted as a tag")
+	}
+}

--- a/common/mask.go
+++ b/common/mask.go
@@ -1,0 +1,26 @@
+package common
+
+// MaskSecret renders a credential for a log line: enough to tell one value from
+// another, never enough to use.
+//
+// The -v flag exists so a user can see how a call was assembled, and answering
+// "did my password reach the request at all, and is it the one I meant?" is a
+// large part of that. Printing the value outright answers it at the cost of
+// leaving the credential in a terminal scrollback, a CI job log or a redirected
+// output file — places it outlives the debugging session by a long way. Printing
+// nothing at all answers neither question.
+//
+// So the compromise is a short prefix: "(empty)" separates "not set" from "set",
+// and the first two characters separate "the password I typed" from "some other
+// password". Values short enough that a prefix would give away a meaningful
+// share of them are replaced wholesale.
+func MaskSecret(s string) string {
+	if s == "" {
+		return "(empty)"
+	}
+	r := []rune(s) // a prefix is taken in characters, so a multi-byte value is not cut mid-rune
+	if len(r) <= 6 {
+		return "***"
+	}
+	return string(r[:2]) + "***"
+}

--- a/common/mask_test.go
+++ b/common/mask_test.go
@@ -1,0 +1,59 @@
+package common
+
+import "testing"
+
+func TestMaskSecret(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty is distinguishable from set", "", "(empty)"},
+		{"one char", "a", "***"},
+		{"short values give nothing away", "abcdef", "***"},
+		{"just over the threshold", "abcdefg", "ab***"},
+		{"typical password", "p4ssw0rd-with-more", "p4***"},
+		{"long opaque token", "ey-token-shaped-value-for-masking-only", "ey***"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MaskSecret(tc.in); got != tc.want {
+				t.Errorf("MaskSecret(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// The whole point is that the secret does not appear in the output. Checked
+// separately from the table so the property is stated rather than implied by a
+// list of expected strings.
+func TestMaskSecretNeverContainsTheWholeValue(t *testing.T) {
+	for _, secret := range []string{
+		"a",
+		"short",
+		"abcdefg",
+		"correct-horse-battery-staple",
+		"s.vault-token-shaped-value-for-masking-only",
+	} {
+		got := MaskSecret(secret)
+		if got == secret {
+			t.Errorf("MaskSecret(%q) returned the secret unchanged", secret)
+		}
+		if len(got) >= len(secret) && len(secret) > 6 {
+			t.Errorf("MaskSecret(%q) = %q is not shorter than the secret", secret, got)
+		}
+	}
+}
+
+// A multi-byte value must not be cut in the middle of a character — the prefix
+// is taken in runes, so the result stays printable.
+func TestMaskSecretMultiByte(t *testing.T) {
+	got := MaskSecret("비밀번호입니다")
+	if want := "비밀***"; got != want {
+		t.Errorf("MaskSecret(multi-byte) = %q, want %q", got, want)
+	}
+	for _, r := range got {
+		if r == '�' {
+			t.Errorf("MaskSecret produced a replacement character: %q", got)
+		}
+	}
+}

--- a/common/outputbuffer_test.go
+++ b/common/outputbuffer_test.go
@@ -1,0 +1,286 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// captureStdout collects everything fn writes to stdout. These helpers stream a
+// child's output rather than returning it, so the only way to observe what they
+// carried is to read the stream they print to.
+//
+// The reader runs in its own goroutine and drains continuously. That matters:
+// the child now inherits this pipe directly, so a reader that waited until fn
+// returned would fill the pipe and deadlock the very hang these tests exist to
+// rule out.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	out, _ := captureStdoutTimed(t, fn, "")
+	return out
+}
+
+// captureStdoutTimed is captureStdout with one extra observation: how long after
+// fn started the given marker first appeared in the stream. It answers whether
+// output reaches the terminal while the child is still running or only once it
+// exits. An empty marker skips the timing.
+func captureStdoutTimed(t *testing.T, fn func(), marker string) (string, time.Duration) {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	type result struct {
+		out       string
+		firstSeen time.Duration
+	}
+	done := make(chan result, 1)
+	start := time.Now()
+
+	go func() {
+		var sb strings.Builder
+		var firstSeen time.Duration
+		buf := make([]byte, 32*1024)
+		for {
+			n, readErr := r.Read(buf)
+			if n > 0 {
+				sb.Write(buf[:n])
+				if marker != "" && firstSeen == 0 && strings.Contains(sb.String(), marker) {
+					firstSeen = time.Since(start)
+				}
+			}
+			if readErr != nil {
+				break
+			}
+		}
+		done <- result{sb.String(), firstSeen}
+	}()
+
+	fn()
+	w.Close()
+	os.Stdout = orig
+	res := <-done
+	r.Close()
+	return res.out, res.firstSeen
+}
+
+// oneLongLine builds an awk program that emits a single line of n bytes followed
+// by a short marker line, so both the line itself and whatever came after it can
+// be checked.
+//
+// The line is generated inside the child rather than passed as an argument: an
+// argv entry this large exceeds the per-argument limit and the exec would fail
+// before any of this is exercised.
+func oneLongLine(n int) (awkProg string, shellCmd string) {
+	awkProg = fmt.Sprintf(
+		`BEGIN{s="x";while(length(s)<%d){s=s s}print substr(s,1,%d);print "END"}`, n, n)
+	return awkProg, "awk '" + awkProg + "'"
+}
+
+// No single line, at any size, may stall the stream.
+//
+// The old implementation read the child through a bufio.Scanner, which has to
+// hold a whole line before emitting it and therefore caps line length. Past the
+// cap it stopped and reported the truncation as an ordinary end of input; with
+// nothing left draining the pipe, the child blocked on write and cmd.Wait()
+// blocked on the child. Against that implementation this test does not fail, it
+// hangs until the go test timeout — exactly what a user saw mid-`logs -f`.
+//
+// 10MB is far past any limit the scanner version could have been configured
+// with, so passing it shows the ceiling is gone rather than merely raised.
+func TestStreamingHelpersCarryLongLines(t *testing.T) {
+	sizes := []struct {
+		name string
+		n    int
+	}{
+		{"1MB", 1024 * 1024},
+		{"1MB+1", 1024*1024 + 1},
+		{"10MB", 10 * 1024 * 1024},
+	}
+
+	for _, size := range sizes {
+		t.Run(size.name, func(t *testing.T) {
+			awkProg, shellCmd := oneLongLine(size.n)
+			args := []string{awkProg}
+
+			t.Run("RunCommand", func(t *testing.T) {
+				out := captureStdout(t, func() {
+					if err := RunCommand("awk", args, nil); err != nil {
+						t.Errorf("RunCommand: %v", err)
+					}
+				})
+				assertCarriedLongLine(t, out, size.n)
+			})
+
+			t.Run("SysCallWithError", func(t *testing.T) {
+				out := captureStdout(t, func() {
+					if err := SysCallWithError(shellCmd); err != nil {
+						t.Errorf("SysCallWithError: %v", err)
+					}
+				})
+				assertCarriedLongLine(t, out, size.n)
+			})
+
+			t.Run("SysCall", func(t *testing.T) {
+				out := captureStdout(t, func() { SysCall(shellCmd) })
+				assertCarriedLongLine(t, out, size.n)
+			})
+		})
+	}
+}
+
+// assertCarriedLongLine checks both halves of the failure: the long line itself
+// has to arrive whole, and the output that followed it must not have been cut
+// off — a stalled stream loses everything after the oversized line, not just
+// that line.
+func assertCarriedLongLine(t *testing.T, out string, want int) {
+	t.Helper()
+
+	var longest int
+	for _, line := range strings.Split(out, "\n") {
+		if len(line) > longest {
+			longest = len(line)
+		}
+	}
+	if longest < want {
+		t.Errorf("longest line carried was %d bytes, want at least %d — the line was truncated", longest, want)
+	}
+	if !strings.Contains(out, "END") {
+		t.Error("output after the long line was lost; the stream stopped early")
+	}
+}
+
+// A long run of ordinary lines has to arrive complete. Line length is one way to
+// stall a stream; sheer volume through a pipe is another, and `logs --tail all`
+// produces exactly this shape.
+func TestStreamingHelpersCarryManyLines(t *testing.T) {
+	const lines = 50000
+	awkProg := fmt.Sprintf(`BEGIN{for(i=1;i<=%d;i++)print i}`, lines)
+
+	out := captureStdout(t, func() {
+		if err := RunCommand("awk", []string{awkProg}, nil); err != nil {
+			t.Errorf("RunCommand: %v", err)
+		}
+	})
+
+	got := strings.Count(out, "\n")
+	if got != lines {
+		t.Errorf("carried %d lines, want %d", got, lines)
+	}
+	if !strings.Contains(out, fmt.Sprintf("\n%d\n", lines)) {
+		t.Errorf("the last line (%d) never arrived", lines)
+	}
+}
+
+// Output must reach the terminal as the child produces it, not in one burst when
+// the child exits. A user watching `logs -f` is reading a live stream; anything
+// that batches it makes the command look frozen even when nothing is wrong.
+func TestStreamingHelpersAreNotBuffered(t *testing.T) {
+	const delay = 1500 * time.Millisecond
+
+	out, firstSeen := captureStdoutTimed(t, func() {
+		if err := RunCommand("sh", []string{"-c", "echo EARLY; sleep 1.5; echo LATE"}, nil); err != nil {
+			t.Errorf("RunCommand: %v", err)
+		}
+	}, "EARLY")
+
+	if !strings.Contains(out, "EARLY") || !strings.Contains(out, "LATE") {
+		t.Fatalf("both markers should have arrived, got %q", out)
+	}
+	if firstSeen == 0 {
+		t.Fatal("the first marker was never observed arriving")
+	}
+	// The child sleeps 1.5s after the first line. Seeing that line well before
+	// the sleep ends proves it was not held until exit.
+	if firstSeen > delay/2 {
+		t.Errorf("first line took %v to appear; the child slept %v afterwards, so the output was buffered until exit", firstSeen, delay)
+	}
+}
+
+// A failing command still has to report its exit status. Streaming straight to
+// the terminal must not cost the caller the one thing it uses to branch on.
+func TestStreamingHelpersReportExitCode(t *testing.T) {
+	const wantCode = 7
+
+	t.Run("RunCommandInDir", func(t *testing.T) {
+		var err error
+		captureStdout(t, func() {
+			err = RunCommandInDir("", "sh", []string{"-c", "echo before-exit; exit 7"}, nil)
+		})
+		assertExitCode(t, err, wantCode)
+	})
+
+	t.Run("SysCallWithError", func(t *testing.T) {
+		var err error
+		captureStdout(t, func() {
+			err = SysCallWithError("echo before-exit; exit 7")
+		})
+		assertExitCode(t, err, wantCode)
+	})
+
+	t.Run("success is nil", func(t *testing.T) {
+		var err error
+		captureStdout(t, func() {
+			err = RunCommandInDir("", "sh", []string{"-c", "echo ok"}, nil)
+		})
+		if err != nil {
+			t.Errorf("a command that succeeded returned %v", err)
+		}
+	})
+}
+
+func assertExitCode(t *testing.T, err error, want int) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("a command that exited %d returned no error", want)
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("error was %T (%v), want *exec.ExitError carrying the exit status", err, err)
+	}
+	if got := exitErr.ExitCode(); got != want {
+		t.Errorf("exit code %d, want %d", got, want)
+	}
+}
+
+// stderr has to keep arriving on stdout, interleaved in the order the child
+// wrote it. These helpers have always merged the two streams and callers read
+// them as one; splitting them would reorder a live log and drop errors for
+// anyone piping the command.
+func TestStreamingHelpersMergeStderrIntoStdout(t *testing.T) {
+	t.Run("RunCommand", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			if err := RunCommand("sh", []string{"-c", "echo OUT-1; echo ERR-1 >&2; echo OUT-2"}, nil); err != nil {
+				t.Errorf("RunCommand: %v", err)
+			}
+		})
+		assertMergedInOrder(t, out)
+	})
+
+	t.Run("SysCall", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			SysCall("echo OUT-1; echo ERR-1 >&2; echo OUT-2")
+		})
+		assertMergedInOrder(t, out)
+	})
+}
+
+func assertMergedInOrder(t *testing.T, out string) {
+	t.Helper()
+	for _, want := range []string{"OUT-1", "ERR-1", "OUT-2"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("%q missing from stdout; got %q", want, out)
+		}
+	}
+	first, mid, last := strings.Index(out, "OUT-1"), strings.Index(out, "ERR-1"), strings.Index(out, "OUT-2")
+	if first > mid || mid > last {
+		t.Errorf("stdout and stderr arrived out of order: %q", out)
+	}
+}

--- a/common/runcommand_test.go
+++ b/common/runcommand_test.go
@@ -1,0 +1,111 @@
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Arguments carrying shell metacharacters must reach the program literally
+// instead of being interpreted. The infra commands used to build a string and
+// hand it to `/bin/sh -c`, which made `logs --tail '1; echo INJECTED'` and
+// `remove -s 'openbao;id'` execute the injected part.
+func TestRunCommandOutputDoesNotInterpretMetacharacters(t *testing.T) {
+	payloads := []string{
+		"1; echo INJECTED",
+		"1h'; echo INJECTED; :'",
+		"$(echo INJECTED)",
+		"`echo INJECTED`",
+		"a | echo INJECTED",
+		"a && echo INJECTED",
+		"openbao;id",
+	}
+
+	for _, payload := range payloads {
+		out, err := RunCommandOutput("printf", []string{"%s", payload}, nil)
+		if err != nil {
+			t.Fatalf("RunCommandOutput(%q): %v", payload, err)
+		}
+		got := string(out)
+		if got != payload {
+			t.Errorf("argument %q was altered on the way to the program: got %q", payload, got)
+		}
+		// `printf %s` echoes its argument verbatim, so the literal text is
+		// expected. What must never appear is INJECTED on its own — the mark of
+		// a shell having run the payload as a second command.
+		for _, line := range strings.Split(got, "\n") {
+			if strings.TrimSpace(line) == "INJECTED" {
+				t.Errorf("payload %q was executed by a shell; output: %q", payload, got)
+			}
+		}
+	}
+}
+
+// A failing command must surface as an error. SysCall printed the failure and
+// returned nothing, so callers carried on and reported success.
+func TestRunCommandReturnsExitStatus(t *testing.T) {
+	if err := RunCommand("false", nil, nil); err == nil {
+		t.Error("RunCommand must return an error when the program exits non-zero")
+	}
+	if err := RunCommand("true", nil, nil); err != nil {
+		t.Errorf("RunCommand must return nil on success, got %v", err)
+	}
+	if err := RunCommand("cm-mayfly-no-such-program", nil, nil); err == nil {
+		t.Error("RunCommand must return an error when the program does not exist")
+	}
+}
+
+// extraEnv reaches the child process, so COMPOSE_PROJECT_NAME no longer has to
+// be prefixed onto a shell command string.
+func TestRunCommandPassesExtraEnv(t *testing.T) {
+	out, err := RunCommandOutput("sh", []string{"-c", "printf %s \"$COMPOSE_PROJECT_NAME\""},
+		[]string{"COMPOSE_PROJECT_NAME=cm-test-project"})
+	if err != nil {
+		t.Fatalf("RunCommandOutput: %v", err)
+	}
+	if string(out) != "cm-test-project" {
+		t.Errorf("extraEnv did not reach the child process: got %q", out)
+	}
+}
+
+// The child must inherit the parent environment alongside extraEnv, otherwise
+// docker would lose PATH, HOME, DOCKER_HOST and friends.
+func TestRunCommandInheritsParentEnv(t *testing.T) {
+	t.Setenv("CM_MAYFLY_TEST_INHERITED", "yes")
+
+	out, err := RunCommandOutput("sh", []string{"-c", "printf %s \"$CM_MAYFLY_TEST_INHERITED\""},
+		[]string{"COMPOSE_PROJECT_NAME=cm-test-project"})
+	if err != nil {
+		t.Fatalf("RunCommandOutput: %v", err)
+	}
+	if string(out) != "yes" {
+		t.Errorf("parent environment was not inherited: got %q", out)
+	}
+}
+
+// A path holding shell metacharacters must be removed as a literal path, not
+// re-parsed. This is the `sudo rm -rf .../openbao;id` case.
+func TestRunCommandTreatsPathsLiterally(t *testing.T) {
+	dir := t.TempDir()
+	victim := filepath.Join(dir, "keep-me")
+	if err := os.WriteFile(victim, []byte("data"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// "odd;name" is a single path component, not a command separator.
+	odd := filepath.Join(dir, "odd;name")
+	if err := os.WriteFile(odd, []byte("data"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RunCommand("rm", []string{"-rf", odd}, nil); err != nil {
+		t.Fatalf("RunCommand rm: %v", err)
+	}
+	if _, err := os.Stat(odd); !os.IsNotExist(err) {
+		t.Errorf("the literal path %q should have been removed", odd)
+	}
+	if _, err := os.Stat(victim); err != nil {
+		t.Errorf("an unrelated file was affected: %v", err)
+	}
+}

--- a/common/utility.go
+++ b/common/utility.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -16,27 +15,52 @@ const (
 	NotDefined string = "Not_Defined"
 )
 
-// SysCall executes user-passed command via system call.
+// streamTo wires a child process to this process's own stdout so its output
+// reaches the terminal without passing through a buffer we own.
+//
+// These helpers never parse what the child writes — they only forward it — so
+// there is nothing to gain from reading it line by line, and a great deal to
+// lose. A line scanner has to hold a whole line in memory before it can emit
+// it, which means it must declare a maximum line length; past that limit it
+// stops and reports the truncation as an ordinary end of input. Nothing then
+// drains the pipe, so the child blocks writing while cmd.Wait() blocks on the
+// child, and a `logs -f` session freezes mid-stream. Raising the limit only
+// moves the line at which it happens.
+//
+// Handing os.Stdout to the child removes the pipe entirely: the file descriptor
+// is inherited, the child writes to the terminal directly, and no length applies
+// because no buffer of ours is involved. Output also stays byte-exact and
+// unbuffered, which keeps colour codes, progress redraws and interactive prompts
+// working as they do when the command is run by hand.
+//
+// stderr is merged into stdout rather than sent to fd 2. These helpers have
+// always combined the two streams, and callers such as `infra logs` rely on the
+// merge: docker writes container output to both, and splitting them now would
+// reorder a running log and hide errors from anyone piping the command. Sharing
+// one descriptor also keeps the two streams strictly ordered, which a split
+// cannot guarantee.
+func streamTo(cmd *exec.Cmd) {
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stdout
+}
+
+// These three helpers deliberately run their argument through /bin/sh: the
+// callers that remain need shell features (pipes, redirection, $VAR expansion
+// inside `docker exec`). Everything that did not need a shell was moved to
+// RunCommand*/exec.Command with an argument vector. Callers must therefore
+// pass a fixed command string; do not build one out of flags or arguments.
+//
+// SysCall executes the given shell command, streaming its output.
 func SysCall(cmdStr string) {
-	//cmdStr := "docker-compose -f " + common.DockerFilePath + " up"
-	cmd := exec.Command("/bin/sh", "-c", cmdStr)
+	cmd := exec.Command("/bin/sh", "-c", cmdStr) // #nosec G204 -- shell is intentional here; every call site passes a fixed command string
+	streamTo(cmd)
 
-	cmdReader, _ := cmd.StdoutPipe()
-	cmd.Stderr = cmd.Stdout
-
-	err := cmd.Start()
-	if err != nil {
+	if err := cmd.Start(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
-	scanner := bufio.NewScanner(cmdReader)
-	for scanner.Scan() {
-		fmt.Printf("%s\n", scanner.Text())
-	}
-
-	err = cmd.Wait()
-	if err != nil {
+	if err := cmd.Wait(); err != nil {
 		fmt.Println(err)
 		//os.Exit(1)
 	}
@@ -45,28 +69,65 @@ func SysCall(cmdStr string) {
 
 // SysCallWithError executes user-passed command via system call and returns error.
 func SysCallWithError(cmdStr string) error {
-	cmd := exec.Command("/bin/sh", "-c", cmdStr)
+	cmd := exec.Command("/bin/sh", "-c", cmdStr) // #nosec G204 -- shell is intentional here; every call site passes a fixed command string
+	streamTo(cmd)
 
-	cmdReader, _ := cmd.StdoutPipe()
-	cmd.Stderr = cmd.Stdout
-
-	err := cmd.Start()
-	if err != nil {
+	if err := cmd.Start(); err != nil {
 		return err
 	}
 
-	scanner := bufio.NewScanner(cmdReader)
-	for scanner.Scan() {
-		fmt.Printf("%s\n", scanner.Text())
+	return cmd.Wait()
+}
+
+// RunCommand executes a program directly, without going through a shell, and
+// streams its combined output. Every element of args is handed to the program as
+// a single argument, so a value that contains shell metacharacters (`;`, `|`,
+// `$(…)`, backticks, quotes) is passed through literally instead of being
+// interpreted. extraEnv entries ("KEY=VALUE") are appended to the current
+// environment.
+//
+// The error returned carries the process exit status, so a caller can tell a
+// failed command from a successful one — unlike SysCall, which discards it.
+func RunCommand(name string, args []string, extraEnv []string) error {
+	return RunCommandInDir("", name, args, extraEnv)
+}
+
+// RunCommandInDir is RunCommand with a working directory. An empty dir runs the
+// program in the caller's own working directory, exactly as RunCommand does.
+//
+// Setting the directory on the process is what lets a caller drop `cd <dir> &&
+// …` from a shell string: the path stops being a fragment of a command line
+// that a shell would re-parse, so a directory containing `$(…)`, a quote or a
+// space is handed to the kernel as one literal argument.
+func RunCommandInDir(dir, name string, args []string, extraEnv []string) error {
+	cmd := exec.Command(name, args...) // #nosec G204 -- arguments are passed as a vector, never re-parsed by a shell
+	cmd.Dir = dir
+	if len(extraEnv) > 0 {
+		cmd.Env = append(os.Environ(), extraEnv...)
 	}
 
-	err = cmd.Wait()
-	return err
+	streamTo(cmd)
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	return cmd.Wait()
+}
+
+// RunCommandOutput executes a program directly, without a shell, and returns its
+// standard output. It is the capture-only counterpart of RunCommand.
+func RunCommandOutput(name string, args []string, extraEnv []string) ([]byte, error) {
+	cmd := exec.Command(name, args...) // #nosec G204 -- arguments are passed as a vector, never re-parsed by a shell
+	if len(extraEnv) > 0 {
+		cmd.Env = append(os.Environ(), extraEnv...)
+	}
+	return cmd.Output()
 }
 
 // SysCallWithOutput executes user-passed command via system call and returns output.
 func SysCallWithOutput(cmdStr string) string {
-	cmd := exec.Command("/bin/sh", "-c", cmdStr)
+	cmd := exec.Command("/bin/sh", "-c", cmdStr) // #nosec G204 -- shell is intentional here; the openbao call sites pass fixed docker/curl command strings
 
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/openbao/init.go
+++ b/internal/openbao/init.go
@@ -4,13 +4,13 @@
 // The cm-mayfly first-run flow matches the upstream cb-tumblebug `make up`
 // pattern:
 //
-//	1. docker compose up -d openbao   (openbao alone — depends_on chain
-//	                                   doesn't pull other services in)
-//	2. wait for openbao API to respond
-//	3. run cb-tumblebug's openbao-init.sh, which writes VAULT_TOKEN into
-//	   the shared .env file
-//	4. (caller) docker compose up -d   (everything else — these containers
-//	                                   now see the populated VAULT_TOKEN)
+//  1. docker compose up -d openbao   (openbao alone — depends_on chain
+//     doesn't pull other services in)
+//  2. wait for openbao API to respond
+//  3. run cb-tumblebug's openbao-init.sh, which writes VAULT_TOKEN into
+//     the shared .env file
+//  4. (caller) docker compose up -d   (everything else — these containers
+//     now see the populated VAULT_TOKEN)
 //
 // Keeping Init/Unseal/Status here as plain functions lets `setup openbao`
 // commands and `infra run` share one implementation (single source of truth).
@@ -46,23 +46,51 @@ func envPath() string {
 }
 
 // HasVaultToken reports whether mayfly's .env has a non-empty VAULT_TOKEN.
-// Quoted empty values ("" / '') count as empty.
+// A value that is nothing but a pair of quotes counts as empty — ParseDotEnv
+// strips the quotes, so both the double- and single-quoted forms reduce to the
+// empty string here.
 func HasVaultToken() bool {
-	f, err := os.Open(envPath())
-	if err != nil {
-		return false
+	return readEnvValue(vaultTokenKey) != ""
+}
+
+// composeUpOpenbao brings up the openbao service on its own. `docker compose up
+// -d openbao` only starts the named service — depends_on flows from dependents
+// to dependencies, so nothing else is pulled in.
+//
+// Init() and the preflight's startOpenbaoAlone() both need exactly this, and
+// both used to assemble their own `COMPOSE_PROJECT_NAME=… docker compose …`
+// string for /bin/sh. One copy, executed as an argument vector, means the
+// compose file path is passed to the kernel literally instead of being re-parsed
+// by a shell, and there is no second copy to drift.
+func composeUpOpenbao() error {
+	return common.RunCommand(
+		"docker",
+		[]string{"compose", "-f", common.DefaultDockerComposeConfig, "up", "-d", "openbao"},
+		[]string{"COMPOSE_PROJECT_NAME=" + common.ComposeProjectName},
+	)
+}
+
+// warnOnFailure prints what went wrong and why it matters, and carries on.
+//
+// The permission fixes in Init used to discard their results with `_ =`. Most of
+// them are best-effort by design: sudo may not be usable without a password, and
+// the directories are frequently already owned correctly, in which case the
+// failure is harmless and aborting would break a setup that works today. But
+// when one of them does matter, the consequence used to appear much later and in
+// an unrelated place — typically as OpenBao failing to write its keyring — with
+// nothing to connect it back to the chown that never ran. Naming the failure at
+// the moment it happens costs nothing and removes that guessing.
+//
+// Only failures that make the rest of the flow impossible are returned as errors
+// (see the mkdir fallbacks); everything else comes through here.
+func warnOnFailure(err error, what, consequence string) {
+	if err == nil {
+		return
 	}
-	defer f.Close()
-	s := bufio.NewScanner(f)
-	for s.Scan() {
-		line := s.Text()
-		if !strings.HasPrefix(line, vaultTokenKey+"=") {
-			continue
-		}
-		v := strings.TrimSpace(strings.TrimPrefix(line, vaultTokenKey+"="))
-		return v != "" && v != `""` && v != `''`
+	fmt.Printf("  warn: %s: %v\n", what, err)
+	if consequence != "" {
+		fmt.Printf("        %s\n", consequence)
 	}
-	return false
 }
 
 // Init runs the official OpenBao initialization flow. When force is false and
@@ -100,19 +128,26 @@ func Init(force bool) error {
 	// host is the only reliable workaround that doesn't require changing
 	// docker-compose.yaml to run the entrypoint as root.
 	openbaoDataDir, _ := filepath.Abs(filepath.Join("conf", "docker", "data", "openbao", "data"))
+	// #nosec G204 -- fixed argv; openbaoDataDir is an absolute path built from repo-relative constants, and no shell parses it
 	if err := exec.Command("sudo", "-n", "mkdir", "-p", openbaoDataDir).Run(); err != nil {
 		// Fall back to plain mkdir if sudo isn't usable — better than aborting.
-		_ = os.MkdirAll(openbaoDataDir, 0755)
+		// This one is not optional: without the directory there is nothing for
+		// the container to bind-mount, so a failure here is reported rather than
+		// left to surface later as an unexplained openbao startup error.
+		if err2 := os.MkdirAll(openbaoDataDir, 0700); err2 != nil {
+			return fmt.Errorf("failed to create %s: %w (sudo fallback also failed: %v)",
+				openbaoDataDir, err2, err)
+		}
 	}
 	// 100:100 matches the openbao user/group inside the official image.
-	_ = exec.Command("sudo", "-n", "chown", "-R", "100:100", openbaoDataDir).Run()
+	warnOnFailure(
+		exec.Command("sudo", "-n", "chown", "-R", "100:100", openbaoDataDir).Run(), // #nosec G204 -- fixed argv, constant-derived path, no shell involved
+		fmt.Sprintf("could not give %s to UID 100 (the openbao user inside the container)", openbaoDataDir),
+		"OpenBao will fail to write its keyring if the directory is not writable by that user.",
+	)
 
 	fmt.Println("Step 1/3: docker compose up -d openbao")
-	upCmd := fmt.Sprintf(
-		"COMPOSE_PROJECT_NAME=%s docker compose -f %s up -d openbao",
-		common.ComposeProjectName, common.DefaultDockerComposeConfig,
-	)
-	if err := common.SysCallWithError(upCmd); err != nil {
+	if err := composeUpOpenbao(); err != nil {
 		return fmt.Errorf("failed to bring up openbao: %w", err)
 	}
 
@@ -142,11 +177,21 @@ func Init(force bool) error {
 	// secrets subdir exists and is owned by us (we'll write init.json into
 	// it; the openbao-unseal sidecar mounts it read-only as :ro).
 	openbaoRoot := filepath.Dir(absSecretsDir) // .../data/openbao
-	_ = exec.Command("sudo", "-n", "chown",
-		fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
-		openbaoRoot,
-	).Run()
-	if err := os.MkdirAll(absSecretsDir, 0755); err != nil {
+	warnOnFailure(
+		// #nosec G204 -- fixed argv; the only interpolation is our own numeric uid/gid, and openbaoRoot is constant-derived
+		exec.Command("sudo", "-n", "chown",
+			fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
+			openbaoRoot,
+		).Run(),
+		fmt.Sprintf("could not take ownership of %s", openbaoRoot),
+		"If docker created it as root, creating the secrets directory below it will fail.",
+	)
+	// 0700: openbao-init.json lands here and holds the root token and the
+	// unseal keys. Nobody but the owner has any reason to read it, and the
+	// openbao-unseal sidecar mounts the directory into a container rather than
+	// reading it as another host user.
+	if err := os.MkdirAll(absSecretsDir, 0700); err != nil {
+		// #nosec G204 -- fixed argv, constant-derived absolute path, no shell involved
 		if err2 := exec.Command("sudo", "-n", "mkdir", "-p", absSecretsDir).Run(); err2 != nil {
 			return fmt.Errorf("failed to create %s: %w (sudo fallback also failed: %v)",
 				absSecretsDir, err, err2)
@@ -155,24 +200,57 @@ func Init(force bool) error {
 	// Make sure secrets dir is owned by us so openbao-init.sh can write
 	// init.json. Recursive is fine here — secrets is a sibling of data,
 	// the chown above on openbaoRoot is non-recursive.
-	_ = exec.Command("sudo", "-n", "chown", "-R",
-		fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
-		absSecretsDir,
-	).Run()
+	warnOnFailure(
+		// #nosec G204 -- fixed argv; the only interpolation is our own numeric uid/gid, and absSecretsDir is constant-derived
+		exec.Command("sudo", "-n", "chown", "-R",
+			fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
+			absSecretsDir,
+		).Run(),
+		fmt.Sprintf("could not take ownership of %s", absSecretsDir),
+		"openbao-init.sh writes openbao-init.json there and will fail if it cannot.",
+	)
+	// MkdirAll only applies its mode when it creates the directory, so a
+	// secrets directory left over from an earlier run keeps whatever mode it
+	// had (0755 before this change). Narrow it explicitly.
+	warnOnFailure(
+		os.Chmod(absSecretsDir, 0700), // #nosec G302 -- a directory, not a file: 0700 is already owner-only
+		fmt.Sprintf("could not restrict %s to the owner", absSecretsDir),
+		"The root token and unseal keys stored there would stay readable by other local users.",
+	)
 	absEnv, _ := filepath.Abs(envPath())
 	initOut := filepath.Join(absSecretsDir, "openbao-init.json")
 	script := filepath.Join(cbDir, "init", "openbao", "openbao-init.sh")
 	if _, err := os.Stat(script); err != nil {
 		return fmt.Errorf("openbao-init.sh not found at %s: %w", script, err)
 	}
-	_ = os.Chmod(script, 0755)
-	runCmd := fmt.Sprintf(
-		"cd %q && ENV_FILE=%q INIT_OUTPUT=%q ./init/openbao/openbao-init.sh",
-		cbDir, absEnv, initOut,
+	warnOnFailure(
+		os.Chmod(script, 0750), // #nosec G302 -- openbao-init.sh must stay executable to be run; 0750 keeps it off other users
+		fmt.Sprintf("could not make %s executable", script),
+		"Running it will fail if it is not already executable.",
 	)
-	if err := common.SysCallWithError(runCmd); err != nil {
+	// The script is executed directly with cbDir as its working directory. It
+	// used to be assembled into a `cd %q && ENV_FILE=%q … ./init/openbao/…`
+	// string handed to /bin/sh, but %q is Go quoting, not shell quoting: it
+	// produces double quotes, inside which a shell still expands $VAR and
+	// $(command). A checkout path or an .env path containing either — a
+	// directory literally named `$(id)`, or simply `$HOME` — was substituted or
+	// executed by the shell before the script ever ran.
+	if err := common.RunCommandInDir(
+		cbDir,
+		"./init/openbao/openbao-init.sh",
+		nil,
+		[]string{"ENV_FILE=" + absEnv, "INIT_OUTPUT=" + initOut},
+	); err != nil {
 		return fmt.Errorf("openbao-init.sh failed: %w", err)
 	}
+
+	// openbao-init.json now holds the root token and the unseal keys. The
+	// upstream script does not restrict it, so do it here.
+	warnOnFailure(
+		os.Chmod(initOut, 0600),
+		fmt.Sprintf("could not restrict %s to the owner", initOut),
+		"It contains the root token and the unseal keys.",
+	)
 
 	if !HasVaultToken() {
 		return fmt.Errorf(
@@ -254,7 +332,9 @@ func UnsealWith(initFile, addr string) error {
 	if !st.Sealed {
 		return nil // already unsealed — nothing to do
 	}
-	raw, err := os.ReadFile(initFile)
+	// initFile is openbaoInitFilePath() in every call site: a repo-relative
+	// constant path, never an operator-supplied one.
+	raw, err := os.ReadFile(initFile) // #nosec G304 -- constant repo-relative path, not caller-supplied
 	if err != nil {
 		return fmt.Errorf("cannot read unseal key file %s: %w", initFile, err)
 	}
@@ -382,10 +462,14 @@ func Status() StatusInfo {
 func waitOpenbaoAPI(timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for {
-		out := common.SysCallWithOutput(
-			fmt.Sprintf(`curl -sf %s/v1/sys/seal-status 2>/dev/null`, openbaoAddr),
-		)
-		if out != "" {
+		// curl is invoked as an argument vector rather than a shell string, in
+		// line with the rest of this package. openbaoAddr is a constant so the
+		// shell form was not exploitable, but keeping one style means the next
+		// address that stops being constant does not reintroduce the question.
+		// -sf already keeps curl quiet and makes an HTTP error a non-zero exit,
+		// so the discarded stderr redirect is not needed.
+		out, err := common.RunCommandOutput("curl", []string{"-sf", openbaoAddr + "/v1/sys/seal-status"}, nil)
+		if err == nil && len(out) > 0 {
 			return nil
 		}
 		if time.Now().After(deadline) {
@@ -397,30 +481,149 @@ func waitOpenbaoAPI(timeout time.Duration) error {
 
 // ensureCbTumblebugSource returns the path to a cb-tumblebug git checkout
 // matching the image tag in docker-compose.yaml, cloning it on demand.
+//
+// The checkout's *actual* version is verified, not merely the presence of the
+// init script. cb-tumblebug changes its credential yaml field names and its
+// OpenBao registration between releases, and running the wrong release's
+// openbao-init.sh does not fail — it reports success while writing an
+// inconsistent state (empty credential values that only surface much later).
+// A directory left over from an earlier version therefore has to be caught
+// here, on what is the main path of a first-time build.
 func ensureCbTumblebugSource() (string, error) {
 	version, err := tumblebugVersionFromCompose()
 	if err != nil {
 		return "", fmt.Errorf("could not read cb-tumblebug version from docker-compose.yaml: %w", err)
 	}
 	gitTag := "v" + version
-	targetDir := filepath.Join(os.Getenv("HOME"), "go", "src", "github.com", "cloud-barista")
-	cbDir := filepath.Join(targetDir, "cb-tumblebug")
-	scriptPath := filepath.Join(cbDir, "init", "openbao", "openbao-init.sh")
-	if _, err := os.Stat(scriptPath); err == nil {
-		return cbDir, nil
+	// $HOME plus fixed segments; nothing operator-supplied contributes, and
+	// Clean resolves the result before any file operation sees it.
+	targetDir := filepath.Clean(filepath.Join(os.Getenv("HOME"), "go", "src", "github.com", "cloud-barista"))
+	cbDir := filepath.Clean(filepath.Join(targetDir, "cb-tumblebug"))
+
+	if _, err := os.Stat(cbDir); err == nil { // #nosec G703 -- $HOME plus fixed segments, cleaned above
+		if err := reconcileCbTumblebugCheckout(cbDir, gitTag); err != nil {
+			return "", err
+		}
+		return cbDir, initScriptErr(cbDir, gitTag)
 	}
-	if err := os.MkdirAll(targetDir, 0755); err != nil {
+
+	// 0750 rather than 0755: only the operator running mayfly reads this checkout.
+	if err := os.MkdirAll(targetDir, 0750); err != nil { // #nosec G703 -- $HOME plus fixed segments, cleaned above
 		return "", err
 	}
-	clone := fmt.Sprintf("cd %q && git clone -b %s https://github.com/cloud-barista/cb-tumblebug.git", targetDir, gitTag)
 	fmt.Printf("  Cloning cb-tumblebug %s into %s ...\n", gitTag, cbDir)
-	if err := common.SysCallWithError(clone); err != nil {
+	if err := common.RunCommandInDir(
+		targetDir,
+		"git",
+		[]string{"clone", "-b", gitTag, "https://github.com/cloud-barista/cb-tumblebug.git"},
+		nil,
+	); err != nil {
 		return "", fmt.Errorf("git clone failed: %w", err)
 	}
-	if _, err := os.Stat(scriptPath); err != nil {
-		return "", fmt.Errorf("openbao-init.sh still missing after clone: %w", err)
+	// Confirm the clone really landed on the wanted tag. `clone -b` accepts a
+	// branch name just as happily as a tag, so checking the checked-out version
+	// is what distinguishes "cloned release v0.12.25" from "cloned some branch".
+	tag, commit, err := common.GitCheckoutVersion(cbDir)
+	if err != nil {
+		return "", fmt.Errorf("cb-tumblebug was cloned but its version cannot be read: %w", err)
 	}
-	return cbDir, nil
+	if tag != gitTag {
+		return "", fmt.Errorf(
+			"cb-tumblebug was cloned but is not on %s (currently on %s) — remove %s and run the command again",
+			gitTag, describeCheckout(tag, commit), cbDir)
+	}
+	return cbDir, initScriptErr(cbDir, gitTag)
+}
+
+// cbTumblebugInitScript is the OpenBao initialization script shipped inside a
+// cb-tumblebug checkout.
+func cbTumblebugInitScript(cbDir string) string {
+	return filepath.Join(cbDir, "init", "openbao", "openbao-init.sh")
+}
+
+// initScriptErr reports whether the checkout actually carries the script this
+// package is about to run.
+func initScriptErr(cbDir, gitTag string) error {
+	if _, err := os.Stat(cbTumblebugInitScript(cbDir)); err != nil {
+		return fmt.Errorf("openbao-init.sh is missing from the cb-tumblebug %s checkout at %s: %w", gitTag, cbDir, err)
+	}
+	return nil
+}
+
+// reconcileCbTumblebugCheckout makes an existing cb-tumblebug directory match
+// gitTag, or fails loudly.
+//
+// This runs unattended (`infra run` initializes OpenBao by itself), so it
+// cannot put a menu in front of the user the way `setup tumblebug-init` does.
+// The order of preference is therefore: never proceed on a mismatched version;
+// switch to the right tag when that is unambiguously safe; otherwise stop with
+// an error that says what to do. A mismatch is always reported, whichever
+// branch is taken.
+func reconcileCbTumblebugCheckout(cbDir, gitTag string) error {
+	tag, commit, err := common.GitCheckoutVersion(cbDir)
+	if err != nil {
+		return fmt.Errorf(
+			"%s already exists but its cb-tumblebug version cannot be verified (%v). "+
+				"Running the wrong version's openbao-init.sh corrupts the credential store without reporting an error. "+
+				"Remove the directory and run the command again to get a clean %s checkout",
+			cbDir, err, gitTag)
+	}
+	if tag == gitTag {
+		return nil
+	}
+
+	fmt.Printf("  cb-tumblebug at %s is on %s, but docker-compose.yaml runs %s.\n",
+		cbDir, describeCheckout(tag, commit), gitTag)
+
+	clean, err := common.GitWorkTreeClean(cbDir)
+	if err != nil {
+		return fmt.Errorf("cb-tumblebug version mismatch at %s (%s, expected %s), and its state cannot be read: %w",
+			cbDir, describeCheckout(tag, commit), gitTag, err)
+	}
+	if !clean {
+		return fmt.Errorf(
+			"cb-tumblebug at %s is on %s but %s is required, and the checkout has local changes so it cannot be switched automatically. "+
+				"Commit or discard the changes and run `git -C %s checkout %s`, or remove the directory and run the command again",
+			cbDir, describeCheckout(tag, commit), gitTag, cbDir, gitTag)
+	}
+	if !common.GitTagExists(cbDir, gitTag) {
+		return fmt.Errorf(
+			"cb-tumblebug at %s is on %s but %s is required, and that tag is not present in the local checkout. "+
+				"Run `git -C %s fetch --tags && git -C %s checkout %s`, or remove the directory and run the command again",
+			cbDir, describeCheckout(tag, commit), gitTag, cbDir, cbDir, gitTag)
+	}
+
+	fmt.Printf("  Switching cb-tumblebug to %s ...\n", gitTag)
+	if _, err := common.GitOutputInDir(cbDir, "checkout", gitTag); err != nil {
+		return fmt.Errorf("could not switch cb-tumblebug at %s to %s: %w — remove the directory and run the command again",
+			cbDir, gitTag, err)
+	}
+
+	// Read the version back rather than trusting the checkout to have done what
+	// was asked: the whole point here is that a silent mismatch is the failure.
+	tag, commit, err = common.GitCheckoutVersion(cbDir)
+	if err != nil || tag != gitTag {
+		return fmt.Errorf("cb-tumblebug at %s is still not on %s after switching (currently on %s)",
+			cbDir, gitTag, describeCheckout(tag, commit))
+	}
+	fmt.Printf("  cb-tumblebug is now on %s.\n", gitTag)
+	return nil
+}
+
+// describeCheckout renders a checkout for a message: its tag when it sits on
+// one, otherwise the commit it is parked at.
+func describeCheckout(tag, commit string) string {
+	if tag != "" {
+		return tag
+	}
+	if commit == "" {
+		return "an unknown version"
+	}
+	short := commit
+	if len(short) > 12 {
+		short = short[:12]
+	}
+	return "commit " + short + " (no release tag)"
 }
 
 func tumblebugVersionFromCompose() (string, error) {
@@ -443,23 +646,25 @@ func readEnvToken() string {
 	return readEnvValue(vaultTokenKey)
 }
 
-// readEnvValue returns the raw value of key from mayfly's .env, or "" when the
-// file or the key is absent. Values are used as-is (no shell-style expansion) —
-// the keys read here (VAULT_TOKEN, TB_API_*) are plain literals.
+// readEnvValue returns the value of key from mayfly's .env, or "" when the file
+// or the key is absent. Values are used as-is apart from quote stripping (no
+// shell-style expansion) — the keys read here (VAULT_TOKEN, TB_API_*) are plain
+// literals.
+//
+// This delegates to common.ParseDotEnv rather than scanning the file itself.
+// The hand-rolled scanner it replaces did not strip surrounding quotes, and the
+// values are used as credentials: TB_API_PASSWORD="pass" came back with the
+// quotes attached, so the Basic auth header carried `"pass"` and cb-tumblebug
+// answered 401. probeContainerToken reads that 401 as "cannot tell", which
+// downgrades the container-token check to unknown and quietly disables the very
+// signal container_token.go exists to provide. Having one parser means a value
+// is read the same way whoever reads it.
 func readEnvValue(key string) string {
-	f, err := os.Open(envPath())
+	values, err := common.ParseDotEnv(envPath())
 	if err != nil {
 		return ""
 	}
-	defer f.Close()
-	s := bufio.NewScanner(f)
-	for s.Scan() {
-		line := s.Text()
-		if strings.HasPrefix(line, key+"=") {
-			return strings.TrimSpace(strings.TrimPrefix(line, key+"="))
-		}
-	}
-	return ""
+	return values[key]
 }
 
 func maskToken(tok string) string {

--- a/internal/openbao/init_test.go
+++ b/internal/openbao/init_test.go
@@ -1,0 +1,180 @@
+package openbao
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cm-mayfly/cm-mayfly/common"
+)
+
+// writeEnv lays down a conf/docker/.env under a fresh temp root and chdirs
+// there, which is what envPath() resolves against.
+func writeEnv(t *testing.T, contents string) string {
+	t.Helper()
+	root := t.TempDir()
+	dockerDir := filepath.Join(root, "conf", "docker")
+	if err := os.MkdirAll(dockerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(dockerDir, ".env")
+	if err := os.WriteFile(p, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(root)
+	return p
+}
+
+// readEnvValue must strip surrounding quotes.
+//
+// This is the regression that mattered most: the previous hand-rolled scanner
+// returned TB_API_PASSWORD="pass" with the quotes attached, so the Basic auth
+// header carried `"pass"`, cb-tumblebug answered 401, and probeContainerToken
+// read that 401 as "cannot tell" — silently turning the container-token check
+// into a permanent "unknown".
+func TestReadEnvValueStripsQuotes(t *testing.T) {
+	writeEnv(t, strings.Join([]string{
+		`TB_API_USERNAME="default"`,
+		`TB_API_PASSWORD="p@ss word"`,
+		`SINGLE='sq-value'`,
+		`PLAIN=plain-value`,
+		`SPACED =  spaced-value  `,
+		`export EXPORTED="exported-value"`,
+		`# COMMENTED="ignored"`,
+		``,
+	}, "\n"))
+
+	for _, tc := range []struct{ key, want string }{
+		{"TB_API_USERNAME", "default"},
+		{"TB_API_PASSWORD", "p@ss word"},
+		{"SINGLE", "sq-value"},
+		{"PLAIN", "plain-value"},
+		{"SPACED", "spaced-value"},
+		{"EXPORTED", "exported-value"},
+		{"COMMENTED", ""},
+		{"ABSENT", ""},
+	} {
+		if got := readEnvValue(tc.key); got != tc.want {
+			t.Errorf("readEnvValue(%q) = %q, want %q", tc.key, got, tc.want)
+		}
+	}
+}
+
+// HasVaultToken has to agree with readEnvValue, including on the quoted-empty
+// forms it used to special-case by hand.
+func TestHasVaultToken(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		env  string
+		want bool
+	}{
+		{"set", "VAULT_TOKEN=s.abc123\n", true},
+		{"set quoted", `VAULT_TOKEN="s.abc123"` + "\n", true},
+		{"blank", "VAULT_TOKEN=\n", false},
+		{"double-quoted empty", `VAULT_TOKEN=""` + "\n", false},
+		{"single-quoted empty", `VAULT_TOKEN=''` + "\n", false},
+		{"absent", "TUMBLEBUG_DB_PASSWORD=keepme\n", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			writeEnv(t, tc.env)
+			if got := HasVaultToken(); got != tc.want {
+				t.Errorf("HasVaultToken() = %v, want %v (env %q)", got, tc.want, tc.env)
+			}
+		})
+	}
+}
+
+// A missing .env is not a token.
+func TestHasVaultTokenNoFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if HasVaultToken() {
+		t.Error("HasVaultToken() = true with no .env at all")
+	}
+}
+
+// The openbao flow runs its script through common.RunCommandInDir, not a shell
+// string. This pins the property that actually protects it: a working directory
+// holding shell metacharacters is passed to the kernel literally instead of
+// being expanded.
+//
+// The old code built `cd %q && ENV_FILE=%q … ./init/openbao/openbao-init.sh`
+// for /bin/sh. %q is Go quoting, which emits double quotes — and inside double
+// quotes a shell still expands $VAR and runs $(command). A checkout path
+// containing either was substituted, or executed, before the script started.
+func TestRunCommandInDirDoesNotGoThroughAShell(t *testing.T) {
+	parent := t.TempDir()
+	// A directory name a shell would mangle: command substitution, a variable
+	// reference, and whitespace.
+	hostile := filepath.Join(parent, `$(touch pwned) $HOME dir`)
+	if err := os.Mkdir(hostile, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// A script in that directory, invoked by relative path exactly as
+	// openbao-init.sh is, that reports where it ran and what it was handed.
+	script := filepath.Join(hostile, "probe.sh")
+	body := "#!/bin/sh\npwd\nprintf 'ENV_FILE=%s\\n' \"$ENV_FILE\"\n"
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// The env value carries metacharacters too — it stands in for a path that
+	// would have been interpolated into the old command string.
+	envValue := `/tmp/$(touch pwned-env)/.env`
+
+	out := captureStdout(t, func() {
+		if err := common.RunCommandInDir(hostile, "./probe.sh", nil, []string{"ENV_FILE=" + envValue}); err != nil {
+			t.Fatalf("RunCommandInDir: %v", err)
+		}
+	})
+
+	// The script ran in the hostile directory, name intact.
+	if !strings.Contains(out, hostile) {
+		t.Errorf("script did not run in %q; output was %q", hostile, out)
+	}
+	// The env var arrived byte-for-byte, unexpanded.
+	if !strings.Contains(out, "ENV_FILE="+envValue) {
+		t.Errorf("ENV_FILE was not passed literally; output was %q", out)
+	}
+	// Nothing executed the command substitutions.
+	for _, dir := range []string{parent, hostile} {
+		if _, err := os.Stat(filepath.Join(dir, "pwned")); err == nil {
+			t.Errorf("command substitution in the directory name was executed (found %s/pwned)", dir)
+		}
+		if _, err := os.Stat(filepath.Join(dir, "pwned-env")); err == nil {
+			t.Errorf("command substitution in the env value was executed (found %s/pwned-env)", dir)
+		}
+	}
+}
+
+// captureStdout collects everything fn prints, since RunCommandInDir streams the
+// child's output to stdout rather than returning it.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var sb strings.Builder
+		buf := make([]byte, 4096)
+		for {
+			n, err := r.Read(buf)
+			if n > 0 {
+				sb.Write(buf[:n])
+			}
+			if err != nil {
+				break
+			}
+		}
+		done <- sb.String()
+	}()
+	fn()
+	w.Close()
+	os.Stdout = orig
+	return <-done
+}

--- a/internal/openbao/preflight.go
+++ b/internal/openbao/preflight.go
@@ -18,8 +18,6 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/cm-mayfly/cm-mayfly/common"
 )
 
 // Case enumerates the OpenBao state-consistency verdicts. See the state-signal
@@ -235,7 +233,7 @@ func waitOpenbaoActive(addr string, timeout time.Duration) error {
 	for {
 		if resp, err := c.Get(url); err == nil {
 			code := resp.StatusCode
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			if code == http.StatusOK {
 				return nil // active
 			}
@@ -252,11 +250,7 @@ func waitOpenbaoActive(addr string, timeout time.Duration) error {
 // This is exactly the staged flow Init() already relies on; `infra run` uses it
 // to get a definitive diagnosis before deciding whether to bring up the rest.
 func startOpenbaoAlone() error {
-	up := fmt.Sprintf(
-		"COMPOSE_PROJECT_NAME=%s docker compose -f %s up -d openbao",
-		common.ComposeProjectName, common.DefaultDockerComposeConfig,
-	)
-	if err := common.SysCallWithError(up); err != nil {
+	if err := composeUpOpenbao(); err != nil {
 		return err
 	}
 	return waitOpenbaoAPI(60 * time.Second)
@@ -478,8 +472,8 @@ func adviceFor(c Case, shape initFileShape, reachable bool) string {
 			envPathHint, rootTok, jsonPathHint, envPathHint)
 	case CaseCorrupt:
 		return fmt.Sprintf(
-			"⚠ OpenBao data exists on disk but the API reports it is not initialized (possible mount misconfig).\n"+
-				"  Check: ./mayfly setup openbao status\n"+
+			"⚠ OpenBao data exists on disk but the API reports it is not initialized (possible mount misconfig).\n" +
+				"  Check: ./mayfly setup openbao status\n" +
 				"  If the data is truly unusable: ./mayfly infra remove --clean-all  then re-init.")
 	case CaseWrongToken:
 		return fmt.Sprintf(

--- a/internal/openbao/tumblebug_source_test.go
+++ b/internal/openbao/tumblebug_source_test.go
@@ -1,0 +1,224 @@
+package openbao
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// requireGit skips the test when git is unavailable so the suite stays green
+// on machines and CI images without a git binary.
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not available")
+	}
+}
+
+// runGit runs git inside dir with a fixed identity, since committing fails
+// when no user.name/user.email is configured in the environment.
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	full := append([]string{
+		"-c", "user.email=test@example.com",
+		"-c", "user.name=test",
+		"-c", "commit.gpgsign=false",
+	}, args...)
+	cmd := exec.Command("git", full...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// fakeTumblebugCheckout builds a local stand-in for a cb-tumblebug clone: two
+// releases carrying different openbao-init.sh contents, both tagged the way
+// cb-tumblebug tags its releases — lightweight. No network is involved; the
+// point of these tests is the version check, not the clone.
+func fakeTumblebugCheckout(t *testing.T) string {
+	t.Helper()
+	requireGit(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-q", "-b", "main")
+
+	scriptDir := filepath.Join(dir, "init", "openbao")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(scriptDir, "openbao-init.sh")
+
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho v0.12.22\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-q", "-m", "v0.12.22")
+	runGit(t, dir, "tag", "v0.12.22") // lightweight, as upstream does
+
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho v0.12.25\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-q", "-m", "v0.12.25")
+	runGit(t, dir, "tag", "v0.12.25")
+
+	return dir
+}
+
+// TestReconcileAcceptsMatchingCheckout: the wanted release is already checked
+// out, so nothing happens and nothing is reported.
+func TestReconcileAcceptsMatchingCheckout(t *testing.T) {
+	dir := fakeTumblebugCheckout(t)
+	runGit(t, dir, "checkout", "-q", "v0.12.25")
+
+	if err := reconcileCbTumblebugCheckout(dir, "v0.12.25"); err != nil {
+		t.Fatalf("a checkout already on the wanted tag was rejected: %v", err)
+	}
+	if got := runGit(t, dir, "describe", "--exact-match", "--tags", "HEAD"); got != "v0.12.25" {
+		t.Errorf("checkout moved unexpectedly: now on %q", got)
+	}
+}
+
+// TestReconcileSwitchesStaleCheckout is the bug this change is about: a
+// directory left over from an older release must not be used as-is. With a
+// clean work tree the fix is to move it onto the wanted tag.
+func TestReconcileSwitchesStaleCheckout(t *testing.T) {
+	dir := fakeTumblebugCheckout(t)
+	runGit(t, dir, "checkout", "-q", "v0.12.22")
+
+	if err := reconcileCbTumblebugCheckout(dir, "v0.12.25"); err != nil {
+		t.Fatalf("a clean stale checkout should have been switched, got: %v", err)
+	}
+	if got := runGit(t, dir, "describe", "--exact-match", "--tags", "HEAD"); got != "v0.12.25" {
+		t.Fatalf("checkout was not switched: still on %q", got)
+	}
+	// The script that would actually run must be the new release's.
+	body, err := os.ReadFile(filepath.Join(dir, "init", "openbao", "openbao-init.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "v0.12.25") {
+		t.Errorf("the old release's openbao-init.sh is still on disk: %q", body)
+	}
+}
+
+// TestReconcileRefusesDirtyStaleCheckout: switching would carry local edits
+// onto another release, so this stops instead — loudly, with instructions.
+func TestReconcileRefusesDirtyStaleCheckout(t *testing.T) {
+	dir := fakeTumblebugCheckout(t)
+	runGit(t, dir, "checkout", "-q", "v0.12.22")
+	if err := os.WriteFile(filepath.Join(dir, "init", "openbao", "openbao-init.sh"),
+		[]byte("#!/bin/sh\necho edited\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := reconcileCbTumblebugCheckout(dir, "v0.12.25")
+	if err == nil {
+		t.Fatal("a stale checkout with local changes was accepted silently")
+	}
+	for _, want := range []string{"v0.12.22", "v0.12.25", "local changes"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q, got: %v", want, err)
+		}
+	}
+	if got := runGit(t, dir, "describe", "--exact-match", "--tags", "HEAD"); got != "v0.12.22" {
+		t.Errorf("the checkout was moved despite local changes: now on %q", got)
+	}
+}
+
+// TestReconcileRefusesWhenTagAbsent: the wanted release is not in this
+// checkout at all, so there is nothing safe to switch to.
+func TestReconcileRefusesWhenTagAbsent(t *testing.T) {
+	dir := fakeTumblebugCheckout(t)
+	runGit(t, dir, "checkout", "-q", "v0.12.22")
+
+	err := reconcileCbTumblebugCheckout(dir, "v0.99.0")
+	if err == nil {
+		t.Fatal("a checkout missing the wanted tag was accepted silently")
+	}
+	if !strings.Contains(err.Error(), "not present in the local checkout") {
+		t.Errorf("error should explain the tag is missing, got: %v", err)
+	}
+}
+
+// TestReconcileRefusesOffTagCheckout: HEAD parked on an untagged commit cannot
+// be shown to match the wanted release, so it is not used.
+func TestReconcileRefusesOffTagCheckout(t *testing.T) {
+	dir := fakeTumblebugCheckout(t)
+	runGit(t, dir, "checkout", "-q", "v0.12.22")
+	if err := os.WriteFile(filepath.Join(dir, "extra.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-q", "-m", "local work")
+
+	// The wanted tag exists and the tree is clean, so this one is recoverable:
+	// it must end up on the tag rather than quietly running the untagged code.
+	if err := reconcileCbTumblebugCheckout(dir, "v0.12.25"); err != nil {
+		t.Fatalf("a clean off-tag checkout should have been switched, got: %v", err)
+	}
+	if got := runGit(t, dir, "describe", "--exact-match", "--tags", "HEAD"); got != "v0.12.25" {
+		t.Fatalf("checkout was not switched: still on %q", got)
+	}
+}
+
+// TestReconcileRefusesNonGitDirectory: a directory that is not a checkout has
+// no version to verify, so it cannot be trusted to hold the right release.
+func TestReconcileRefusesNonGitDirectory(t *testing.T) {
+	requireGit(t)
+	dir := t.TempDir()
+	scriptDir := filepath.Join(dir, "init", "openbao")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The script is present — under the old code that alone was enough.
+	if err := os.WriteFile(filepath.Join(scriptDir, "openbao-init.sh"), []byte("#!/bin/sh\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := reconcileCbTumblebugCheckout(dir, "v0.12.25")
+	if err == nil {
+		t.Fatal("a non-git directory was accepted just because openbao-init.sh existed")
+	}
+	if !strings.Contains(err.Error(), "cannot be verified") {
+		t.Errorf("error should say the version cannot be verified, got: %v", err)
+	}
+}
+
+// TestInitScriptErr checks the remaining half of the guarantee: the checkout is
+// on the right release *and* actually carries the script.
+func TestInitScriptErr(t *testing.T) {
+	dir := fakeTumblebugCheckout(t)
+	runGit(t, dir, "checkout", "-q", "v0.12.25")
+	if err := initScriptErr(dir, "v0.12.25"); err != nil {
+		t.Fatalf("a checkout carrying openbao-init.sh was rejected: %v", err)
+	}
+
+	empty := t.TempDir()
+	err := initScriptErr(empty, "v0.12.25")
+	if err == nil {
+		t.Fatal("a checkout without openbao-init.sh was accepted")
+	}
+	if !strings.Contains(err.Error(), "openbao-init.sh is missing") {
+		t.Errorf("unexpected error text: %v", err)
+	}
+}
+
+func TestDescribeCheckout(t *testing.T) {
+	cases := []struct {
+		tag, commit, want string
+	}{
+		{"v0.12.25", "abcdef1234567890", "v0.12.25"},
+		{"", "abcdef1234567890", "commit abcdef123456 (no release tag)"},
+		{"", "", "an unknown version"},
+	}
+	for _, c := range cases {
+		if got := describeCheckout(c.tag, c.commit); got != c.want {
+			t.Errorf("describeCheckout(%q, %q) = %q, want %q", c.tag, c.commit, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## What this changes

`-s` accepts a comma-separated list and the execution path has always expanded it, but `run`, `update` and `logs` never read it that way. `run` and `update` looked the whole string up as one service name and stopped with "not found" — the example in `docs/cm-mayfly-infra.md` did not work. `logs` passed it through verbatim, and since compose does not validate service names, that returned nothing instead of an error.

Investigating that surfaced two wider problems, and this PR addresses both rather than patching the three symptoms.

**Service names were parsed in five places under three different rules.** The same input behaved differently depending on the command. They are now one function that splits on commas and spaces, validates each name against the compose file, names the offending entry when one is unknown, and refuses a value that yields nothing.

That last condition matters more than it sounds. `-s ","` previously collapsed to "no services", which `remove` reads as "every service" — a typo deleted the whole environment. Verified against a running stack: the old binary listed 14 data directories for removal, the new one stops.

**Commands were assembled into shell strings.** `--tail`, `--since` and `-s` values reached `/bin/sh`, so a value containing `;` ran as a second command (reproduced: `--tail '1; echo INJECTED'` executed). They are now argument vectors with no shell involved, and `COMPOSE_PROJECT_NAME` is passed through the child environment instead of being prefixed onto a string. No shell assembly remains on any execution path.

Exit statuses are now checked, so a failed step stops the sequence instead of reporting success. `remove` additionally verifies passwordless sudo up front and confirms every delete target resolves inside the data directory.

## Also included

- `rest` treats the whole 2xx range as success. `201` and `204` exited 2, which made a healthcheck against such an endpoint permanently unhealthy. All five verbs now return a failure status; only `get` did before.
- `api` reports an unsupported method instead of dereferencing a nil response, which surfaced as a stack trace on a config typo.
- `setup credential` honours the configured host, port and credentials for the registration call, wires up the header flag, and checks the response status. It previously posted to a fixed address with fixed credentials and reported success regardless of the reply.
- The `.env` writer narrows the file to owner-only and replaces it atomically. The mode had never taken effect, because it only applies on create.
- Verbose output masks passwords and tokens, the generated init script gets an unpredictable name, and the secrets directory is owner-only.
- Version detection asks git for lightweight tags. Every cb-tumblebug release tag is lightweight, so detection failed on all of them and a correctly checked-out release still prompted to switch on every run. The OpenBao path now verifies the checkout it is about to use rather than trusting a file's presence.
- Service listings and dependency resolution read the compose file instead of hardcoded tables, image sizes match the exact tag, and the status table shows which version is actually running.
- Streaming no longer passes output through a line scanner, which stalled the command on a line beyond its limit.
- `cmd/k8s` moves behind a build tag with a README. It is preserved for future work, not built today.

## Verification

Built a new instance and ran the full path from an empty host: 22 services healthy, 88 CSP connections registered, assets loaded, then stop/start, host reboot, all three removal modes, and a rebuild. Each of the 14 defects was reproduced on the old binary and confirmed blocked on the new one, side by side against a running stack.

Display changes were checked against 22 running containers — every table line measures the same width, and the version column halved because the status qualifier is now a mark rather than a phrase.

Static analysis went from 70 findings to 0 (19 high, 31 medium). 35 of those are suppressions, each carrying a stated reason; the rest were fixed in code. Dependency scanning reports no vulnerabilities, and the build, vet and tests pass across all seven packages.

Four defects only appeared during that verification and are fixed here too: version detection failing on every release, `update -d` being unregistered, shell assembly in the initialization path (confirmed executing), and long lines stalling rather than truncating.

## Compatibility

Intentional behaviour changes, worth noting in release notes:

- Non-GET requests return a non-zero exit status on failure. Scripts that ignored the result will start seeing failures.
- `201` and `204` are treated as success.
- `-s " "` is now an error. It previously meant "all services", which is what made the deletion incident possible.
- Conflicting removal flags are rejected instead of one silently winning.
- `infra update` reports failure when every local image lookup fails, rather than rendering a table claiming nothing is installed.