### PR TITLE
docker: Empty airflow api base_url so UI auth redirects are relative

### DIFF
--- a/conf/docker/conf/cm-cicada/_airflow/airflow-home/airflow.cfg
+++ b/conf/docker/conf/cm-cicada/_airflow/airflow-home/airflow.cfg
@@ -29,7 +29,10 @@ sql_alchemy_conn = mysql+mysqldb://airflow:airflow_pass@airflow-mysql/airflow
 # Airflow 3에서 [webserver] 섹션이 없어지고 api-server 설정이 여기로 왔다.
 host = 0.0.0.0
 port = 8080
-base_url = http://localhost:8080
+# base_url을 비워두면 Airflow가 로그인/로그아웃 리다이렉트를 상대경로(/auth/login/)로
+# 내보낸다. 브라우저가 접속한 주소 기준으로 해석하므로, 공인 IP·호스트명 등 어떤 주소로
+# 들어와도 그 주소를 유지한다(고정 localhost:8080으로 튕기지 않음).
+base_url =
 secret_key = i1SEBjQvnCA93YEo+yjYEA==
 expose_config = False
 

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -805,6 +805,11 @@ services:
       # worker, api-server) inherits it, which is what keeps signing and validation
       # on the same key. Managed centrally in the host .env.
       - AIRFLOW__API_AUTH__JWT_SECRET=${AIRFLOW_JWT_SECRET}
+      # Empty base_url makes Airflow emit relative auth redirects (/auth/login/) so the
+      # UI works on whatever address the client connected with (public IP/host) instead
+      # of bouncing to a fixed localhost:8080. Overrides airflow.cfg for images that
+      # still ship base_url=http://localhost:8080.
+      - AIRFLOW__API__BASE_URL=
       # MySQL credentials (managed centrally in the host .env)
       - MYSQL_USER=${AIRFLOW_DB_USER}
       - MYSQL_PASSWORD=${AIRFLOW_DB_PASSWORD}


### PR DESCRIPTION
## Changes
airflow-server 의 `[api] base_url` 을 빈 값으로 둔다.
- `conf/docker/docker-compose.yaml`: airflow-server env 에 `AIRFLOW__API__BASE_URL=` 추가 (이미지 설정을 오버라이드)
- `conf/docker/conf/cm-cicada/_airflow/airflow-home/airflow.cfg`: 컨테이너에 마운트되는 실사용 사본의 `base_url =` 비움

## Why
기존엔 `base_url = http://localhost:8080` 으로 고정돼 있어, 공인 IP·호스트명으로 Airflow UI 에 접속해도 로그인/로그아웃 시 `localhost:8080` 으로 리다이렉트되어 접속이 끊겼다. base_url 을 비우면 Airflow 가 auth 리다이렉트를 상대경로(`/auth/login/`)로 내보내고, 브라우저가 접속한 주소 기준으로 해석한다 → 어떤 주소로 들어와도 그 주소를 유지한다. (프록시·추가 컨테이너 없이 기존 airflow-server 하나로 해결.)

## Impact
- **당장 진행 중인 테스트/워크플로우 실행에는 영향이 없습니다.** 마이그레이션 실행·태스크 컴포넌트·내부 API 호출(`AIRFLOW_CONN_AIRFLOW_API=localhost`)과 무관.
- **Airflow UI 접근을 위해 필요한 부가 설정**입니다.

## Ref
- 같은 변경을 cm-cicada 소스에도 반영: cloud-barista/cm-cicada#79
