### PR TITLE
chore(lineup): move cm-damselfly to 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.6.1
+### Changelog
+* Move cm-damselfly to `0.6.2`. It carries the migration models the rest of the lineup already builds against — infra model `v0.1.12` (cm-beetle/imdl) and software model `v0.1.3` (cm-grasshopper/smdl) — where `0.6.1` still served `v0.1.11` and `v0.1.1`. The infra model follows CB-Tumblebug `0.12.30`, whose `InfraInfo` replaced the single `postCommand`/`postCommandResult` pair with the phased `postCommands`/`postCommandResults` set, and the software model adds snap and flatpak package types. The rest of the lineup is unchanged from `v0.6.0`.
+* No REST surface change: cm-damselfly still exposes the same 29 operations on the same paths, so `conf/api.yaml` records only the new version.
+
 # v0.6.0
 ### Changelog
 * Move every C-Mig framework in the lineup to `0.6.0` — cm-beetle, cm-butterfly (api and front), cm-honeybee, cm-cicada, airflow-server, cm-grasshopper and cm-ant. cm-damselfly runs `0.6.1`, which supersedes its `0.6.0`. The Cloud-Barista components keep their own versioning and follow what cm-beetle `v0.6.0` lists as its related components: cb-tumblebug `0.12.30`, cb-spider `0.12.42`, cb-mapui `0.12.56`, mc-terrarium `0.1.4`. `conf/api.yaml` is regenerated from each subsystem's swagger at those tags and follows the same set.

--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -158,7 +158,7 @@ services:
       release: https://raw.githubusercontent.com/cloud-barista/cm-grasshopper/{release}/pkg/api/rest/docs/swagger.json
 
   cm-damselfly:
-    version: 0.6.1(latest)
+    version: 0.6.2(latest)
     baseurl: http://cm-damselfly:8088/damselfly
     auth: # cm-damselfly checks these only when DAMSELFLY_API_AUTH_ENABLED=true; otherwise they are ignored.
       type: basic

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -695,7 +695,7 @@ services:
   # https://hub.docker.com/r/cloudbaristaorg/cm-damselfly
   cm-damselfly:
     # image: cloudbaristaorg/cm-damselfly:edge
-    image: cloudbaristaorg/cm-damselfly:0.6.1
+    image: cloudbaristaorg/cm-damselfly:0.6.2
     container_name: cm-damselfly
     logging: *default-logging
     pull_policy: always


### PR DESCRIPTION
cm-damselfly 0.6.2 carries the migration models the rest of the lineup already builds against: infra model v0.1.12 (cm-beetle/imdl) and software model v0.1.3 (cm-grasshopper/smdl), where 0.6.1 still served v0.1.11 and v0.1.1.

Its REST surface is unchanged — the same 29 operations on the same paths — so conf/api.yaml only records the new version. It was regenerated as a full dump; cm-beetle and cm-honeybee were regenerated the same way and produced no diff.

The rest of the lineup is unchanged from v0.6.0. cb-spider stays at 0.12.42 for the same reason as before: nothing in this lineup was tested against 0.13.0.

Verified on a running lineup — all containers healthy, cm-damselfly reports the new model versions, and the snap/flatpak package fields that the previous model version had no place for now survive a save-and-read round trip.