### PR TITLE
fix(docker): pass the tumblebug credentials to cm-grasshopper

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -950,6 +950,15 @@ services:
       - ./data/cm-grasshopper/k8s_job_log:/k8s_job_log:rw
       - ./data/cm-grasshopper/data_root/:/root/.cm-grasshopper:rw
       - ./data/cm-honeybee/:/root/.cm-grasshopper/honeybee:ro
+    environment:
+      # cm-grasshopper calls cb-tumblebug when it installs software and when it reads the
+      # connection details of a target node. Those credentials are currently hardcoded as
+      # default/default in cm-grasshopper.yaml, so they only work while cb-tumblebug also
+      # uses the defaults. We pass the shared .env values here so that once cm-grasshopper
+      # reads its API credentials from the environment, non-default credentials work
+      # without a compose change on our side. Same situation as cm-cicada.
+      - TB_API_USERNAME=${TB_API_USERNAME}
+      - TB_API_PASSWORD=${TB_API_PASSWORD}
     command: >
       /bin/sh -c "
         if [ ! -f /root/.ssh/known_hosts ]; then


### PR DESCRIPTION
Part of #208

cm-grasshopper calls CB-Tumblebug when it installs software (`lib/software/install.go`) and when it reads the connection details of a target node (`lib/ssh/client.go`), and takes those credentials from `cm-grasshopper.yaml`, where they are written as `default/default`. Its service block had no credentials passed to it at all, so a deployment that changed them had no way to reach cm-grasshopper.

This does not fix that on its own: cm-grasshopper reads its configuration as plain YAML and never consults the environment, so the values are ignored until the reading side changes. That is asked for in cloud-barista/cm-grasshopper#25.

Passing them now puts cm-grasshopper on the same footing as the other components, so nothing further is needed here once it lands.