### PR TITLE
fix(docker): follow the .env password for the Celery result backend

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -773,6 +773,17 @@ services:
       # The AIRFLOW__CORE__ alias is gone: Airflow 3 removed [core] sql_alchemy_conn, so only
       # the [database] key is consulted.
       - AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=mysql+mysqldb://${AIRFLOW_DB_USER}:${AIRFLOW_DB_PASSWORD}@airflow-mysql/${AIRFLOW_DB_NAME}
+      # The Celery result backend is a *separate* connection string, and airflow.cfg hardcodes it
+      # the same way: db+mysql://airflow:airflow_pass@airflow-mysql/airflow. Overriding
+      # AIRFLOW__DATABASE__SQL_ALCHEMY_CONN alone does not cover it.
+      #
+      # The scheduler and the celery worker are the only processes that open this connection, and
+      # they open it while starting up. When AIRFLOW_DB_PASSWORD differs from the hardcoded
+      # airflow_pass, both die immediately with "Access denied for user 'airflow'" while
+      # api-server and dag-processor - which use the [database] connection - keep running. The
+      # container therefore stays healthy, the web UI looks normal, and every workflow run sits at
+      # Pending 0/N tasks forever with nothing in the migration frameworks' logs.
+      - AIRFLOW__CELERY__RESULT_BACKEND=db+mysql://${AIRFLOW_DB_USER}:${AIRFLOW_DB_PASSWORD}@airflow-mysql/${AIRFLOW_DB_NAME}
     ports:
       - "5555:5555"
       - "8080:8080"


### PR DESCRIPTION
## Problem

On a freshly built environment the migration workflow stayed at `Pending 0/5 tasks` indefinitely. Every container reported `healthy`, the web console looked normal, and no request ever reached the downstream frameworks, so nothing showed up in their logs either.

## Cause

The airflow image's `airflow.cfg` hardcodes the database connection string in **two** places:

| Config key | Overridden before | Effect |
|---|---|---|
| `[database] sql_alchemy_conn` | yes | uses the `.env` value |
| `[celery] result_backend` | **no** | keeps the hardcoded `airflow:airflow_pass` |

Only the scheduler and the celery worker open `result_backend`, and both open it while starting up. So when `AIRFLOW_DB_PASSWORD` differs from the hardcoded value, those two die immediately with `Access denied for user 'airflow'` while api-server and dag-processor start normally.

Because the entrypoint launches each process in the background and then holds the container with `sleep infinity`, **the container stays `healthy` even with both processes dead.** Everything looks fine until a workflow is actually run.

## Why it went unnoticed

Existing deployments all used `airflow_pass`, the value `.env.example` documents as the previous default — which happens to match the hardcoded string exactly. That coincidence hid the fact that `result_backend` was ignoring the configuration entirely.

Since `.env.example` leaves this value blank for operators to set, changing it must not silently stop the workflow engine.

## Fix

Add `AIRFLOW__CELERY__RESULT_BACKEND` so it follows `.env` just like the existing `SQL_ALCHEMY_CONN` override. Environment variables take precedence over `airflow.cfg`, so no image change is needed.

## Verification

Reproduced and resolved on a clean host:

| Check | Before | After |
|---|---|---|
| scheduler / celery worker | missing | running |
| `Access denied` in logs | present | none |
| Workflow run | `Pending 0/5` forever | tasks start executing |
| Infrastructure resources | none created | virtual network created |

The effective value inside the running container was confirmed to come from the environment variable rather than the config file.

**No regression risk** — deployments keeping the documented default receive a byte-identical value.