### PR TITLE
Update cm-damselfly image version to 0.6.1

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -673,7 +673,7 @@ services:
   # https://hub.docker.com/r/cloudbaristaorg/cm-damselfly
   cm-damselfly:
     # image: cloudbaristaorg/cm-damselfly:edge
-    image: cloudbaristaorg/cm-damselfly:0.6.0
+    image: cloudbaristaorg/cm-damselfly:0.6.1
     container_name: cm-damselfly
     logging: *default-logging
     pull_policy: always


### PR DESCRIPTION
- cm-damselfly v0.6.1 uses the infra model v0.1.11
  - Update cm-damselfly image version to 0.6.1 in docker-compose.yaml