### PR TITLE
chore(lineup): track the published versions of the sub-frameworks until v0.6.0

### DIFF
--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -68,7 +68,7 @@ services:
       latest: https://raw.githubusercontent.com/cloud-barista/cm-ant/main/api/swagger.json
       release: https://raw.githubusercontent.com/cloud-barista/cm-ant/{release}/api/swagger.json
   cm-beetle:
-    version: 0.6.0(latest)
+    version: 0.5.7(latest)
     baseurl: http://cm-beetle:8056/beetle
     auth:
       type: basic
@@ -81,14 +81,14 @@ services:
   cm-butterfly-api:
     # No public swagger source is registered for this service, so the version is
     # kept in step with the image tag in conf/docker/docker-compose.yaml by hand.
-    version: 0.6.0
+    version: 0.5.5
     #baseurl: http://localhost:4000
     baseurl: http://cm-butterfly-api:4000
     auth:
       type: none
       
   cm-cicada:
-    version: 0.6.0(latest)
+    version: 0.5.2(latest)
     baseurl: http://cm-cicada:8083/cicada
     auth:
       type: none
@@ -97,7 +97,7 @@ services:
       release: https://raw.githubusercontent.com/cloud-barista/cm-cicada/{release}/pkg/api/rest/docs/swagger.json
 
   cm-honeybee:
-    version: 0.6.0(latest)
+    version: 0.5.3(latest)
     baseurl: http://cm-honeybee:8081/honeybee
     auth:
       type: none
@@ -106,7 +106,7 @@ services:
       release: https://raw.githubusercontent.com/cloud-barista/cm-honeybee/{release}/server/pkg/api/rest/docs/swagger.json
 
   cm-honeybee-agent:
-    version: 0.6.0(latest)
+    version: 0.5.3(latest)
     baseurl: http://cm-honeybee:8082/honeybee-agent
     auth:
       type: none
@@ -115,7 +115,7 @@ services:
       release: https://raw.githubusercontent.com/cloud-barista/cm-honeybee/{release}/agent/pkg/api/rest/docs/swagger.json
 
   cm-grasshopper:
-    version: 0.6.0(latest)
+    version: 0.5.2(latest)
     baseurl: http://cm-grasshopper:8084/grasshopper
     auth:
       type: none

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -400,7 +400,7 @@ services:
   # see conf folder : https://github.com/cloud-barista/cm-beetle/tree/main/conf
   # And remove the conf-related comments in the volumes settings below.
   cm-beetle:
-    image: cloudbaristaorg/cm-beetle:0.6.0
+    image: cloudbaristaorg/cm-beetle:0.5.7
     container_name: cm-beetle
     logging: *default-logging
     pull_policy: always
@@ -453,7 +453,7 @@ services:
   # (Not required) https://github.com/cloud-barista/cm-butterfly/tree/main/api/conf/authsetting.yaml.sample to authsetting.yaml
   # https://hub.docker.com/r/cloudbaristaorg/cm-butterfly-api
   cm-butterfly-api:
-    image: cloudbaristaorg/cm-butterfly-api:0.6.0
+    image: cloudbaristaorg/cm-butterfly-api:0.5.5
     # image: cloudbaristaorg/cm-butterfly-api:edge
     container_name: cm-butterfly-api
     logging: *default-logging
@@ -507,7 +507,7 @@ services:
   # https://github.com/cloud-barista/cm-butterfly/blob/main/front/nginx.conf
   # https://hub.docker.com/r/cloudbaristaorg/cm-butterfly-front
   cm-butterfly-front:
-    image: cloudbaristaorg/cm-butterfly-front:0.6.0
+    image: cloudbaristaorg/cm-butterfly-front:0.5.5
     # image: cloudbaristaorg/cm-butterfly-front:edge
 
     container_name: cm-butterfly-front
@@ -571,7 +571,7 @@ services:
   # See https://github.com/cloud-barista/cm-honeybee/blob/main/server/docker-compose.yaml
   cm-honeybee:
     # image: cloudbaristaorg/cm-honeybee:edge
-    image: cloudbaristaorg/cm-honeybee:0.6.0
+    image: cloudbaristaorg/cm-honeybee:0.5.3
     container_name: cm-honeybee
     logging: *default-logging
     pull_policy: always
@@ -626,7 +626,7 @@ services:
   # **important** : The cm-beetle, cm-grasshopper, and airflow-server containers must be in a readyz state and running beforehand
   cm-cicada:
     # image: cloudbaristaorg/cm-cicada:edge
-    image: cloudbaristaorg/cm-cicada:0.6.0
+    image: cloudbaristaorg/cm-cicada:0.5.2
     container_name: cm-cicada
     logging: *default-logging
     pull_policy: always
@@ -738,7 +738,7 @@ services:
     container_name: airflow-server
     logging: *default-logging
     # image: cloudbaristaorg/airflow-server:edge
-    image: cloudbaristaorg/airflow-server:0.6.0
+    image: cloudbaristaorg/airflow-server:0.5.2
     restart: unless-stopped
     environment:
       # SMTP settings (managed centrally in the host .env)
@@ -843,7 +843,7 @@ services:
   # See https://github.com/cloud-barista/cm-grasshopper/blob/main/docker-compose.yaml
   cm-grasshopper:
     # image: cloudbaristaorg/cm-grasshopper:edge
-    image: cloudbaristaorg/cm-grasshopper:0.6.0
+    image: cloudbaristaorg/cm-grasshopper:0.5.2
     container_name: cm-grasshopper
     logging: *default-logging
     pull_policy: always


### PR DESCRIPTION
## Background

The v0.6.0 release has been postponed.
The sub-frameworks keep releasing in the meantime, and cm-mayfly is how those releases are brought up and tried quickly.

To keep that path working through the wait, the 0.6.0-oriented documentation and settings that landed in #191 are kept as they are.
Only the version references move — the compose file, and `conf/api.yaml` where it is needed — so that they name what each sub-framework has actually published.

## Changes

### `conf/docker/docker-compose.yaml` — image tags

| # | Service | Before | Now | Note |
|--:|---|---|---|---|
| 1 | cm-beetle | 0.6.0 | 0.5.7 | |
| 2 | cm-butterfly-api | 0.6.0 | 0.5.5 | pre-release of 2 August |
| 3 | cm-butterfly-front | 0.6.0 | 0.5.5 | same |
| 4 | cm-honeybee | 0.6.0 | 0.5.3 | |
| 5 | cm-cicada | 0.6.0 | 0.5.2 | |
| 6 | airflow-server | 0.6.0 | 0.5.2 | follows cm-cicada |
| 7 | cm-grasshopper | 0.6.0 | 0.5.2 | |

Unchanged: cm-damselfly 0.6.0 and cm-ant 0.6.0, which are the versions those two run.
Also unchanged: cb-tumblebug 0.12.25, cb-spider 0.12.35, cb-mapui 0.12.50 and mc-terrarium 0.1.4 — the combination cm-beetle 0.5.7 names in its Related Components — and the supporting containers.

### `conf/api.yaml` — version labels

The labels take the same values as the compose file: cm-beetle 0.5.7, cm-butterfly-api 0.5.5, cm-cicada 0.5.2, cm-honeybee and its agent 0.5.3, cm-grasshopper 0.5.2.
cm-ant and cm-damselfly already read 0.6.0.

A sub-framework can add operations during this window, so a label naming a version other than the one running would read wrong.
Only the label changes; the operations and the parenthetical source note are untouched.

`CHANGELOG.md` and the docs keep their v0.6.0 wording.

## Notes

No source change, so the built binaries are unaffected.

The lineup was brought up on a development server: every service running and healthy, console and readyz responding, and the compose file valid.
The api.yaml change is label text and carries no runtime effect.