### PR TITLE
chore(lineup): pin cm-butterfly to 0.5.3 in docker-compose

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -433,12 +433,8 @@ services:
   # (Not required) https://github.com/cloud-barista/cm-butterfly/tree/main/api/conf/authsetting.yaml.sample to authsetting.yaml
   # https://hub.docker.com/r/cloudbaristaorg/cm-butterfly-api
   cm-butterfly-api:
-    # Pinned to edge for final pre-release review: the 0.5.2 image predates the
-    # api.yaml update in this change, so edge is the image that actually carries
-    # it. This will move to 0.5.3 once that release is published; for a stable
-    # build use 0.5.2.
-    image: cloudbaristaorg/cm-butterfly-api:edge
-    # image: cloudbaristaorg/cm-butterfly-api:0.5.2
+    image: cloudbaristaorg/cm-butterfly-api:0.5.3
+    # image: cloudbaristaorg/cm-butterfly-api:edge
     container_name: cm-butterfly-api
     pull_policy: always
     platform: linux/amd64
@@ -490,12 +486,8 @@ services:
   # https://github.com/cloud-barista/cm-butterfly/blob/main/front/nginx.conf
   # https://hub.docker.com/r/cloudbaristaorg/cm-butterfly-front
   cm-butterfly-front:
-    # Pinned to edge for final pre-release review: the 0.5.2 image predates the
-    # api.yaml update in this change, so edge is the image that actually carries
-    # it. This will move to 0.5.3 once that release is published; for a stable
-    # build use 0.5.2.
-    image: cloudbaristaorg/cm-butterfly-front:edge
-    # image: cloudbaristaorg/cm-butterfly-front:0.5.2
+    image: cloudbaristaorg/cm-butterfly-front:0.5.3
+    # image: cloudbaristaorg/cm-butterfly-front:edge
 
     container_name: cm-butterfly-front
     pull_policy: always


### PR DESCRIPTION
cm-butterfly was the only service in the compose lineup still on `edge`. cm-butterfly v0.5.3 is now published, so the api and front images move to `0.5.3`, with `edge` kept as a commented-out line for local rollback.

With this, no `edge` tag remains in the compose file. `edge` points at whatever was built most recently and can be overwritten by a build from another branch, so two people pulling the same lineup could otherwise end up running different images.

## Verification
- `docker compose config` parses cleanly
- no `image: *:edge` remains in the compose file
- `cloudbaristaorg/cm-butterfly-api:0.5.3` and `cm-butterfly-front:0.5.3` resolve on Docker Hub and their manifests pull