### PR TITLE
chore(lineup): bump cm-honeybee to 0.5.12

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -603,7 +603,7 @@ services:
   # See https://github.com/cloud-barista/cm-honeybee/blob/main/server/docker-compose.yaml
   cm-honeybee:
     # image: cloudbaristaorg/cm-honeybee:edge
-    image: cloudbaristaorg/cm-honeybee:0.5.11
+    image: cloudbaristaorg/cm-honeybee:0.5.12
     container_name: cm-honeybee
     logging: *default-logging
     pull_policy: always


### PR DESCRIPTION
Bump cm-honeybee to **0.5.12** in the docker compose lineup.

0.5.12 restores the SSH credential in `connection_info` responses (hydrated from OpenBao, returned encrypted). Since 0.5.11 moved SSH secrets to OpenBao and stopped returning them, consumers that decrypt these fields to SSH into the source host (cm-grasshopper) received empty credentials and failed software migration with `failed to determine auth method`.

- cm-honeybee 0.5.11 -> 0.5.12