### PR TITLE
chore(lineup): use cm-butterfly 0.5.6

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -489,7 +489,7 @@ services:
   # (Not required) https://github.com/cloud-barista/cm-butterfly/tree/main/api/conf/authsetting.yaml.sample to authsetting.yaml
   # https://hub.docker.com/r/cloudbaristaorg/cm-butterfly-api
   cm-butterfly-api:
-    image: cloudbaristaorg/cm-butterfly-api:0.5.5
+    image: cloudbaristaorg/cm-butterfly-api:0.5.6
     # image: cloudbaristaorg/cm-butterfly-api:edge
     container_name: cm-butterfly-api
     logging: *default-logging
@@ -543,7 +543,7 @@ services:
   # https://github.com/cloud-barista/cm-butterfly/blob/main/front/nginx.conf
   # https://hub.docker.com/r/cloudbaristaorg/cm-butterfly-front
   cm-butterfly-front:
-    image: cloudbaristaorg/cm-butterfly-front:0.5.5
+    image: cloudbaristaorg/cm-butterfly-front:0.5.6
     # image: cloudbaristaorg/cm-butterfly-front:edge
 
     container_name: cm-butterfly-front


### PR DESCRIPTION
cm-butterfly v0.5.6 has been released, so the lineup moves to that tag.

| Image | From → To |
|---|---|
| cloudbaristaorg/cm-butterfly-api | 0.5.5 → 0.5.6 |
| cloudbaristaorg/cm-butterfly-front | 0.5.5 → 0.5.6 |

0.5.6 is the first console release that reads its subsystem credentials from the environment this compose file already supplies. Running the previous console against this compose sends the variable reference itself as the username, so the two belong together.

Verified on a running lineup: both images pull, `docker compose config` passes, all 25 containers come up healthy, and the console loads with every subsystem answering through its proxy.