### PR TITLE
fix(docker): pass the tumblebug credentials through to cm-beetle

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -465,8 +465,12 @@ services:
       - BEETLE_NODE_ENV=development
       # - BEETLE_AUTOCONTROL_DURATION_MS=10000
       - BEETLE_TUMBLEBUG_ENDPOINT=http://cb-tumblebug:1323
-      # - BEETLE_TUMBLEBUG_API_USERNAME=default
-      # - BEETLE_TUMBLEBUG_API_PASSWORD=default
+      # cm-beetle calls cb-tumblebug with these, so they have to match the
+      # credentials cb-tumblebug is started with. Left commented out they fell
+      # back to the image default and every call returned 401 as soon as
+      # TB_API_* was set to anything other than "default".
+      - BEETLE_TUMBLEBUG_API_USERNAME=${TB_API_USERNAME}
+      - BEETLE_TUMBLEBUG_API_PASSWORD=${TB_API_PASSWORD}
       # Set REQUESTS_PER_SEC to CB-Tumblebug's own per-client-IP limit
       # - BEETLE_TUMBLEBUG_RETRIEVAL_REQUESTS_PER_SEC=2
       # - BEETLE_TUMBLEBUG_RETRIEVAL_MAX_WAIT_SEC=8


### PR DESCRIPTION
cm-beetle calls cb-tumblebug and reads `BEETLE_TUMBLEBUG_API_USERNAME` and `BEETLE_TUMBLEBUG_API_PASSWORD` for that call, but both lines were commented out, so it fell back to the image default of `default`.

This goes unnoticed because every other service already takes its credentials from the `.env` file and the shipped values happen to be `default` as well. Set `TB_API_USERNAME` to anything else and cb-tumblebug starts with the new credentials while cm-beetle keeps sending the old ones — every call it makes comes back 401.

Wiring the two variables to the same `.env` entries cb-tumblebug is started with keeps the pair in step.

Verified by setting all subsystem credentials to non-default values: cm-beetle's calls returned 401 before the change and 200 after.