### PR TITLE
chore(lineup): move the C-Mig frameworks to 0.6.0 and regenerate api.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v0.6.0
 ### Changelog
-* Move every C-Mig framework in the lineup to `0.6.0` — cm-beetle, cm-butterfly (api and front), cm-honeybee, cm-damselfly, cm-cicada, airflow-server, cm-grasshopper and cm-ant. The Cloud-Barista components keep their own versioning: cb-tumblebug `0.12.25`, cb-spider `0.12.35`, cb-mapui `0.12.50`, mc-terrarium `0.1.4`. `conf/api.yaml` follows the same set.
+* Move every C-Mig framework in the lineup to `0.6.0` — cm-beetle, cm-butterfly (api and front), cm-honeybee, cm-cicada, airflow-server, cm-grasshopper and cm-ant. cm-damselfly runs `0.6.1`, which supersedes its `0.6.0`. The Cloud-Barista components keep their own versioning and follow what cm-beetle `v0.6.0` lists as its related components: cb-tumblebug `0.12.30`, cb-spider `0.12.42`, cb-mapui `0.12.56`, mc-terrarium `0.1.4`. `conf/api.yaml` is regenerated from each subsystem's swagger at those tags and follows the same set.
 * Cap the logs a running stack writes. MySQL binary logging is off by default — `airflow-mysql` is a single instance with no replication, point-in-time recovery or change-data-capture to replay it — and container log size and file count are set, both configurable from `.env`. A lineup left running had filled a disk until image pulls began to fail.
 * Drop the bundled cb-tumblebug assets under `conf/docker/conf/cb-tumblebug/assets/` (33 files, about 33 MB). Both images already ship those files, so the copy added nothing, and the Spider half of it was older than the image it was meant for.
 * `infra update` now updates only the services its version check found stale, instead of restarting everything. Floating tags are compared by digest.
@@ -9,7 +9,7 @@
   * Added `conf/docker/.env.example` template and gitignored the real `conf/docker/.env`.
   * The `infra` commands now fail with a clear message when `conf/docker/.env` is missing.
   * Copy step: `cp conf/docker/.env.example conf/docker/.env` then set the required values.
-* CB-Tumblebug 라인업 업그레이드 (cb-tumblebug 0.12.1 → 0.12.25, cb-spider 0.12.0 → 0.12.35, cb-mapui 0.12.1 → 0.12.50)
+* CB-Tumblebug 라인업 업그레이드 (cb-tumblebug 0.12.1 → 0.12.30, cb-spider 0.12.0 → 0.12.42, cb-mapui 0.12.1 → 0.12.56)
 * mc-terrarium 0.1.4 신규 추가 (OpenTofu 기반 자원 확장)
 * openbao 2.5.1 신규 추가 (CSP 자격증명 시크릿 매니저, persistent 모드)
 * openbao-unseal sidecar 신규 추가 — 재기동 시 OpenBao 자동 unseal (사용자 개입 불필요)
@@ -21,10 +21,10 @@
 ### Feature
 * cb-spider / cb-tumblebug / mc-terrarium 인증 환경변수(`SPIDER_USERNAME`/`SPIDER_PASSWORD`, `TB_API_*`, `TERRARIUM_API_*`)와 OpenBao 연동(`VAULT_ADDR`/`VAULT_TOKEN`)을 `conf/docker/.env`로 추가 관리
 * `conf/openbao/openbao-config.hcl` 신규 — OpenBao persistent 모드 설정 (KMS Auto-Unseal stanza 주석 예시 포함)
-* 컨테이너를 기동하는 `mayfly infra run`/`update` 실행 직전 `conf/docker/.env`의 필수값을 자체 검증. cb-spider 0.12.35의 REST 인증(`SPIDER_USERNAME`/`SPIDER_PASSWORD`)과 5종 DB 비밀번호(`TUMBLEBUG_DB_PASSWORD`, `BUTTERFLY_DB_PASSWORD`, `ANT_DB_PASSWORD`, `AIRFLOW_DB_PASSWORD`, `AIRFLOW_DB_ROOT_PASSWORD`)가 비어 있으면 어떤 키가 누락됐는지 명시한 뒤 docker compose 호출 전에 중단해, 컨테이너가 영문도 모르고 죽는 상황을 막는다. 필수값 검증은 컨테이너를 띄우는 `run`/`update`에만 적용되고, `remove`/`stop`/`info`/`logs` 등 나머지 하위 명령은 값 검증 없이 실행된다(파일 존재 검증은 전 하위 명령 유지).
+* 컨테이너를 기동하는 `mayfly infra run`/`update` 실행 직전 `conf/docker/.env`의 필수값을 자체 검증. cb-spider의 REST 인증(`SPIDER_USERNAME`/`SPIDER_PASSWORD`)과 5종 DB 비밀번호(`TUMBLEBUG_DB_PASSWORD`, `BUTTERFLY_DB_PASSWORD`, `ANT_DB_PASSWORD`, `AIRFLOW_DB_PASSWORD`, `AIRFLOW_DB_ROOT_PASSWORD`)가 비어 있으면 어떤 키가 누락됐는지 명시한 뒤 docker compose 호출 전에 중단해, 컨테이너가 영문도 모르고 죽는 상황을 막는다. 필수값 검증은 컨테이너를 띄우는 `run`/`update`에만 적용되고, `remove`/`stop`/`info`/`logs` 등 나머지 하위 명령은 값 검증 없이 실행된다(파일 존재 검증은 전 하위 명령 유지).
 
 ### Notice
-* cb-spider 0.12.35는 `SPIDER_USERNAME`/`SPIDER_PASSWORD`가 비어있으면 log.Fatal로 컨테이너 기동을 차단합니다. `conf/docker/.env.example`에는 다른 비밀번호 항목과 동일하게 **빈 값**으로 제공되므로, `cp conf/docker/.env.example conf/docker/.env` 후 두 값을 **반드시** 설정해야 합니다. 누락 시 `mayfly infra` 단계에서 위 *Feature*의 필수값 검증이 어떤 키가 비었는지 알려주고 docker compose 호출 전에 중단합니다.
+* cb-spider는 `SPIDER_USERNAME`/`SPIDER_PASSWORD`가 비어있으면 log.Fatal로 컨테이너 기동을 차단합니다. `conf/docker/.env.example`에는 다른 비밀번호 항목과 동일하게 **빈 값**으로 제공되므로, `cp conf/docker/.env.example conf/docker/.env` 후 두 값을 **반드시** 설정해야 합니다. 누락 시 `mayfly infra` 단계에서 위 *Feature*의 필수값 검증이 어떤 키가 비었는지 알려주고 docker compose 호출 전에 중단합니다.
 * openbao-unseal sidecar는 호스트 파일에 평문 unseal 키를 보관합니다. 운영 등급에 따라 KMS Auto-Unseal 또는 수동 unseal 전환을 검토하세요. 자세한 가이드는 `docs/openbao-unseal.md` 참조.
 * clean 재기동 권장 — 자동 데이터 마이그레이션 미제공.
 

--- a/README.md
+++ b/README.md
@@ -196,12 +196,12 @@ Example output:
 ```
 [v]Status of Cloud-Migrator runtime images
 CONTAINER           REPOSITORY                     TAG                 IMAGE ID            SIZE
-cb-tumblebug        cloudbaristaorg/cb-tumblebug   0.12.25              d4c2abdc0e21        118MB
+cb-tumblebug        cloudbaristaorg/cb-tumblebug   0.12.30              d4c2abdc0e21        118MB
 ```
 
-Based on the cb-tumblebug version (e.g., v0.12.25), download the corresponding cb-tumblebug repository:
+Based on the cb-tumblebug version (e.g., v0.12.30), download the corresponding cb-tumblebug repository:
 ```
-$ git clone -b v0.12.25 https://github.com/cloud-barista/cb-tumblebug.git cb-tumblebug-v0.12.25
+$ git clone -b v0.12.30 https://github.com/cloud-barista/cb-tumblebug.git cb-tumblebug-v0.12.30
 ```
 
 Then follow the detailed guide at:

--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -1,41 +1,60 @@
 # =============================================================================
-# Service registry for the `mayfly api` / `mayfly rest` commands.
+# Service registry for the Cloud-Migrator subsystems.
 #
-# Each service entry has a baseurl and an `auth` block that tells cm-mayfly how
-# to authenticate when it calls that service.
+# Two things read this file, and they must read the same one:
 #
-# auth.type — the authentication METHOD to use (it declares HOW to authenticate,
-# not whether the remote service enforces auth):
-#   * none   — send no credentials. This is also the effective default when the
-#              auth block is omitted.
-#   * basic  — HTTP Basic Auth built from auth.username + auth.password.
-#   * bearer — send auth.token as a Bearer token.
+#   * cm-mayfly    — the `mayfly api` / `mayfly rest` commands call a subsystem
+#                    directly from the host.
+#   * cm-butterfly — its proxy answers POST /api/{subsystem}/{operationId} by
+#                    looking the operationId up here and calling
+#                    services.<subsystem>.baseurl + resourcePath.
 #
-# Credential values (username / password / token) may each be written either as
-# a literal or as a ${VAR} reference:
-#   * literal   e.g. "username: default" — the value is taken from this file.
-#   * ${VAR}    e.g. "password: ${TB_API_PASSWORD}" — the value is read from the
-#               environment at call time. Writing a value as ${VAR} is the
-#               explicit signal that the credential lives outside this file.
+# cm-mayfly holds the master copy and generates serviceActions from each
+# subsystem's swagger (`mayfly api tool`). cm-butterfly takes this file as it
+# is — there is no conversion step, and a difference between the two copies
+# means one of them has drifted.
 #
-# Resolution order for a ${VAR} reference (first hit wins):
-#   1. the process environment (an OS-level / exported variable),
-#   2. conf/docker/.env (the single shared environment file),
-#   3. otherwise it resolves to empty — for basic auth no Authorization header
-#      is then sent, and a warning is printed. There is no implicit default.
+# The operationId is scoped to its subsystem: the same name exists in more than
+# one of them, which is why cm-butterfly's proxy path carries the subsystem.
 #
-# A --username / --password / --token flag passed on the command line overrides
-# whatever is configured here.
+# CREDENTIALS
 #
-# api.yaml only controls what cm-mayfly SENDS. Whether a service actually
-# enforces auth is the service's own decision (for example cm-damselfly checks
-# credentials only when DAMSELFLY_API_AUTH_ENABLED=true). Sending credentials to
-# a service that is not enforcing auth is harmless — they are simply ignored —
-# so basic auth can be configured here regardless of the server's current state.
+#   auth.type  none | basic | bearer
+#   none       send nothing. Also the effect when the auth block is omitted.
+#   basic      build the header from auth.username + auth.password.
+#   bearer     send a token. cm-mayfly takes auth.token from this file;
+#              cm-butterfly takes it from the incoming request instead.
 #
-# A possible future enhancement is to make auth.type itself a ${VAR} reference,
-# for services whose method can change at runtime; that is intentionally left
-# out for now until a concrete need appears.
+# A username or password may be written as ${VAR} and is read from the process
+# environment. Under docker compose the values come from the single shared .env
+# — cm-mayfly reads it directly, and the compose file passes the same values
+# into the cm-butterfly-api container.
+#
+# A ${VAR} that resolves to nothing is an error, not a default:
+#
+#   * cm-mayfly    sends no Authorization header and warns.
+#   * cm-butterfly refuses to start and names the variable.
+#
+# There is no implicit fallback anywhere. These values were literals once, so a
+# deployment could change its .env while the file kept sending the old
+# credentials, and the only symptom was a 401 that looked like a screen failing
+# to load.
+#
+# A --username / --password / --token flag on the cm-mayfly command line
+# overrides whatever is configured here.
+#
+# This file only controls what gets SENT. Whether a subsystem enforces auth is
+# its own decision — cm-damselfly, for instance, checks credentials only when
+# DAMSELFLY_API_AUTH_ENABLED=true. Sending credentials to a subsystem that is
+# not enforcing them is harmless.
+#
+# baseurl is literal and has no environment override. It describes how the
+# deployment is wired — under compose these are the service hostnames. Running
+# a subsystem on localhost for development means editing it by hand, and that
+# edit is not committed.
+#
+# The swagger block records where each subsystem's spec comes from. cm-mayfly
+# uses it to regenerate; cm-butterfly ignores it.
 # =============================================================================
 services:
   cb-spider: #service name
@@ -68,7 +87,7 @@ services:
       latest: https://raw.githubusercontent.com/cloud-barista/cm-ant/main/api/swagger.json
       release: https://raw.githubusercontent.com/cloud-barista/cm-ant/{release}/api/swagger.json
   cm-beetle:
-    version: 0.5.11(latest)
+    version: 0.6.0(latest)
     baseurl: http://cm-beetle:8056/beetle
     auth:
       type: basic
@@ -81,14 +100,14 @@ services:
   cm-butterfly-api:
     # No public swagger source is registered for this service, so the version is
     # kept in step with the image tag in conf/docker/docker-compose.yaml by hand.
-    version: 0.5.5
+    version: 0.6.0
     #baseurl: http://localhost:4000
     baseurl: http://cm-butterfly-api:4000
     auth:
       type: none
       
   cm-cicada:
-    version: 0.5.3(latest)
+    version: 0.6.0(latest)
     baseurl: http://cm-cicada:8083/cicada
     auth:
       type: none
@@ -97,7 +116,7 @@ services:
       release: https://raw.githubusercontent.com/cloud-barista/cm-cicada/{release}/pkg/api/rest/docs/swagger.json
 
   cm-honeybee:
-    version: 0.5.12(latest)
+    version: 0.6.0(latest)
     baseurl: http://cm-honeybee:8081/honeybee
     auth:
       type: none
@@ -105,17 +124,32 @@ services:
       latest: https://raw.githubusercontent.com/cloud-barista/cm-honeybee/main/server/pkg/api/rest/docs/swagger.json
       release: https://raw.githubusercontent.com/cloud-barista/cm-honeybee/{release}/server/pkg/api/rest/docs/swagger.json
 
-  cm-honeybee-agent:
-    version: 0.5.12(latest)
-    baseurl: http://cm-honeybee:8082/honeybee-agent
-    auth:
-      type: none
-    swagger:
-      latest: https://raw.githubusercontent.com/cloud-barista/cm-honeybee/main/agent/pkg/api/rest/docs/swagger.json
-      release: https://raw.githubusercontent.com/cloud-barista/cm-honeybee/{release}/agent/pkg/api/rest/docs/swagger.json
+  # cm-honeybee-agent — commented out, not removed.
+  #
+  # The agent runs on the server being migrated, not next to cm-honeybee, so the
+  # baseurl below never resolves as written. It is kept because losing the entry
+  # would also lose the spec, and without the spec there is no way to call the
+  # agent at all.
+  #
+  # To reach an agent, replace the host with the address of the server it is
+  # installed on. `mayfly api` and `mayfly rest` can override the host, so an
+  # operator can check one server's agent that way. The console could do the
+  # same by rewriting the host from the target server chosen for a call.
+  #
+  # Nothing in cm-mayfly or cm-butterfly calls it today, so it stays commented
+  # out rather than appearing as a service that is always unreachable.
+  #
+  #cm-honeybee-agent:
+  #  version: 0.5.12(latest)
+  #  baseurl: http://cm-honeybee:8082/honeybee-agent
+  #  auth:
+  #    type: none
+  #  swagger:
+  #    latest: https://raw.githubusercontent.com/cloud-barista/cm-honeybee/main/agent/pkg/api/rest/docs/swagger.json
+  #    release: https://raw.githubusercontent.com/cloud-barista/cm-honeybee/{release}/agent/pkg/api/rest/docs/swagger.json
 
   cm-grasshopper:
-    version: 0.5.3(latest)
+    version: 0.6.0(latest)
     baseurl: http://cm-grasshopper:8084/grasshopper
     auth:
       type: none
@@ -2735,10 +2769,10 @@ serviceActions:
       method: post
       resourcePath: /migration/ns/{nsId}/infraWithDefaults
       description: "Migrate an infrastructure to the multi-cloud infrastructure (Infra) with defaults.\n\nBy default this API runs synchronously. Send header `Prefer: respond-async` to run it\nasynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}\n(status flow: Handling → Success / Error). Only the \"respond-async\" token is recognized."
-    MigrateK8sCluster:
+    MigrateK8sInfra:
       method: post
       resourcePath: /migration/ns/{nsId}/k8sCluster
-      description: "Migrate an on-premise Kubernetes cluster to a managed K8s service (e.g., AWS EKS).\n\n**Workflow**:\n1. Call POST /recommendation/k8sCluster to get a RecommendedK8sInfra.\n2. Pass the recommendation result as-is to this endpoint.\n\n**Internal steps**: VNet → SSH Key → Security Group → K8s Cluster → Node Groups\n\nBy default this API runs synchronously (EKS takes ~10-20 min). Send header\n`Prefer: respond-async` to run it asynchronously: receive 202 Accepted with a\nreqId, then poll GET /request/{reqId} to check status."
+      description: "Migrate an on-premise Kubernetes cluster to a managed K8s service (e.g., AWS EKS).\n\n**Workflow**:\n1. Call POST /recommendation/k8sCluster to get a RecommendK8sInfraResponse.\n2. Pass the recommendation result as-is to this endpoint.\n\n**Internal steps**: VNet → SSH Key → Security Group → K8s Cluster → Node Groups\n\n**Long-running** — This API waits for the cluster to become Active, up to **40 min**\n(typically **~10-20 min** on EKS), then adds the node groups, so it can take longer still.\n\nBy default it runs synchronously, so configure your own HTTP client to wait that long —\nmost client defaults cut the connection first. Send header `Prefer: respond-async` to run it\nasynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}\n(status flow: Handling → Success / Error). Only the \"respond-async\" token is recognized.\n\nIf a synchronous connection drops the migration keeps running on the server; poll\nGET /migration/ns/{nsId}/k8sCluster/{k8sClusterId} with the cluster name you supplied."
     MigrateNlbs:
       method: post
       resourcePath: /migration/middleware/ns/{nsId}/infra/{infraId}/nlb
@@ -2755,10 +2789,10 @@ serviceActions:
       method: post
       resourcePath: /recommendation/infraWithNlb
       description: "Perform NLB-aware infrastructure recommendation and return multiple Pareto-optimal candidates.\n\nThe recommendation engine:\n1. Correlates NLB backend server IPs with source Node IPs\n2. Normalizes backend ports via majority vote when ports differ\n3. Assigns NLB-related nodes to shared NodeGroups (N:1), unrelated nodes to individual NodeGroups (1:1)\n4. Finds ranked compatible spec-image pairs per NodeGroup (representative node for NLB groups)\n5. Generates up to `limit` candidates — candidate i uses the i-th ranked pair per NodeGroup\n6. Maps source NLB configuration to target cloud NLB model (same for all candidates)\n\n[Note] `sourceInfra.nlbs` must be populated (HAProxy frontend-backend pairs from cm-honeybee).\n\n[Note] The returned `targetInfra.nodeGroups[].name` values are referenced by `targetNlbList[].targetGroup.nodeGroupId`.\nUse the same NodeGroup IDs when calling POST /migration/infra so that the NLB migration can reference them immediately.\n\n---\n## CSP-Specific NLB Notes\n\nAWS:\n- Port translation supported (e.g., listener 9999 → backend 8086).\n- DNS endpoint; allow ~5 min for propagation after creation.\n- [Auto] SG rule for backend port opened from 0.0.0.0/0.\n\nAzure:\n- Port translation supported. DNS + static IP endpoint.\n- [Auto] Health check timeout omitted (not supported by Azure).\n\nGCP:\n- Port translation NOT supported; traffic arrives at backend VMs on the listener port.\n- [Auto] Listener port is forced equal to the backend port — clients must connect on the application port (e.g., 8086, not 9999).\n- IP-only endpoint (no DNS name).\n\nIBM:\n- Port translation supported.\n- Listener address is assigned asynchronously; re-query if the address is empty after migration.\n- [Auto] Health check timeout forced strictly less than the interval.\n---"
-    RecommendK8sCluster:
+    RecommendK8sInfra:
       method: post
       resourcePath: /recommendation/k8sCluster
-      description: "Recommend a complete K8s cluster configuration based on on-premise infra data from cm-honeybee.\nReturns a RecommendedK8sInfra that can be passed directly to the K8s migration API.\n\n**Required Parameters**: `desiredProvider`, `desiredRegion`\n**Input**: On-premise infra model (from honeybee /infra/refined) with K8s cluster info and node roles"
+      description: "Recommend a complete K8s infra configuration based on on-premise infra data from cm-honeybee.\nReturns a RecommendK8sInfraResponse that can be passed directly to the K8s migration API.\n\n**Required Parameters**: `desiredProvider`, `desiredRegion`\n**Input**: On-premise infra model (from honeybee /infra/refined) with K8s cluster info and node roles"
     RecommendK8sNodeGroupImages:
       method: post
       resourcePath: /recommendation/resources/k8sNodeGroupImages
@@ -3250,31 +3284,6 @@ serviceActions:
       method: post
       resourcePath: /velero/migration/precheck
       description: "Check source cluster, target cluster, and the S3 object store before executing Velero migration."
-  cm-honeybee-agent:
-    Get-Data-Info:
-      method: get
-      resourcePath: /data
-      description: "Get data migration information (required fields only for data migration)."
-    Get-Helm-Info:
-      method: get
-      resourcePath: /helm
-      description: "Get helm information."
-    Get-Infra-Info:
-      method: get
-      resourcePath: /infra
-      description: "Get infra information."
-    Get-Kubernetes-Info:
-      method: get
-      resourcePath: /kubernetes
-      description: "Get kubernetes information."
-    Get-Software-Info:
-      method: get
-      resourcePath: /software
-      description: "Get software information."
-    Health-Check-Readyz:
-      method: get
-      resourcePath: /readyz
-      description: "Check Honeybee Agent is ready"
   cm-honeybee:
     Create-Connection-Info:
       method: post

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -429,7 +429,7 @@ services:
   # see conf folder : https://github.com/cloud-barista/cm-beetle/tree/main/conf
   # And remove the conf-related comments in the volumes settings below.
   cm-beetle:
-    image: cloudbaristaorg/cm-beetle:0.5.11
+    image: cloudbaristaorg/cm-beetle:0.6.0
     container_name: cm-beetle
     logging: *default-logging
     pull_policy: always
@@ -489,7 +489,7 @@ services:
   # (Not required) https://github.com/cloud-barista/cm-butterfly/tree/main/api/conf/authsetting.yaml.sample to authsetting.yaml
   # https://hub.docker.com/r/cloudbaristaorg/cm-butterfly-api
   cm-butterfly-api:
-    image: cloudbaristaorg/cm-butterfly-api:0.5.8
+    image: cloudbaristaorg/cm-butterfly-api:0.6.0
     # image: cloudbaristaorg/cm-butterfly-api:edge
     container_name: cm-butterfly-api
     logging: *default-logging
@@ -561,7 +561,7 @@ services:
   # https://github.com/cloud-barista/cm-butterfly/blob/main/front/nginx.conf
   # https://hub.docker.com/r/cloudbaristaorg/cm-butterfly-front
   cm-butterfly-front:
-    image: cloudbaristaorg/cm-butterfly-front:0.5.8
+    image: cloudbaristaorg/cm-butterfly-front:0.6.0
     # image: cloudbaristaorg/cm-butterfly-front:edge
 
     container_name: cm-butterfly-front
@@ -625,7 +625,7 @@ services:
   # See https://github.com/cloud-barista/cm-honeybee/blob/main/server/docker-compose.yaml
   cm-honeybee:
     # image: cloudbaristaorg/cm-honeybee:edge
-    image: cloudbaristaorg/cm-honeybee:0.5.13
+    image: cloudbaristaorg/cm-honeybee:0.6.0
     container_name: cm-honeybee
     logging: *default-logging
     pull_policy: always
@@ -726,7 +726,7 @@ services:
   # **important** : The cm-beetle, cm-grasshopper, and airflow-server containers must be in a readyz state and running beforehand
   cm-cicada:
     # image: cloudbaristaorg/cm-cicada:edge
-    image: cloudbaristaorg/cm-cicada:0.5.3
+    image: cloudbaristaorg/cm-cicada:0.6.0
     container_name: cm-cicada
     logging: *default-logging
     pull_policy: always
@@ -838,7 +838,7 @@ services:
     container_name: airflow-server
     logging: *default-logging
     # image: cloudbaristaorg/airflow-server:edge
-    image: cloudbaristaorg/airflow-server:0.5.3
+    image: cloudbaristaorg/airflow-server:0.6.0
     restart: unless-stopped
     environment:
       # SMTP settings (managed centrally in the host .env)
@@ -948,7 +948,7 @@ services:
   # See https://github.com/cloud-barista/cm-grasshopper/blob/main/docker-compose.yaml
   cm-grasshopper:
     # image: cloudbaristaorg/cm-grasshopper:edge
-    image: cloudbaristaorg/cm-grasshopper:0.5.7
+    image: cloudbaristaorg/cm-grasshopper:0.6.0
     container_name: cm-grasshopper
     logging: *default-logging
     pull_policy: always


### PR DESCRIPTION
cm-beetle, cm-honeybee, cm-cicada, airflow-server and cm-grasshopper all published v0.6.0, so the lineup moves with them.
cm-ant was already at 0.6.0, and cm-damselfly stays at 0.6.1 because it supersedes its own 0.6.0.

The Cloud-Barista components keep the versions cm-beetle v0.6.0 lists as its related components: cb-tumblebug 0.12.30, cb-spider 0.12.42, cb-mapui 0.12.56 and mc-terrarium 0.1.4.
cb-spider has a newer 0.13.0, but nothing in this lineup was tested against it.

`conf/api.yaml` is regenerated as a full dump for every service that has a swagger source, not only the ones whose tag moved.
The only actual API change is in cm-beetle, where `MigrateK8sCluster` and `RecommendK8sCluster` became `MigrateK8sInfra` and `RecommendK8sInfra`.
Doing the full dump also cleared three version strings that had fallen behind their compose tags: cm-honeybee at 0.5.12, cm-grasshopper at 0.5.3 and cm-butterfly-api at 0.5.5.

Note on ordering: `cm-butterfly-api` and `cm-butterfly-front` are set to 0.6.0, which is released together with this lineup.
Please merge after the cm-butterfly v0.6.0 images are published.