### PR TITLE
feat(infra): repeatable -s, OpenBao readiness guard for targeted run/update, and api tool fixes

### DIFF
--- a/cmd/apicall/parse.go
+++ b/cmd/apicall/parse.go
@@ -83,18 +83,18 @@ func runTool(cmd *cobra.Command) error {
 		}
 	}
 	if srcN > 1 {
-		return fmt.Errorf("소스 옵션은 -f / --latest / --release 중 하나만 지정하세요.")
+		return fmt.Errorf("specify only one source option: -f, --latest or --release")
 	}
 
 	// No source given: ask (latest vs a specific release).
 	if srcN == 0 {
 		if skipConfirm {
-			return fmt.Errorf("자동화(-y) 시에는 소스(-f/--latest/--release)와 대상(--service)을 명시하세요.")
+			return fmt.Errorf("with -y, name both the source (-f/--latest/--release) and the target (--service)")
 		}
-		if promptChoice("Swagger 소스가 지정되지 않았습니다. 어떤 Swagger를 사용할까요?", "최신(각 서비스 기본 브랜치)", "특정 릴리스 버전") == 2 {
-			releaseVer = promptLine("릴리스 버전을 입력하세요 (예: v0.5.2): ")
+		if promptChoice("No Swagger source given. Which Swagger should be used?", "Latest (each service's default branch)", "A specific release") == 2 {
+			releaseVer = promptLine("Enter the release tag (e.g. v0.5.2): ")
 			if releaseVer == "" {
-				return fmt.Errorf("릴리스 버전이 입력되지 않았습니다.")
+				return fmt.Errorf("no release tag was entered")
 			}
 		} else {
 			useLatest = true
@@ -102,7 +102,7 @@ func runTool(cmd *cobra.Command) error {
 	}
 
 	if !applyToYaml {
-		fmt.Println("api.yaml에 직접 반영하려면 --apply 플래그를 지정해 주세요. (현재는 화면 출력만 합니다.)")
+		fmt.Println("Add --apply to write the result into api.yaml (this run only prints it).")
 	}
 
 	// Determine the target services.
@@ -111,21 +111,21 @@ func runTool(cmd *cobra.Command) error {
 	case serviceName != "":
 		svcs = []string{serviceName}
 	case fileSet:
-		return fmt.Errorf("-f로 단일 소스를 줄 때는 --service로 대상 서비스를 지정하세요.")
+		return fmt.Errorf("when a single source is given with -f, name the target service with --service")
 	default:
 		if skipConfirm {
-			return fmt.Errorf("자동화(-y) 시에는 --service를 명시하세요.")
+			return fmt.Errorf("with -y, name the target service with --service")
 		}
-		if promptChoice("--service 미지정 — 처리 대상을 선택하세요.", "특정 서비스만", "전체 서비스") == 1 {
-			s := promptLine("서비스명을 입력하세요: ")
+		if promptChoice("--service not given - choose what to process.", "A single service", "Every service") == 1 {
+			s := promptLine("Enter the service name: ")
 			if s == "" {
-				return fmt.Errorf("서비스명이 입력되지 않았습니다.")
+				return fmt.Errorf("no service name was entered")
 			}
 			svcs = []string{s}
 		} else {
 			svcs = registeredSwaggerServices()
 			if len(svcs) == 0 {
-				return fmt.Errorf("swagger 정보가 등록된 서비스가 없습니다 (api.yaml services.<svc>.swagger).")
+				return fmt.Errorf("no service has a swagger source registered (api.yaml services.<svc>.swagger)")
 			}
 		}
 	}
@@ -140,9 +140,9 @@ func runTool(cmd *cobra.Command) error {
 		url, ok := resolveSwaggerURL(svc)
 		if !ok {
 			if len(svcs) == 1 {
-				return fmt.Errorf("서비스 %q에 swagger 정보가 없습니다. -f로 직접 지정하거나 api.yaml의 services.%s.swagger를 확인하세요.", svc, svc)
+				return fmt.Errorf("service %q has no swagger source. Pass one with -f, or check services.%s.swagger in api.yaml", svc, svc)
 			}
-			missing = append(missing, swaggerTarget{svc, "(swagger 미등록)"})
+			missing = append(missing, swaggerTarget{svc, "(no swagger registered)"})
 			continue
 		}
 		if swaggerExists(url) {
@@ -153,44 +153,44 @@ func runTool(cmd *cobra.Command) error {
 	}
 
 	// Summary + confirmation.
-	verb := "api.yaml 구조로 화면에 출력합니다"
+	verb := "will be printed in api.yaml form"
 	if applyToYaml {
-		verb = "api.yaml에 반영합니다"
+		verb = "will be written into api.yaml"
 	}
 	multi := len(svcs) > 1
 	if multi {
-		relLabel := "최신"
+		relLabel := "latest"
 		if releaseVer != "" {
-			relLabel = releaseVer + " 릴리스 버전의"
+			relLabel = releaseVer + " release"
 		}
-		fmt.Printf("\n모든 서비스에 대해 %s API를 %s.\n", relLabel, verb)
+		fmt.Printf("\nThe %s API of every service %s.\n", relLabel, verb)
 		if len(missing) > 0 {
 			fmt.Println()
 			fmt.Println(hrThick)
-			fmt.Println("[경고]")
+			fmt.Println("[Warning]")
 			fmt.Println(hrThick)
-			fmt.Println("아래 서비스들은 요청한 버전의 API 문서가 존재하지 않습니다. 버전 및 URL을 확인하세요.")
-			fmt.Println("(-f 와 -s 옵션을 이용하면 특정 URL과 특정 서비스를 지정할 수 있습니다.)")
+			fmt.Println("No API document exists at the requested version for the services below. Check the version and the URL.")
+			fmt.Println("(Use -f and -s to point at a specific URL and service.)")
 			printTargets(missing)
 			fmt.Println(hrThin)
 		}
 		if len(present) == 0 {
-			fmt.Println("\n처리할 수 있는 서비스가 없습니다.")
+			fmt.Println("\nThere is no service to process.")
 			return nil
 		}
-		fmt.Println("\n아래 서비스들의 API만 처리합니다.")
+		fmt.Println("\nOnly the API of the services below will be processed.")
 		printTargets(present)
 	} else {
 		if len(present) == 0 {
 			m := missing[0]
-			return fmt.Errorf("요청한 Swagger를 찾을 수 없습니다: %s : %s — 버전(vX.Y.Z) 또는 --latest 를 확인하세요.", m.svc, m.url)
+			return fmt.Errorf("the requested Swagger was not found: %s : %s - check the version (vX.Y.Z) or use --latest", m.svc, m.url)
 		}
 		t := present[0]
-		scope := t.svc + " Service 전체"
+		scope := t.svc + " service (all actions)"
 		if actionName != "" {
-			scope = fmt.Sprintf("%s Service의 %s 액션", t.svc, actionName)
+			scope = fmt.Sprintf("the %s action of the %s service", actionName, t.svc)
 		}
-		fmt.Printf("\n%s에 대해 %s.\n소스: %s\n", scope, verb, t.url)
+		fmt.Printf("\n%s %s.\nSource: %s\n", scope, verb, t.url)
 	}
 
 	// A raw -f source carries no requested version, so the version recorded in
@@ -206,15 +206,15 @@ func runTool(cmd *cobra.Command) error {
 		fmt.Println("  Use --release <tag> instead to record the exact version.")
 	}
 
-	if !skipConfirm && !confirmYN("\n계속 진행하시겠습니까? (Y/n): ") {
-		fmt.Println("취소되었습니다.")
+	if !skipConfirm && !confirmYN("\nProceed? (Y/n): ") {
+		fmt.Println("Cancelled.")
 		return nil
 	}
 
 	var firstErr error
 	for _, t := range present {
 		if err := processOne(t.svc, t.url); err != nil {
-			fmt.Printf("[%s] 실패: %v\n", t.svc, err)
+			fmt.Printf("[%s] failed: %v\n", t.svc, err)
 			if firstErr == nil {
 				firstErr = err
 			}
@@ -381,7 +381,7 @@ func promptChoice(q string, opts ...string) int {
 	for i, o := range opts {
 		fmt.Printf("  %d) %s\n", i+1, o)
 	}
-	fmt.Print("선택: ")
+	fmt.Print("Choice: ")
 	line, _ := stdinReader.ReadString('\n')
 	n, _ := strconv.Atoi(strings.TrimSpace(line))
 	if n < 1 || n > len(opts) {
@@ -704,22 +704,22 @@ func splitNonEmpty(block string) []string {
 }
 
 func convertActionlName(tmpActionName string) string {
-	//일부 특수 기호들 제거
+	// Strip some special characters
 	tmpActionName = strings.ReplaceAll(tmpActionName, ":", "-")
 	tmpActionName = strings.ReplaceAll(tmpActionName, "`", "")
 	tmpActionName = strings.ReplaceAll(tmpActionName, "'", "")
 
-	//카멜타입으로 변경
+	// Convert to camel case
 	tmpActionName = toCamelCase(tmpActionName)
 
 	return tmpActionName
 }
 
 func toCamelCase(str string) string {
-	words := strings.Fields(str) // 문자열을 공백을 기준으로 단어로 분할
+	words := strings.Fields(str) // Split the string into words on whitespace
 	var result strings.Builder
 	for _, word := range words {
-		result.WriteString(strings.Title(word)) // 각 단어의 첫 글자를 대문자로 만듦
+		result.WriteString(strings.Title(word)) // Capitalize the first letter of each word
 	}
 	return result.String()
 }

--- a/cmd/apicall/parse.go
+++ b/cmd/apicall/parse.go
@@ -193,6 +193,19 @@ func runTool(cmd *cobra.Command) error {
 		fmt.Printf("\n%s에 대해 %s.\n소스: %s\n", scope, verb, t.url)
 	}
 
+	// A raw -f source carries no requested version, so the version recorded in
+	// api.yaml falls back to whatever the document declares in info.version —
+	// usually "latest", which does not say which release is actually deployed.
+	// Warn before writing that, because the only fix afterwards is editing
+	// api.yaml by hand.
+	if applyToYaml && fileSet {
+		fmt.Println("\n⚠ Caution: the Swagger given with -f does not carry the release it belongs to.")
+		fmt.Println("  The version recorded in api.yaml will be the document's own info.version")
+		fmt.Println("  (most services publish \"latest\"), so it may not match the release you are")
+		fmt.Println("  deploying, and correcting it afterwards means editing api.yaml by hand.")
+		fmt.Println("  Use --release <tag> instead to record the exact version.")
+	}
+
 	if !skipConfirm && !confirmYN("\n계속 진행하시겠습니까? (Y/n): ") {
 		fmt.Println("취소되었습니다.")
 		return nil
@@ -245,7 +258,39 @@ func processOne(svc, source string) error {
 		fmt.Print(renderActions(actions))
 		return nil
 	}
-	return applyToApiYaml(common.API_FILE, svc, actionName != "", actions, version)
+	apiFile, err := resolveApiFile()
+	if err != nil {
+		return err
+	}
+	return applyToApiYaml(apiFile, svc, actionName != "", actions, version)
+}
+
+// resolveApiFile returns the api.yaml that --apply should update.
+//
+// -c names the file the command works on, and it has to name it for writing as
+// well as for reading: resolving the swagger URLs from one file and then writing
+// the result into another is how an update silently lands in the wrong place.
+//
+// Without -c the configured default is used when it exists, and otherwise an
+// api.yaml in the current directory is accepted, so the tool still works from a
+// checkout whose layout puts the file elsewhere.
+func resolveApiFile() (string, error) {
+	if configFile != "" {
+		if _, err := os.Stat(configFile); err == nil {
+			return configFile, nil
+		}
+		// An explicitly named file that does not exist is an error, not a
+		// reason to quietly fall back to some other file.
+		if configFile != common.API_FILE {
+			return "", fmt.Errorf("config file not found: %s", configFile)
+		}
+	}
+	for _, candidate := range []string{common.API_FILE, "./api.yaml"} {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("api.yaml not found (looked for %s and ./api.yaml)\nRun this from the directory that holds it, or point at it with -c", common.API_FILE)
 }
 
 // recordedVersion returns the version recorded to api.yaml as
@@ -431,8 +476,9 @@ func applyToApiYaml(apiFile, service string, singleAction bool, actions map[stri
 		return fmt.Errorf("failed to read %s: %w", apiFile, err)
 	}
 
-	// apiFile is common.API_FILE at the only call site — the tool's own
-	// conf/api.yaml — so the backup name derived from it is equally fixed.
+	// apiFile is whatever resolveApiFile settled on — the configured default or
+	// the file named with -c — so the backup sits next to the file being
+	// updated rather than next to a fixed path.
 	backup := fmt.Sprintf("%s.bak.%s", apiFile, time.Now().Format("20060102-150405"))
 	if err := os.WriteFile(backup, orig, 0600); err != nil { // #nosec G703 -- derived from the fixed internal api.yaml path
 		return fmt.Errorf("failed to write backup %s: %w", backup, err)
@@ -584,7 +630,7 @@ func updateServiceActionsBlock(content, service string, singleAction bool, actio
 	}
 	sa := mapChild(root, "serviceActions")
 	if sa == nil {
-		return "", fmt.Errorf("'serviceActions:' section not found in %s", common.API_FILE)
+		return "", fmt.Errorf("'serviceActions:' section not found in the target api.yaml")
 	}
 	lines := strings.Split(content, "\n")
 

--- a/cmd/docker/common.go
+++ b/cmd/docker/common.go
@@ -274,6 +274,22 @@ func resolveServices(raw string) ([]string, error) {
 	return validateServiceNames(names, available)
 }
 
+// resolveSelectedServices turns the -s flag values into a validated service
+// list. The flag is repeatable and each occurrence may itself hold several
+// names separated by commas or spaces, so the occurrences are joined and handed
+// to resolveServices — the single splitting/validating path every subcommand
+// shares. All three forms therefore select the same services:
+//
+//	-s cb-spider -s cb-tumblebug
+//	-s cb-spider,cb-tumblebug
+//	-s "cb-spider cb-tumblebug"
+//
+// Omitting -s entirely still means "every service", and a value that holds only
+// separators is still an error rather than "all" — see resolveServices.
+func resolveSelectedServices() ([]string, error) {
+	return resolveServices(strings.Join(ServiceNames, ","))
+}
+
 // validateServiceNames checks each already-split name against the services
 // declared in the compose file. It is split out from resolveServices so the
 // validation can be exercised without touching the filesystem.

--- a/cmd/docker/common.go
+++ b/cmd/docker/common.go
@@ -31,6 +31,12 @@ type ComposeService struct {
 	Tag        string
 	Category   string
 	DependsOn  []string
+	// UsesOpenBao reports whether the service is handed an OpenBao address or
+	// token through its environment. Those services cannot work until OpenBao
+	// has been initialized, so starting them on their own needs a preflight.
+	// It is derived from the compose file rather than a hardcoded list, so a
+	// service that starts (or stops) using OpenBao is picked up automatically.
+	UsesOpenBao bool
 }
 
 // ComposeFile is the parsed compose file. Order preserves the order the
@@ -114,8 +120,9 @@ func parseComposeContent(content []byte) (*ComposeFile, error) {
 		}
 
 		var body struct {
-			Image     string    `yaml:"image"`
-			DependsOn yaml.Node `yaml:"depends_on"`
+			Image       string    `yaml:"image"`
+			DependsOn   yaml.Node `yaml:"depends_on"`
+			Environment yaml.Node `yaml:"environment"`
 		}
 		if err := root.Services.Content[i+1].Decode(&body); err != nil {
 			// A service we cannot decode is still a service: record the name so
@@ -127,12 +134,13 @@ func parseComposeContent(content []byte) (*ComposeFile, error) {
 
 		repository, tag := splitImageRef(body.Image)
 		svc := ComposeService{
-			Name:       name,
-			Image:      body.Image,
-			Repository: repository,
-			Tag:        tag,
-			Category:   categorizeService(name, repository),
-			DependsOn:  decodeDependsOn(&body.DependsOn),
+			Name:        name,
+			Image:       body.Image,
+			Repository:  repository,
+			Tag:         tag,
+			Category:    categorizeService(name, repository),
+			DependsOn:   decodeDependsOn(&body.DependsOn),
+			UsesOpenBao: nodeMentions(&body.Environment, openBaoEnvPrefix),
 		}
 
 		result.Order = append(result.Order, name)
@@ -272,6 +280,49 @@ func resolveServices(raw string) ([]string, error) {
 	}
 
 	return validateServiceNames(names, available)
+}
+
+// openBaoEnvPrefix is the environment-variable prefix that marks a service as
+// depending on OpenBao (VAULT_ADDR / VAULT_TOKEN). The compose file wires the
+// dependency through the environment rather than depends_on, so this is what we
+// look for.
+const openBaoEnvPrefix = "VAULT_"
+
+// nodeMentions reports whether any scalar anywhere under node contains needle.
+// compose accepts `environment` as either a list ("- KEY=value") or a mapping,
+// so the node is walked instead of being decoded into one specific shape.
+func nodeMentions(node *yaml.Node, needle string) bool {
+	if node == nil {
+		return false
+	}
+	if strings.Contains(node.Value, needle) {
+		return true
+	}
+	for _, child := range node.Content {
+		if nodeMentions(child, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// openBaoDependentTargets returns the subset of the given services that cannot
+// start without OpenBao, in the order they were given.
+func openBaoDependentTargets(targets []string) ([]string, error) {
+	if len(targets) == 0 {
+		return nil, nil
+	}
+	parsed, err := loadComposeFile()
+	if err != nil {
+		return nil, err
+	}
+	var dependent []string
+	for _, name := range targets {
+		if svc, ok := parsed.Services[name]; ok && svc.UsesOpenBao {
+			dependent = append(dependent, name)
+		}
+	}
+	return dependent, nil
 }
 
 // resolveSelectedServices turns the -s flag values into a validated service

--- a/cmd/docker/info.go
+++ b/cmd/docker/info.go
@@ -67,7 +67,7 @@ var infoCmd = &cobra.Command{
 			fmt.Println("")
 
 			fmt.Println("[v]Status of Cloud-Migrator runtime images")
-			services, err := resolveServices(ServiceName)
+			services, err := resolveSelectedServices()
 			if err != nil {
 				fmt.Printf("❌ %v\n", err)
 				return
@@ -152,7 +152,7 @@ func showHumanReadableInfo() {
 	allServices := getServicesFromCompose()
 
 	// Filter services if -s option is used
-	requested, err := resolveServices(ServiceName)
+	requested, err := resolveSelectedServices()
 	if err != nil {
 		fmt.Printf("❌ %v\n", err)
 		return
@@ -542,7 +542,7 @@ func showVersionTestInfo() {
 
 	// Honour -s, like the --human table does. Without this the flag was read,
 	// validated, and then ignored: `info -t -s cm-ant` printed every service.
-	requested, err := resolveServices(ServiceName)
+	requested, err := resolveSelectedServices()
 	if err != nil {
 		fmt.Printf("❌ %v\n", err)
 		return

--- a/cmd/docker/install.go
+++ b/cmd/docker/install.go
@@ -15,7 +15,7 @@ var pullCmd = &cobra.Command{
 		fmt.Println("\n[Install the Docker images of the subsystems that make up the Cloud-Migrator system.]")
 		fmt.Println()
 
-		services, err := resolveServices(ServiceName)
+		services, err := resolveSelectedServices()
 		if err != nil {
 			fmt.Printf("❌ %v\n", err)
 			return

--- a/cmd/docker/log.go
+++ b/cmd/docker/log.go
@@ -37,7 +37,7 @@ Note:
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("\n[View output from Cloud-Migrator system containers.]")
 
-		services, err := resolveServices(ServiceName)
+		services, err := resolveSelectedServices()
 		if err != nil {
 			fmt.Printf("❌ %v\n", err)
 			return

--- a/cmd/docker/remove.go
+++ b/cmd/docker/remove.go
@@ -154,7 +154,7 @@ host data under conf/docker/data/ are kept (equivalent to 'docker compose down')
 		// whole environment", and anything else must name services that actually
 		// exist. A value that splits to nothing (-s "," or -s " ") is rejected
 		// rather than silently widened to everything.
-		services, err := resolveServices(ServiceName)
+		services, err := resolveSelectedServices()
 		if err != nil {
 			fmt.Printf("\n❌ %v\n", err)
 			return

--- a/cmd/docker/root.go
+++ b/cmd/docker/root.go
@@ -23,8 +23,10 @@ var DockerFilePath string
 // ProjectName is a variable that holds docker compose project name.
 var ProjectName string
 
-// ServiceName is used when you want to specify only a specific service
-var ServiceName string
+// ServiceNames holds the raw -s values. The flag may be repeated, and each
+// occurrence may itself list several services separated by commas or spaces.
+// Use resolveSelectedServices to turn it into a validated service list.
+var ServiceNames []string
 
 // restCmd represents the rest command
 var dockerCmd = &cobra.Command{
@@ -344,7 +346,7 @@ func parseDotEnv(path string) (map[string]string, error) {
 func SysCallDockerComposePsWithAll(showAll bool) {
 	fmt.Println("\n[v]Status of Cloud-Migrator runtimes")
 
-	services, err := resolveServices(ServiceName)
+	services, err := resolveSelectedServices()
 	if err != nil {
 		fmt.Printf("❌ %v\n", err)
 		return
@@ -370,6 +372,7 @@ func init() {
 	// Add flags for Docker Compose project name
 	dockerCmd.PersistentFlags().StringVarP(&ProjectName, "project-name", "p", common.ComposeProjectName, "User-defined docker compose porject name")
 
-	// ServiceName is used when you want to specify only a specific service
-	dockerCmd.PersistentFlags().StringVarP(&ServiceName, "service", "s", "", "Want to target specific services only(Default : all)")
+	// -s may be repeated and each value may list several services separated by
+	// commas or spaces; all three forms produce the same target set.
+	dockerCmd.PersistentFlags().StringArrayVarP(&ServiceNames, "service", "s", nil, "Target specific services only (repeatable; comma or space separated). Default: all")
 }

--- a/cmd/docker/run.go
+++ b/cmd/docker/run.go
@@ -183,6 +183,12 @@ var runCmd = &cobra.Command{
 			}
 		}
 
+		// A targeted run skips the staged OpenBao flow above, so check that the
+		// services being asked for can actually work once they are up.
+		if len(targets) > 0 && !openBaoReadyForTargets(targets) {
+			return
+		}
+
 		// Always use detached mode to avoid dependency issues
 		// If user wants to see logs, we'll show them after containers are started
 		if err := runCompose(append([]string{"up", "-d"}, targets...)...); err != nil {
@@ -206,6 +212,64 @@ var runCmd = &cobra.Command{
 			fmt.Println()
 		}
 	},
+}
+
+// openBaoReadyForTargets reports whether a targeted (-s) start may go ahead.
+//
+// The full-stack path initializes OpenBao on the way up. A targeted start
+// deliberately does not: initializing the secret store as a side effect of
+// bringing up one service would be surprising, and it is not what the user
+// asked for. But letting services that read VAULT_ADDR / VAULT_TOKEN start
+// against an uninitialized or inconsistent OpenBao is worse — they come up and
+// then fail on their first secret lookup, with nothing on screen pointing at
+// the cause.
+//
+// So the state is only *checked* here, never repaired: Preflight(false) reads
+// the signals without starting a container, and the user is told which command
+// to run. Services that do not touch OpenBao are not gated at all.
+func openBaoReadyForTargets(targets []string) bool {
+	dependent, err := openBaoDependentTargets(targets)
+	if err != nil {
+		// The compose file is unreadable; resolveSelectedServices already
+		// reported that. Do not add a second, confusing message here.
+		return true
+	}
+	if len(dependent) == 0 {
+		return true
+	}
+
+	pf := openbao.Preflight(false) // read-only: never starts a container
+
+	subject := fmt.Sprintf("%s needs it", dependent[0])
+	if len(dependent) > 1 {
+		subject = fmt.Sprintf("%s need it", strings.Join(dependent, ", "))
+	}
+
+	// CaseFresh is "OK" for a full install, which goes on to initialize OpenBao.
+	// For a targeted start it is a stop condition: nothing will initialize it,
+	// so the dependent services would start without a usable token.
+	if pf.Case == openbao.CaseFresh {
+		fmt.Println()
+		fmt.Printf("❌ OpenBao is not initialized yet, and %s.\n", subject)
+		fmt.Println("Initialize it first, then start the service(s) again:")
+		fmt.Println("  ./mayfly setup openbao init      (initialize OpenBao only)")
+		fmt.Println("  ./mayfly infra run -d            (bring the whole stack up, initializing on the way)")
+		return false
+	}
+
+	if pf.OK {
+		if pf.Note != "" {
+			fmt.Println()
+			fmt.Println(pf.Note)
+		}
+		return true
+	}
+
+	fmt.Println()
+	fmt.Printf("❌ OpenBao is not in a usable state, and %s.\n", subject)
+	fmt.Println(pf.Advice)
+	fmt.Println("\nNothing was started. Resolve the above, then run this command again.")
+	return false
 }
 
 var DetachMode bool

--- a/cmd/docker/run.go
+++ b/cmd/docker/run.go
@@ -101,7 +101,7 @@ var runCmd = &cobra.Command{
 
 		// Resolve -s first so an unusable value stops the command before anything
 		// is started. An empty -s means "every service".
-		targets, err := resolveServices(ServiceName)
+		targets, err := resolveSelectedServices()
 		if err != nil {
 			fmt.Printf("⚠️ %v\n", err)
 			return
@@ -216,6 +216,6 @@ func init() {
 	// background mode
 	runCmd.Flags().BoolVarP(&DetachMode, "detach", "d", false, "Detached mode: Run containers in the background without showing logs")
 
-	// // ServiceName is used when you want to specify only a specific service
-	// runCmd.Flags().StringVarP(&ServiceName, "service", "s", "", "Want to target only one specific service(Default : all)")
+	// -s is a persistent flag on the parent `infra` command, so it is shared by
+	// every subcommand rather than redeclared here.
 }

--- a/cmd/docker/services_test.go
+++ b/cmd/docker/services_test.go
@@ -344,3 +344,94 @@ func TestHostDataTargetsDefaultWipesNothing(t *testing.T) {
 		t.Fatalf("hostDataTargets = %v, want nothing wiped without --clean-db", targets)
 	}
 }
+
+// setServiceNames points the -s flag values at the given occurrences for the
+// duration of the test.
+func setServiceNames(t *testing.T, values ...string) {
+	t.Helper()
+	prev := ServiceNames
+	ServiceNames = values
+	t.Cleanup(func() { ServiceNames = prev })
+}
+
+// -s is repeatable and each occurrence may itself list several names, so
+// repeating the flag, separating with commas, separating with spaces, and mixing
+// the two must all select the same services. Before -s became repeatable only
+// the last occurrence survived, so a user who wrote `-s a -s b` silently got
+// just b — a targeted remove could then hit a narrower set than intended without
+// any error.
+func TestResolveSelectedServicesFormsAreEquivalent(t *testing.T) {
+	writeTestCompose(t, "cb-spider", "cb-tumblebug", "openbao")
+
+	cases := []struct {
+		name   string
+		values []string
+		want   []string
+	}{
+		{"repeated flag", []string{"cb-spider", "cb-tumblebug"}, []string{"cb-spider", "cb-tumblebug"}},
+		{"comma separated", []string{"cb-spider,cb-tumblebug"}, []string{"cb-spider", "cb-tumblebug"}},
+		{"space separated", []string{"cb-spider cb-tumblebug"}, []string{"cb-spider", "cb-tumblebug"}},
+		{"repeat mixed with comma", []string{"cb-spider,cb-tumblebug", "openbao"}, []string{"cb-spider", "cb-tumblebug", "openbao"}},
+		{"duplicates across occurrences collapse", []string{"cb-spider", "cb-spider,cb-tumblebug"}, []string{"cb-spider", "cb-tumblebug"}},
+		{"single value unchanged", []string{"cb-spider"}, []string{"cb-spider"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setServiceNames(t, tc.values...)
+
+			got, err := resolveSelectedServices()
+			if err != nil {
+				t.Fatalf("resolveSelectedServices() with -s %v returned error: %v", tc.values, err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("resolveSelectedServices() with -s %v = %v, want %v", tc.values, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("resolveSelectedServices() with -s %v = %v, want %v", tc.values, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// Omitting -s is still the only way to mean "every service"; the safety rules
+// that guard destructive commands must survive the switch to a repeatable flag.
+func TestResolveSelectedServicesSafetyRules(t *testing.T) {
+	writeTestCompose(t, "cb-spider", "openbao")
+
+	t.Run("omitted means all", func(t *testing.T) {
+		setServiceNames(t)
+
+		got, err := resolveSelectedServices()
+		if err != nil {
+			t.Fatalf("resolveSelectedServices() with no -s returned error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("resolveSelectedServices() with no -s = %v, want empty (all services)", got)
+		}
+	})
+
+	t.Run("separators only is an error, never all", func(t *testing.T) {
+		setServiceNames(t, ",", " ")
+
+		got, err := resolveSelectedServices()
+		if err == nil {
+			t.Fatalf("resolveSelectedServices() with separator-only -s = %v, want an error", got)
+		}
+		if got != nil {
+			t.Fatalf("resolveSelectedServices() returned %v alongside an error; it must return no targets", got)
+		}
+	})
+
+	t.Run("unknown name is reported", func(t *testing.T) {
+		setServiceNames(t, "cb-spider", "nope-one")
+
+		if _, err := resolveSelectedServices(); err == nil {
+			t.Fatal("resolveSelectedServices() with an unknown name returned no error")
+		} else if !strings.Contains(err.Error(), "nope-one") {
+			t.Fatalf("error %q does not name the offending service", err)
+		}
+	})
+}

--- a/cmd/docker/services_test.go
+++ b/cmd/docker/services_test.go
@@ -435,3 +435,68 @@ func TestResolveSelectedServicesSafetyRules(t *testing.T) {
 		}
 	})
 }
+
+// writeComposeWithOpenBaoUser creates a compose file where only cb-tumblebug is
+// handed OpenBao settings, so the dependency has to be read off the file rather
+// than assumed from the service name.
+func writeComposeWithOpenBaoUser(t *testing.T) {
+	t.Helper()
+
+	body := `services:
+  openbao:
+    image: example/openbao:1.0.0
+  cb-tumblebug:
+    image: example/cb-tumblebug:1.0.0
+    environment:
+      - VAULT_ADDR=${VAULT_ADDR}
+      - VAULT_TOKEN=${VAULT_TOKEN}
+  cm-ant:
+    image: example/cm-ant:1.0.0
+    environment:
+      ANT_DB_USER: ${ANT_DB_USER}
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "docker-compose.yaml")
+	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	prev := DockerFilePath
+	DockerFilePath = path
+	t.Cleanup(func() { DockerFilePath = prev })
+}
+
+// Which services need OpenBao is read from the compose file (they are the ones
+// given VAULT_* in their environment), not from a hardcoded list — a list would
+// silently go stale the next time a service starts or stops using OpenBao.
+func TestOpenBaoDependentTargets(t *testing.T) {
+	writeComposeWithOpenBaoUser(t)
+
+	cases := []struct {
+		name    string
+		targets []string
+		want    []string
+	}{
+		{"service that reads VAULT_*", []string{"cb-tumblebug"}, []string{"cb-tumblebug"}},
+		{"service that does not", []string{"cm-ant"}, nil},
+		{"only the dependent ones, order kept", []string{"cm-ant", "cb-tumblebug"}, []string{"cb-tumblebug"}},
+		{"no targets means no gate", nil, nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := openBaoDependentTargets(tc.targets)
+			if err != nil {
+				t.Fatalf("openBaoDependentTargets(%v) returned error: %v", tc.targets, err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("openBaoDependentTargets(%v) = %v, want %v", tc.targets, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("openBaoDependentTargets(%v) = %v, want %v", tc.targets, got, tc.want)
+				}
+			}
+		})
+	}
+}

--- a/cmd/docker/stop.go
+++ b/cmd/docker/stop.go
@@ -18,7 +18,7 @@ var stopCmd = &cobra.Command{
 		fmt.Println("\n[Stop Cloud-Migrator]")
 		fmt.Println()
 
-		services, err := resolveServices(ServiceName)
+		services, err := resolveSelectedServices()
 		if err != nil {
 			fmt.Printf("❌ %v\n", err)
 			return

--- a/cmd/docker/update.go
+++ b/cmd/docker/update.go
@@ -358,6 +358,12 @@ var updateCmd = &cobra.Command{
 		fmt.Println("\n\n[Restart based on the installed latest Docker images.]")
 		fmt.Println()
 
+		// A targeted update brings the named services back up without the staged
+		// OpenBao flow, so apply the same readiness check `infra run` uses.
+		if len(targets) > 0 && !openBaoReadyForTargets(targets) {
+			return
+		}
+
 		// Always bring the stack up detached, mirroring `infra run`. Running
 		// attached ties the stack's lifetime to this terminal, so a Ctrl-C
 		// meant to stop watching output tears the containers back down.

--- a/cmd/docker/update.go
+++ b/cmd/docker/update.go
@@ -285,7 +285,7 @@ var updateCmd = &cobra.Command{
 
 		// Resolve -s first so an unusable value stops the command before anything
 		// is pulled or restarted. An empty -s means "every service".
-		targets, err := resolveServices(ServiceName)
+		targets, err := resolveSelectedServices()
 		if err != nil {
 			fmt.Printf("⚠️ %v\n", err)
 			return

--- a/cmd/rest/delete.go
+++ b/cmd/rest/delete.go
@@ -15,7 +15,7 @@ var restDeleteCmd = &cobra.Command{
 
 	rest delete https://reqres.in/api/users/2`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) < 1 { // 아규먼트가 없으면 도움말 출력
+		if len(args) < 1 { // print the help message when no argument is given
 			//fmt.Println(cmd.Help())
 			_ = cmd.Help()
 			return

--- a/cmd/rest/get.go
+++ b/cmd/rest/get.go
@@ -24,7 +24,7 @@ var restGetCmd = &cobra.Command{
 `,
 	//Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) < 1 { // 아규먼트가 없으면 도움말 출력
+		if len(args) < 1 { // print the help message when no argument is given
 			//fmt.Println(cmd.Help())
 			_ = cmd.Help()
 			return

--- a/cmd/rest/patch.go
+++ b/cmd/rest/patch.go
@@ -19,7 +19,7 @@ var restPatchCmd = &cobra.Command{
 		"job": "leader"
 	}'`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) < 1 { // 아규먼트가 없으면 도움말 출력
+		if len(args) < 1 { // print the help message when no argument is given
 			//fmt.Println(cmd.Help())
 			_ = cmd.Help()
 			return

--- a/cmd/rest/post.go
+++ b/cmd/rest/post.go
@@ -22,7 +22,7 @@ var restPostCmd = &cobra.Command{
 	//Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		//fmt.Println("rest post called")
-		if len(args) < 1 { // 아규먼트가 없으면 도움말 출력
+		if len(args) < 1 { // print the help message when no argument is given
 			//fmt.Println(cmd.Help())
 			_ = cmd.Help()
 			return

--- a/cmd/rest/put.go
+++ b/cmd/rest/put.go
@@ -19,7 +19,7 @@ var restPutCmd = &cobra.Command{
 		"job": "leader"
 	}'`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) < 1 { // 아규먼트가 없으면 도움말 출력
+		if len(args) < 1 { // print the help message when no argument is given
 			//fmt.Println(cmd.Help())
 			_ = cmd.Help()
 			return

--- a/cmd/rest/root.go
+++ b/cmd/rest/root.go
@@ -41,8 +41,8 @@ var restCmd = &cobra.Command{
 
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		//fmt.Println(isVerbose)
-		//fmt.Println("============ 아규먼트 :  " + strconv.Itoa(len(args)))
-		if len(args) != 0 { //하위 커맨드가 실행된 경우에만 실행 그 외에는 도움말만 실행
+		//fmt.Println("============ args :  " + strconv.Itoa(len(args)))
+		if len(args) != 0 { //only run this when a subcommand was invoked; otherwise just show the help
 			if isVerbose {
 				req.EnableTrace()
 			}
@@ -50,13 +50,13 @@ var restCmd = &cobra.Command{
 			SetBasicAuth() // Authorization: Basic <base64-encoded-value>
 			SetHeaders()
 			//SetReqData()
-			err := SetReqData() // 전송 데이터 처리
+			err := SetReqData() // build the request body
 			if err != nil {
 				//fmt.Println(err)
 				return err
 			}
 
-			//출력 파일 지정
+			//write the response to a file instead of stdout
 			if outputFile != "" {
 				req.SetOutput(outputFile)
 			}
@@ -70,9 +70,9 @@ var restCmd = &cobra.Command{
 
 	Run: func(cmd *cobra.Command, args []string) {
 		//fmt.Println(cmd.UsageString())
-		//fmt.Println("============ REST 메인 호출됨!!!!  ")
+		//fmt.Println("============ REST root called!!!!  ")
 		//fmt.Println(cmd.Help())
-		_ = cmd.Help() // root.go에서는 도움말만 출력 함.
+		_ = cmd.Help() // the rest root command only prints the help.
 	},
 
 	// PersistentPostRun: func(cmd *cobra.Command, args []string) {
@@ -138,7 +138,7 @@ func SetReqData() error {
 			fmt.Printf("use [%s] data file\n", inputFileData)
 		}
 
-		// 파일에서 데이터 읽기
+		// read the body from the file
 		// Reading the file the operator names with the request-data flag is
 		// the feature itself; there is no directory this path should be confined to.
 		data, err := ioutil.ReadFile(inputFileData) // #nosec G304 -- operator-supplied request body file is the documented purpose of this flag
@@ -157,7 +157,7 @@ func SetReqData() error {
 }
 
 func ProcessResultInfo(resp *resty.Response) {
-	// 응답 출력
+	// print the response
 	if isVerbose {
 		ShowTraceInfo(resp)
 	} else {
@@ -206,7 +206,7 @@ func doRequest(url string, send func(string) (*resty.Response, error)) int {
 		return 1
 	}
 
-	// 응답 출력
+	// print the response
 	ProcessResultInfo(resp)
 	return exitCodeFor(resp.StatusCode()) // for docker compose healthy check
 }
@@ -265,7 +265,7 @@ func init() {
 	restCmd.PersistentFlags().StringVarP(&username, "user", "u", "", "Username for basic authentication") // - sets the basic authentication header in the HTTP request
 	restCmd.PersistentFlags().StringVarP(&password, "password", "p", "", "Password for basic authentication")
 
-	// 인증 토큰 설정
+	// Add flags for token authentication
 	restCmd.PersistentFlags().StringVarP(&authToken, "authToken", "", "", "sets the auth token of the 'Authorization' header for all HTTP requests.(The default auth scheme is 'Bearer')")
 	restCmd.PersistentFlags().StringVarP(&authScheme, "authScheme", "", "", "sets the auth scheme type in the HTTP request.(Exam. OAuth)(The default auth scheme is Bearer)")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,7 @@ var RootCmd = &cobra.Command{
 	Use:               "mayfly",
 	Short:             "A tool to operate Cloud-Migrator system",
 	Long:              `The mayfly is a tool to operate Cloud-Migrator system.`,
-	CompletionOptions: cobra.CompletionOptions{HiddenDefaultCmd: true}, //completion 옵션 출력 제거
+	CompletionOptions: cobra.CompletionOptions{HiddenDefaultCmd: true}, //hide the default completion command from the help output
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	//	Run: func(cmd *cobra.Command, args []string) { },

--- a/cmd/setup/credential.go
+++ b/cmd/setup/credential.go
@@ -1,16 +1,16 @@
 // https://github.com/cloud-barista/cb-tumblebug/discussions/1773
-// Credential 등록 관련 APIs
+// APIs related to credential registration
 //
 //	GET /credential/publicKey
 //	POST /credential
 //
-// CSP별 Credential 등록 포멧
+// Credential registration format per CSP
 // https://github.com/cloud-barista/cb-spider/wiki/features-and-usages
-//   AWS 예시 : curl -sX GET http://localhost:1024/spider/cloudos/metainfo/AWS -H 'Content-Type: application/json' |json_pp |more
-//		- 응답 값중 아래 둘 중 하나의 형태로 입력
-//		    - Credential : cb-spider 형식
-//			- CredentialCSP : CSP 형식
-//  [최종] curl -sX GET http://localhost:1024/spider/cloudos/metainfo/aws -H 'Content-Type: application/json' | jq '.Credential'
+//   AWS example : curl -sX GET http://localhost:1024/spider/cloudos/metainfo/AWS -H 'Content-Type: application/json' |json_pp |more
+//		- From the response, provide one of the two forms below
+//		    - Credential : cb-spider format
+//			- CredentialCSP : CSP format
+//  [final] curl -sX GET http://localhost:1024/spider/cloudos/metainfo/aws -H 'Content-Type: application/json' | jq '.Credential'
 //         curl -sX POST http://localhost:1323/tumblebug/forward/cloudos/metainfo/aws -u default:default  -d '{}'
 //		   curl -sX GET http://localhost:1323/tumblebug/credential/publicKey -u default:default
 
@@ -91,7 +91,7 @@ type Auth struct {
 
 var serviceInfo ServiceInfo
 
-// 사용자가 -H로 전달한 헤더를 요청에 반영
+// Applies the headers the user passed with -H to the request
 func setHeaders(r *resty.Request) *resty.Request {
 	for _, h := range headers {
 		headerParts := strings.SplitN(h, ":", 2)
@@ -107,8 +107,8 @@ func setHeaders(r *resty.Request) *resty.Request {
 	return r
 }
 
-// newRequest는 호출마다 새 요청을 만든다.
-// 하나의 요청을 재사용하면 앞선 호출에서 설정한 body 같은 상태가 다음 호출에 그대로 남는다.
+// newRequest builds a new request on every call.
+// Reusing a single request would leak state set by an earlier call, such as the body, into the next one.
 func newRequest() *resty.Request {
 	return setHeaders(client.R())
 }
@@ -128,11 +128,11 @@ func SetBasicAuth() {
 	}
 }
 
-// 인증 처리
+// Sets up authentication
 func SetAuth() {
 	switch strings.ToLower(serviceInfo.Auth.Type) {
 	case "none", "":
-		// 인증이 필요 없는 경우 아무 것도 하지 않음
+		// nothing to do when no authentication is required
 	case "basic":
 		// Set basic authentication
 		SetBasicAuth()
@@ -151,16 +151,16 @@ func SetAuth() {
 	}
 }
 
-// Tumblebug의 정보를 확인 함.
+// Checks the Tumblebug service information.
 func checkServiceInfo() error {
 	fmt.Printf("Configuration file[%s] processing...\n", configFile)
 	serviceName := "cb-tumblebug"
-	// 서비스 검증
+	// Verify the service
 	if !viper.IsSet("services." + serviceName) {
 		return errors.New("the name of the service[" + serviceName + "] you want to call is not on the list of supported services.\nPlease check the api.yaml configuration file or the list of available services")
 	}
 
-	// 서비스 정보 파싱
+	// Parse the service information
 	err := viper.UnmarshalKey("services."+serviceName, &serviceInfo)
 	if err != nil {
 		return err
@@ -168,8 +168,8 @@ func checkServiceInfo() error {
 
 	// fmt.Printf("Service Info: %+v\n", serviceInfo)
 
-	// // CLI로 인증 정보를 전달 받았을 경우 인증 처리
-	// 인증 정보를 CLI로 전달 받았을 경우 처리
+	// // Handle authentication when the credentials were given on the CLI
+	// Apply the credentials given on the CLI
 	if authToken != "" {
 		serviceInfo.Auth.Token = authToken
 	}
@@ -184,7 +184,7 @@ func checkServiceInfo() error {
 		return errors.New("couldn't find the BaseURL information for the service to call\nPlease check the api.yaml configuration file")
 	}
 
-	// 사용자 입력 host, port로 BaseURL 정보 업데이트
+	// Update the BaseURL with the host and port entered by the user
 	// The override only fails when the configured BaseURL cannot be parsed. That
 	// used to pass unnoticed and the request went to the unmodified address, so
 	// warn instead — the printed BaseURL below then explains where it really went.
@@ -202,13 +202,13 @@ func checkServiceInfo() error {
 }
 
 func updateBaseURL(baseURL *string, host string, port string) error {
-	// baseURL을 파싱
+	// Parse the baseURL
 	parsedURL, err := url.Parse(*baseURL)
 	if err != nil {
 		return err
 	}
 
-	// host 값이 제공된 경우 parsedURL의 Hostname을 새로운 host 값으로 변경
+	// When a host is given, replace the hostname of parsedURL with that host
 	if host != "" {
 		if port != "" {
 			parsedURL.Host = host + ":" + port
@@ -216,16 +216,16 @@ func updateBaseURL(baseURL *string, host string, port string) error {
 			parsedURL.Host = host + ":" + parsedURL.Port()
 		}
 	} else if port != "" {
-		// host 값이 제공되지 않고 port만 제공된 경우 기존 hostname에 새로운 port를 설정
+		// When only a port is given, keep the existing hostname and apply the new port
 		parsedURL.Host = parsedURL.Hostname() + ":" + port
 	}
 
-	// 업데이트된 URL을 문자열로 변환하여 baseURL에 반영
+	// Write the updated URL back into baseURL as a string
 	*baseURL = parsedURL.String()
 	return nil
 }
 
-// Tumblebug으로부터 사용 가능한 CSP 목록을 가져옴.
+// Retrieves the list of available CSPs from Tumblebug.
 func getCspList() ([]string, error) {
 	url := serviceInfo.BaseURL + AVAILABLE_CSP_LIST_URL
 	if isVerbose {
@@ -243,7 +243,7 @@ func getCspList() ([]string, error) {
 		fmt.Println(string(resp.Body()))
 	}
 
-	// JSON 결과 값에서 "output" 값을 추출
+	// Extract the "output" value out of the JSON result
 	var result map[string]interface{}
 	err = json.Unmarshal(resp.Body(), &result)
 	if err != nil {
@@ -251,12 +251,12 @@ func getCspList() ([]string, error) {
 	}
 
 	if output, ok := result["output"].([]interface{}); ok {
-		// output 값을 문자열 배열로 변환
+		// Convert the output value into a string array
 		outputArray := make([]string, len(output))
 		for i, v := range output {
 			outputArray[i] = fmt.Sprintf("%v", v)
 		}
-		// 알파벳 순으로 정렬
+		// Sort alphabetically
 		sort.Strings(outputArray)
 		return outputArray, nil
 	} else {
@@ -266,26 +266,26 @@ func getCspList() ([]string, error) {
 
 // func selectCspFromCLI(cspList []string) (string, error) {
 func selectCspFromCLI() (string, error) {
-	// CSP 목록을 가져옴
+	// Get the CSP list
 	cspList, err := getCspList()
 	if err != nil {
 		fmt.Println("Error:", err)
 		return "", fmt.Errorf("Error: %v", err)
 	}
 
-	// cspList 배열의 값이 없을 경우 에러를 반환
+	// Return an error when the cspList array is empty
 	if len(cspList) == 0 {
 		return "", fmt.Errorf("No available CSPs found")
 	}
 
-	// CSP 목록을 출력
+	// Print the CSP list
 	fmt.Println("Available CSPs:")
 	for i, csp := range cspList {
 		fmt.Printf("%d. %s\n", i+1, csp)
 	}
 	fmt.Println("0. Exit")
 
-	// 사용자로부터 CSP 번호를 입력받음
+	// Read the CSP number from the user
 	reader := bufio.NewReader(os.Stdin)
 	for {
 		fmt.Print("Please select a CSP by number: ")
@@ -295,23 +295,23 @@ func selectCspFromCLI() (string, error) {
 		}
 		input = strings.TrimSpace(input)
 
-		// 입력된 값을 정수로 변환
+		// Convert the entered value to an integer
 		selection, err := strconv.Atoi(input)
 		if err != nil {
 			fmt.Println("Invalid input. Please enter a number.")
 			continue
 		}
 
-		// 0을 입력한 경우 종료
+		// Exit when 0 was entered
 		if selection == 0 {
 			//fmt.Println("Exiting.")
 			//return "", nil
 			return "", fmt.Errorf("No CSP selected. Exiting.")
 		}
 
-		// 유효한 번호인지 확인
+		// Check that the number is valid
 		if selection > 0 && selection <= len(cspList) {
-			// 선택된 CSP 값을 소문자로 변환하여 저장
+			// Return the selected CSP lowercased
 			return strings.ToLower(cspList[selection-1]), nil
 			//return cspList[selection-1], nil
 		} else {
@@ -320,9 +320,9 @@ func selectCspFromCLI() (string, error) {
 	}
 }
 
-// 사용자로부터 콘솔에서 CSP입력을 받아 처리
+// Takes the CSP entered by the user on the console and processes it
 func getCredentialsMeta(csp string) ([]string, error) {
-	// csp에 대한 인증 정보 입력 형식을 조회합니다.
+	// Look up the credential input format for the csp.
 	fmt.Printf("Retrieving credential input format for %s\n", csp)
 
 	// curl -sX POST http://localhost:1323/tumblebug/forward/cloudos/metainfo/aws -u default:default  -d '{}'
@@ -348,7 +348,7 @@ func getCredentialsMeta(csp string) ([]string, error) {
 		fmt.Println(string(resp.Body()))
 	}
 
-	// JSON 결과 값에서 "Credential" 값을 추출
+	// Extract the "Credential" value out of the JSON result
 	var result map[string]interface{}
 	err = json.Unmarshal(resp.Body(), &result)
 	if err != nil {
@@ -358,7 +358,7 @@ func getCredentialsMeta(csp string) ([]string, error) {
 	if credential, ok := result["Credential"].([]interface{}); ok {
 		fmt.Printf("Successfully retrieved credential meta information for %s\n", csp)
 
-		// Credential 값을 문자열 배열로 변환
+		// Convert the Credential value into a string array
 		credentialArray := make([]string, len(credential))
 		for i, v := range credential {
 			credentialArray[i] = fmt.Sprintf("%v", v)
@@ -371,17 +371,17 @@ func getCredentialsMeta(csp string) ([]string, error) {
 
 }
 
-// CSP의 인증 정보를 암호화 처리 함.
+// Encrypts the credentials of a CSP.
 func processCspCredentialEncrypt() {
 	//fmt.Println("Processing CSP Credential Encryption : ", csp)
 	selectedCsp := ""
 
-	// CLI에서 옵션으로 전달 받은 경우
+	// When it was passed as a CLI option
 	if csp != "" {
 		selectedCsp = strings.ToLower(csp)
 	} else {
 		var err error
-		// 사용자로부터 콘솔에서 CSP를 선택받음
+		// Let the user pick a CSP on the console
 		selectedCsp, err = selectCspFromCLI()
 		if err != nil {
 			fmt.Println("Error:", err)
@@ -389,20 +389,20 @@ func processCspCredentialEncrypt() {
 		}
 	}
 
-	// selectedCsp 값을 소문자로 변환하여 저장
+	// Store selectedCsp lowercased
 	//selectedCsp = strings.ToLower(selectedCsp)
 
-	// 선택된 CSP에 대한 인증 정보를 처리한다는 메시지 출력
+	// Print a message saying the credentials of the selected CSP are being processed
 	fmt.Printf("\nProcessing authentication information for selected [%s] CSP\n", selectedCsp)
 
-	// CSP에 맞는 Credential 메타 정보를 가져옴
+	// Get the credential meta information for the CSP
 	credentialMeta, err := getCredentialsMeta(selectedCsp)
 	if err != nil {
 		fmt.Println("Error:", err)
 		return
 	}
 
-	// 상세 모드에서는 입력 받아야할 Credential 키 값 출력
+	// In verbose mode, print the credential keys that have to be entered
 	if isVerbose {
 		// fmt.Println("Credential Meta :", credentialMeta)
 		fmt.Println("The following credential information is required:")
@@ -412,14 +412,14 @@ func processCspCredentialEncrypt() {
 		fmt.Println()
 	}
 
-	// 사용자로부터 Credential 값을 입력받음
+	// Read the credential values from the user
 	credentials, err := inputCredentialsFromCli(credentialMeta)
 	if err != nil {
 		fmt.Println("Error:", err)
 		return
 	}
 
-	// PublicKey와 PublicKeyTokenId를 가져옴
+	// Get the PublicKey and the PublicKeyTokenId
 	publicKeyResponse, err := getPublicKey()
 	if err != nil {
 		fmt.Println("Error:", err)
@@ -427,12 +427,12 @@ func processCspCredentialEncrypt() {
 	}
 
 	if isVerbose {
-		// PublicKey와 PublicKeyTokenId 값을 출력
+		// Print the PublicKey and PublicKeyTokenId values
 		fmt.Println("PublicKeyTokenId:", publicKeyResponse.PublicKeyTokenId)
 		fmt.Println("PublicKey:", publicKeyResponse.PublicKey)
 	}
 
-	// Credential 정보를 PublicKey로 암호화 처리
+	// Encrypt the credentials with the PublicKey
 	encryptedCredentials, encryptedAesKey, err := encryptCredentialsWithPublicKey(publicKeyResponse.PublicKey, credentials)
 	if err != nil {
 		fmt.Println("Error:", err)
@@ -444,7 +444,7 @@ func processCspCredentialEncrypt() {
 		fmt.Println("Encrypted AES Key:", encryptedAesKey)
 	}
 
-	// 암호화된 Credential 정보를 서버로 전송
+	// Send the encrypted credentials to the server
 	payload := map[string]interface{}{
 		"credentialHolder":                 "admin",
 		"providerName":                     selectedCsp,
@@ -453,7 +453,7 @@ func processCspCredentialEncrypt() {
 		"credentialKeyValueList":           encryptedCredentials,
 	}
 
-	// payload를 예쁘게 출력
+	// Pretty-print the payload
 	if isVerbose {
 		fmt.Println("=============================================")
 		payloadJSON, err := json.MarshalIndent(payload, "", "  ")
@@ -474,43 +474,43 @@ func processCspCredentialEncrypt() {
 	}
 }
 
-// 사용자로부터 콘솔에서 CSP의 인증 정보를 입력받아 map 형태로 반환
+// Reads the CSP credentials from the user on the console and returns them as a map
 func inputCredentialsFromCli(credentialMeta []string) (map[string]string, error) {
 	credentials := make(map[string]string)
 	reader := bufio.NewReader(os.Stdin)
 
-	// 터미널 상태 저장
+	// Save the terminal state
 	oldState, err := term.GetState(int(syscall.Stdin))
 	if err != nil {
 		return nil, fmt.Errorf("Error getting terminal state: %v", err)
 	}
-	// 입력 도중 오류로 빠져나가더라도 터미널의 echo가 꺼진 채 남지 않도록 함
+	// Make sure the terminal is not left with echo turned off if we bail out on an input error
 	defer func() { _ = term.Restore(int(syscall.Stdin), oldState) }()
 
 	for {
 		// ================================
-		// CSP 인증 정보를 입력 받음
+		// Read the CSP credentials
 		// ================================
 		for _, key := range credentialMeta {
 			fmt.Printf("Please enter %s: ", key)
 			// value, err := reader.ReadString('\n')
-			// 입력을 숨김
+			// Hide the input
 			bytePassword, err := term.ReadPassword(int(syscall.Stdin))
 			if err != nil {
 				return nil, fmt.Errorf("Error reading input: %v", err)
 			}
 			value := string(bytePassword)
-			fmt.Println() // 줄바꿈
+			fmt.Println() // line break
 			credentials[key] = strings.TrimSpace(value)
 		}
 
-		// 터미널 설정 복원
+		// Restore the terminal settings
 		if err := term.Restore(int(syscall.Stdin), oldState); err != nil {
 			return nil, fmt.Errorf("Error restoring terminal state: %v", err)
 		}
 
 		// ================================
-		// 입력된 값을 확인할 것인지 물어봄
+		// Ask whether the entered values should be reviewed
 		// ================================
 		for {
 			fmt.Print("Do you want to review the entered credentials? (yes/no): ")
@@ -521,7 +521,7 @@ func inputCredentialsFromCli(credentialMeta []string) (map[string]string, error)
 			review = strings.TrimSpace(strings.ToLower(review))
 
 			if review == "yes" {
-				// 입력된 값들을 출력하여 확인
+				// Print the entered values so they can be reviewed
 				fmt.Println("You have entered the following credentials:")
 				for key, value := range credentials {
 					fmt.Printf("%s: %s\n", key, value)
@@ -535,7 +535,7 @@ func inputCredentialsFromCli(credentialMeta []string) (map[string]string, error)
 		}
 
 		// ================================
-		// 입력된 값을 확인할 것인지 물어봄
+		// Ask whether the entered values should be reviewed
 		// ================================
 		fmt.Print("Is this correct? (yes/no/retry): ")
 		confirmation, err := reader.ReadString('\n')
@@ -557,13 +557,13 @@ func inputCredentialsFromCli(credentialMeta []string) (map[string]string, error)
 	}
 }
 
-// PublicKeyResponse 구조체 정의
+// PublicKeyResponse struct definition
 type PublicKeyResponse struct {
 	PublicKeyTokenId string `json:"publicKeyTokenId"`
 	PublicKey        string `json:"publicKey"`
 }
 
-// 서버로부터 PublicKey와 PublicKeyTokenId를 조회 함.
+// Retrieves the PublicKey and the PublicKeyTokenId from the server.
 func getPublicKey() (*PublicKeyResponse, error) {
 	fmt.Println("Retrieving public key and public key token id")
 	url := serviceInfo.BaseURL + GET_PUBLICKEY_URL
@@ -581,7 +581,7 @@ func getPublicKey() (*PublicKeyResponse, error) {
 		fmt.Println(string(resp.Body()))
 	}
 
-	// JSON 결과 값을 PublicKeyResponse 구조체로 변환
+	// Convert the JSON result into a PublicKeyResponse struct
 	var publicKeyResponse PublicKeyResponse
 	err = json.Unmarshal(resp.Body(), &publicKeyResponse)
 	if err != nil {
@@ -591,7 +591,7 @@ func getPublicKey() (*PublicKeyResponse, error) {
 	return &publicKeyResponse, nil
 }
 
-// PKCS7 패딩 추가 함수
+// Function that adds PKCS7 padding
 // The only caller passes aes.BlockSize() (16), so padding lands in 1..16 and
 // always fits a byte — which PKCS#7 requires anyway, being undefined for block
 // sizes of 256 or more.
@@ -601,7 +601,7 @@ func pkcs7Pad(data []byte, blockSize int) []byte {
 	return append(data, padText...)
 }
 
-// PKCS7 패딩 제거 함수
+// Function that removes PKCS7 padding
 func pkcs7Unpad(data []byte) ([]byte, error) {
 	length := len(data)
 	if length == 0 {
@@ -665,19 +665,19 @@ func encryptCredentialsWithPublicKey(publicKeyPem string, credentials map[string
 	return encryptedCredentials, base64.StdEncoding.EncodeToString(encryptedAesKey), nil
 }
 
-// 서버로 암호화된 Credential 정보를 전송
+// Sends the encrypted credentials to the server
 func sendCredentials(payload map[string]interface{}) (map[string]interface{}, error) {
 	fmt.Println("Sending encrypted credentials to server")
 
-	// 다른 호출들과 마찬가지로 --host/--port/--user/--password로 해석된 정보를 사용한다.
-	// 그래야 한 대의 서버에서 여러 서버의 Tumblebug을 초기화할 수 있다.
-	// (기본값은 그대로 http://localhost:1323/tumblebug)
+	// Like every other call, this uses the address resolved from --host/--port/--user/--password.
+	// That is what makes it possible to initialize the Tumblebug of several servers from a single machine.
+	// (The default is still http://localhost:1323/tumblebug)
 	url := serviceInfo.BaseURL + POST_CREDENTIAL_URL
 	if isVerbose {
 		fmt.Println("Request Url : ", url)
 	}
 
-	// payload를 JSON으로 변환
+	// Convert the payload to JSON
 	reqBody, err := json.Marshal(payload)
 	if err != nil {
 		return nil, fmt.Errorf("Error marshalling payload: %v", err)
@@ -692,25 +692,25 @@ func sendCredentials(payload map[string]interface{}) (map[string]interface{}, er
 		return nil, fmt.Errorf("Error: %v", err)
 	}
 
-	// 응답 결과 확인
-	body := resp.Body() // []byte 타입
+	// Check the response
+	body := resp.Body() // []byte
 	if isVerbose {
 		fmt.Println(string(body))
 	}
 
-	// 2xx가 아니면 등록에 실패한 것이므로 응답 본문과 함께 오류를 반환
+	// Anything but a 2xx means the registration failed, so return an error along with the response body
 	if resp.StatusCode() < 200 || resp.StatusCode() > 299 {
 		return nil, fmt.Errorf("credential registration failed with status %d: %s", resp.StatusCode(), strings.TrimSpace(string(body)))
 	}
 
-	// 응답 결과를 처리하여 리턴 타입에 맞게 반환
+	// Parse the response and return it in the expected return type
 	var result map[string]interface{}
 	err = json.Unmarshal(body, &result)
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing JSON: %v", err)
 	}
 
-	// CSP Credential 정보 등록 완료 메시지 출력
+	// Print a message saying the CSP credential registration is complete
 	fmt.Println("CSP Credential registration completed successfully")
 
 	return result, nil
@@ -725,14 +725,14 @@ var credentialCmd = &cobra.Command{
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		isInit = false
 
-		// 서브 커맨드가 입력되었을 때에는 도움말을 출력하지 않음.
+		// Do not print the help when a subcommand was given.
 		if len(args) == 0 && cmd.Flags().NFlag() == 0 && cmd.HasSubCommands() {
 			//fmt.Println(cmd.Help())
 			_ = cmd.Help()
 			return
 		}
 
-		// 설정 파일 처리
+		// Process the configuration file
 		viper.SetConfigFile(configFile)
 		err := viper.ReadInConfig()
 		if err != nil {
@@ -740,7 +740,7 @@ var credentialCmd = &cobra.Command{
 			return
 		}
 
-		// 호출할 서비스 정보 처리
+		// Process the information of the service to call
 		errParse := checkServiceInfo()
 		if errParse != nil {
 			fmt.Println(errParse)
@@ -765,12 +765,12 @@ var credentialCmd = &cobra.Command{
 		// }
 
 		// if isVerbose {
-		// 	// PublicKey와 PublicKeyTokenId 값을 출력
+		// 	// Print the PublicKey and PublicKeyTokenId values
 		// 	fmt.Println("PublicKeyTokenId:", publicKeyResponse.PublicKeyTokenId)
 		// 	fmt.Println("PublicKey:", publicKeyResponse.PublicKey)
 		// }
 
-		// CSP의 인증 정보를 암호화 처리
+		// Encrypt the credentials of the CSP
 		processCspCredentialEncrypt()
 	},
 }

--- a/cmd/setup/root.go
+++ b/cmd/setup/root.go
@@ -4,7 +4,7 @@ Copyright © 2024 NAME HERE <EMAIL ADDRESS>
 package setup
 
 import (
-	//"github.com/cm-mayfly/cm-mayfly/cmd" //임시로 주석처리
+	//"github.com/cm-mayfly/cm-mayfly/cmd" //temporarily commented out
 	//"github.com/cm-mayfly/cm-mayfly/common"
 	"github.com/cm-mayfly/cm-mayfly/cmd"
 	"github.com/spf13/cobra"

--- a/cmd/tool/mysqlping.go
+++ b/cmd/tool/mysqlping.go
@@ -1,4 +1,4 @@
-// docker compose의 컨테이너 실행 순서 보장을 위해 MySQL의 Ready 상태를 확인하는 기능을 수행
+// Checks whether MySQL is ready, so that docker compose can order container startup accordingly
 package tool
 
 import (
@@ -48,16 +48,16 @@ Flags:
 		//fmt.Println("len(args) ", len(args))
 		//fmt.Println("cmd.Flags().NFlag() ", cmd.Flags().NFlag())
 
-		// 아규먼트나 플래그가 입력 되지 않은 경우에만 도움말 출력 후 종료
+		// Only print the help and exit when neither an argument nor a flag was given
 		if len(args) == 0 && cmd.Flags().NFlag() == 0 {
-			// 환경 변수가 모두 설정되었으면 도움말 출력 없이 종료
+			// If the environment variables are all set, return without printing the help
 			if checkConfig(cmd) {
 				return
 			}
 			_ = cmd.Help()
-			os.Exit(1) // Docker Compose의 Health Check 사용을 감안해서 에러로 리턴 함.
+			os.Exit(1) // return an error, since this is used as a Docker Compose health check.
 		} else {
-			// verbose 플래그만 설정된 경우에는 도움말 출력
+			// Print the help when the only flag given is verbose
 			if len(args) == 0 && cmd.Flags().NFlag() == 1 && isVerbose {
 				_ = cmd.Help()
 				fmt.Print("\n\n")
@@ -65,22 +65,22 @@ Flags:
 
 			if !checkConfig(cmd) {
 				log.Println("Please set the MySQL connection information using flags or environment variables.")
-				os.Exit(1) // 비정상 종료
+				os.Exit(1) // failure exit
 			}
 		}
 	},
 
 	Run: func(cmd *cobra.Command, args []string) {
 		if dbPing() {
-			os.Exit(0) // 정상 종료
+			os.Exit(0) // success exit
 		} else {
-			os.Exit(1) // 비정상 종료
+			os.Exit(1) // failure exit
 		}
 	},
 }
 
 func dbPing() bool {
-	// DSN 구성
+	// Build the DSN
 	log.Printf("Checking MySQL[%s:%s] connection...\n", host, port)
 
 	var dsn string
@@ -94,18 +94,18 @@ func dbPing() bool {
 		log.Println("DSN:", maskDSN(dsn))
 	}
 
-	// MySQL 연결 테스트
+	// Test the MySQL connection
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
 		log.Println("MySQL connection failed:", err)
-		os.Exit(1) // 비정상 종료
+		os.Exit(1) // failure exit
 	}
 	defer db.Close()
 
-	// MySQL Ping 테스트
+	// Ping MySQL
 	if err := db.Ping(); err != nil {
 		log.Println("MySQL ping failed:", err)
-		os.Exit(1) // 비정상 종료
+		os.Exit(1) // failure exit
 	}
 
 	log.Println("MySQL is healthy.")
@@ -153,7 +153,7 @@ func maskSecret(s string) string {
 	return "***"
 }
 
-// DB 접속을 위한 환경 변수 값을 체크 함.
+// Checks the environment variable values used for the DB connection.
 //
 // Precedence: a flag the user actually typed always wins over the matching
 // environment variable, which is what the command's help text promises.
@@ -169,7 +169,7 @@ func checkConfig(cmd *cobra.Command) bool {
 		log.Println("Checking MySQL connection information...")
 	}
 
-	// 플래그로 명시하지 않은 값만 환경 변수로부터 읽어오기
+	// Read from the environment only the values that were not given explicitly as flags
 	if !cmd.Flags().Changed("user") && os.Getenv("MYSQL_USER") != "" {
 		user = os.Getenv("MYSQL_USER")
 	}

--- a/cmd/tool/root.go
+++ b/cmd/tool/root.go
@@ -2,7 +2,7 @@ package tool
 
 import (
 
-	//"github.com/cm-mayfly/cm-mayfly/cmd" //임시로 주석처리
+	//"github.com/cm-mayfly/cm-mayfly/cmd" //temporarily commented out
 	//"github.com/cm-mayfly/cm-mayfly/common"
 	"github.com/cm-mayfly/cm-mayfly/cmd"
 	"github.com/spf13/cobra"


### PR DESCRIPTION
Bundles the CLI improvements merged to our develop.

## `infra -s` is now repeatable

`-s` was a single string, so repeating it (`-s a -s b`) kept only the last value and silently dropped the earlier ones — a targeted command could act on fewer services than asked, with no error. It is now a string array; repeated, comma-separated and space-separated forms all select the same services, fed through the existing `resolveServices` path. Omitting `-s` still means every service, and a separator-only value is still an error rather than "all".

## OpenBao readiness guard for targeted `run`/`update`

A full-stack `run` initializes OpenBao on the way up, but a targeted `-s` run skipped that, so services that read `VAULT_ADDR`/`VAULT_TOKEN` (cb-tumblebug, mc-terrarium) could start against an uninitialized OpenBao and fail on their first secret lookup. The `-s` path now checks OpenBao state read-only (no container is started) and, if it is not usable, prints the command to run instead rather than starting those services. It never initializes OpenBao as a side effect. Which services depend on OpenBao is derived from the compose file (their `VAULT_*` environment), not a hardcoded list.

## `api tool` fixes

- `--apply` now writes to the file `-c` names (it previously read from `-c` but always wrote the default path, so `-c <other>` silently updated the wrong file). Without `-c` it uses the configured default, falling back to `./api.yaml`.
- Warns before applying a raw `-f` source, whose recorded version falls back to the document's `info.version` (usually `latest`) and would not match the deployed release; `--release <tag>` records the exact version.
- The command's prompts, warnings and errors (and the remaining Korean code comments) are now in English.

New unit tests cover the `-s` forms and the compose-derived OpenBao dependency detection.