### PR TITLE
chore(api): refresh api.yaml for the cm-honeybee 0.5.12 lineup

### DIFF
--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -68,7 +68,7 @@ services:
       latest: https://raw.githubusercontent.com/cloud-barista/cm-ant/main/api/swagger.json
       release: https://raw.githubusercontent.com/cloud-barista/cm-ant/{release}/api/swagger.json
   cm-beetle:
-    version: 0.5.10(latest)
+    version: 0.5.11(latest)
     baseurl: http://cm-beetle:8056/beetle
     auth:
       type: basic
@@ -97,7 +97,7 @@ services:
       release: https://raw.githubusercontent.com/cloud-barista/cm-cicada/{release}/pkg/api/rest/docs/swagger.json
 
   cm-honeybee:
-    version: 0.5.11(latest)
+    version: 0.5.12(latest)
     baseurl: http://cm-honeybee:8081/honeybee
     auth:
       type: none
@@ -106,7 +106,7 @@ services:
       release: https://raw.githubusercontent.com/cloud-barista/cm-honeybee/{release}/server/pkg/api/rest/docs/swagger.json
 
   cm-honeybee-agent:
-    version: 0.5.11(latest)
+    version: 0.5.12(latest)
     baseurl: http://cm-honeybee:8082/honeybee-agent
     auth:
       type: none


### PR DESCRIPTION
The compose file now pins cm-honeybee 0.5.12 and cm-beetle 0.5.11, so the version labels are regenerated from those tags. Neither release changes its operationId set, so the action lists are unchanged.

Note that 0.5.12 adds two agent-uninstall routes that its `swagger.json` does not carry, so they cannot be generated here yet.