### PR TITLE
chore(lineup): bump cm-grasshopper to 0.5.7

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -948,7 +948,7 @@ services:
   # See https://github.com/cloud-barista/cm-grasshopper/blob/main/docker-compose.yaml
   cm-grasshopper:
     # image: cloudbaristaorg/cm-grasshopper:edge
-    image: cloudbaristaorg/cm-grasshopper:0.5.6
+    image: cloudbaristaorg/cm-grasshopper:0.5.7
     container_name: cm-grasshopper
     logging: *default-logging
     pull_policy: always


### PR DESCRIPTION
Bump cm-grasshopper to **0.5.7** in the docker compose lineup.

| Image | From → To |
|---|---|
| cloudbaristaorg/cm-grasshopper | 0.5.6 → 0.5.7 |

0.5.7 fixes the IPv6 listen neutralization used on IPv6-disabled targets (e.g. NCP, where `ipv6.disable=1`). 0.5.6 introduced the remediation but a bad `sed` delimiter (`#` collided with the inserted comment marker) meant the offending directive was never commented, so nginx still failed to install with `socket() [::]:80 failed (97)`. 0.5.7 uses an `@` delimiter and discovers the files to fix by content (any active `listen [::]` under `/etc`, including a dependency's config such as nginx-common's default site), so nginx and other IPv6-binding services install and start on IPv4.
