### PR TITLE
chore(lineup): bump cm-cicada/airflow-server to 0.6.1

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -726,7 +726,7 @@ services:
   # **important** : The cm-beetle, cm-grasshopper, and airflow-server containers must be in a readyz state and running beforehand
   cm-cicada:
     # image: cloudbaristaorg/cm-cicada:edge
-    image: cloudbaristaorg/cm-cicada:0.6.0
+    image: cloudbaristaorg/cm-cicada:0.6.1
     container_name: cm-cicada
     logging: *default-logging
     pull_policy: always
@@ -843,7 +843,7 @@ services:
     container_name: airflow-server
     logging: *default-logging
     # image: cloudbaristaorg/airflow-server:edge
-    image: cloudbaristaorg/airflow-server:0.6.0
+    image: cloudbaristaorg/airflow-server:0.6.1
     restart: unless-stopped
     environment:
       # SMTP settings (managed centrally in the host .env)


### PR DESCRIPTION
Bump cm-cicada / airflow-server to **0.6.1** in the docker compose lineup.

cm-cicada v0.6.1 (https://github.com/cloud-barista/cm-cicada/releases/tag/v0.6.1) is a maintenance release (go.mod module updates). The airflow-server image is built from the same tag, so both move together.

- cm-cicada 0.6.0 -> 0.6.1
- airflow-server 0.6.0 -> 0.6.1
